### PR TITLE
Support for node-local transformations

### DIFF
--- a/src/finn/transformation/fpgadataflow/hlssynth_ipgen.py
+++ b/src/finn/transformation/fpgadataflow/hlssynth_ipgen.py
@@ -28,50 +28,53 @@
 
 import finn.custom_op.registry as registry
 import finn.util.basic as util
-from finn.transformation import Transformation
+from finn.transformation import NodeLocalTransformation
 
 
-class HLSSynth_IPGen(Transformation):
+class HLSSynth_IPGen(NodeLocalTransformation):
     """For each node: generate IP block from code in folder
     that is referenced in node attribute "code_gen_dir_ipgen"
     and save path of generated project in node attribute "ipgen_path".
     All nodes in the graph must have the fpgadataflow backend attribute.
 
     This transformation calls Vivado HLS for synthesis, so it will run for
-    some time (several minutes)"""
+    some time (several minutes)
+    
+    * NUM_DEFAULT_WORKERS (int or None) number of parallel workers. Default is 1. None: Use all available cores.
+    """
 
-    def __init__(self):
-        super().__init__()
-
-    def apply(self, model):
-        for node in model.graph.node:
-            op_type = node.op_type
-            if node.domain == "finn":
-                backend_attribute = util.get_by_name(node.attribute, "backend")
-                if backend_attribute is None:
-                    continue
-                backend_value = backend_attribute.s.decode("UTF-8")
-                if backend_value == "fpgadataflow":
-                    try:
-                        # lookup op_type in registry of CustomOps
-                        inst = registry.custom_op[op_type](node)
-                        # ensure that code is generated
-                        assert (
-                            inst.get_nodeattr("code_gen_dir_ipgen") != ""
-                        ), """Node
-                        attribute "code_gen_dir_ipgen" is empty. Please run
-                        transformation CodeGen_ipgen first."""
-                        # call the compilation function for this node
-                        inst.ipgen_singlenode_code()
-                        # ensure that executable path is now set
-                        assert (
-                            inst.get_nodeattr("ipgen_path") != ""
-                        ), """Transformation
-                        HLSSynth_IPGen was not successful. Node attribute "ipgen_path"
-                        is empty."""
-                    except KeyError:
-                        # exception if op_type is not supported
-                        raise Exception(
-                            "Custom op_type %s is currently not supported." % op_type
-                        )
-        return (model, False)
+    def __init__(self, NUM_DEFAULT_WORKERS=1):
+        super().__init__(NUM_DEFAULT_WORKERS=NUM_DEFAULT_WORKERS)
+    
+    def applyNodeLocal(self, node):
+        op_type = node.op_type
+        if node.domain == "finn":
+            backend_attribute = util.get_by_name(node.attribute, "backend")
+            if backend_attribute is None:
+                return (node, False)
+            backend_value = backend_attribute.s.decode("UTF-8")
+            if backend_value == "fpgadataflow":
+                try:
+                    # lookup op_type in registry of CustomOps
+                    inst = registry.custom_op[op_type](node)
+                    # ensure that code is generated
+                    assert (
+                        inst.get_nodeattr("code_gen_dir_ipgen") != ""
+                    ), """Node
+                    attribute "code_gen_dir_ipgen" is empty. Please run
+                    transformation CodeGen_ipgen first."""
+                    # call the compilation function for this node
+                    inst.ipgen_singlenode_code()
+                    # ensure that executable path is now set
+                    assert (
+                        inst.get_nodeattr("ipgen_path") != ""
+                    ), """Transformation
+                    HLSSynth_IPGen was not successful. Node attribute "ipgen_path"
+                    is empty."""
+                except KeyError:
+                    # exception if op_type is not supported
+                    raise Exception(
+                        "Custom op_type %s is currently not supported." % op_type
+                    )
+        
+        return (node, False)


### PR DESCRIPTION
Hi,
here is my current implementation for the `NodeLocalTransformation` and the updated `HLSSynth_IPGen`, which now subclasses `NodeLocalTransformation`.

By default all operations still run in serial, because I have noticed that there is a case where the synthesis will overshoot the 16 GB memory mark when working on the LFC network. And this already happens for only two threads. See this plot:
![memory_spike_slide](https://user-images.githubusercontent.com/11065832/79978058-8f799d80-849f-11ea-94af-36955851c426.png)
On some systems, as my desktop system this is not a problem, but my laptop would then forcefully kill the vivado process, which caused errors later down the line.

So for now the default is set such that one needs to consciously enable parallelization.