### PR TITLE
[fix]  batchnorm transform always removes producer and consumer nodes

### DIFF
--- a/src/finn/transformation/batchnorm_to_affine.py
+++ b/src/finn/transformation/batchnorm_to_affine.py
@@ -67,8 +67,10 @@ class BatchNormToAffine(Transformation):
                 # remove old nodes
                 graph.node.remove(n)
                 if consumer is not None:
-                    graph.node.remove(consumer)
+                    if consumer.op_type == "Squeeze":
+                        graph.node.remove(consumer)
                 if producer is not None:
-                    graph.node.remove(producer)
+                    if producer.op_type == "Unsqueeze":
+                        graph.node.remove(producer)
         model = model.transform(InferShapes())
         return (model, graph_modified)


### PR DESCRIPTION
I think the intent of removing producer and consumer was limited to the squeeze and unsqueeze nodes but in reality the function was removing them in any case.

this should fix #43 