### PR TITLE
Feature/graph order util fct

### DIFF
--- a/src/finn/core/modelwrapper.py
+++ b/src/finn/core/modelwrapper.py
@@ -301,6 +301,27 @@ class ModelWrapper:
         except ValueError:
             return None
 
+    def find_successors(self, node):
+        successors = []
+        try:
+            for outp_tensor in node.output:
+                tensor_consumer_list = self.find_consumers(outp_tensor)
+                for consumer in tensor_consumer_list:
+                    successors.append(consumer)
+            return successors
+        except ValueError:
+            return None
+
+    def find_predecessors(self, node):
+        predecessors = []
+        try:
+            for inp_tensor in node.input:
+                producer = self.find_producer(inp_tensor)
+                predecessors.append(producer)
+            return predecessors
+        except ValueError:
+            return None
+
     def get_all_tensor_names(self):
         """Returns a list of all (input, output and value_info) tensor names
         in the graph."""

--- a/src/finn/core/modelwrapper.py
+++ b/src/finn/core/modelwrapper.py
@@ -301,7 +301,7 @@ class ModelWrapper:
         else:
             return None
 
-    def find_successors(self, node):
+    def find_direct_successors(self, node):
         """Finds and returns a list of the nodes that are successors of
         given node."""
         successors = []
@@ -315,7 +315,7 @@ class ModelWrapper:
         else:
             return None
 
-    def find_predecessors(self, node):
+    def find_direct_predecessors(self, node):
         """Finds and returns a list of the nodes that are predecessors of
         given node."""
         predecessors = []

--- a/src/finn/core/modelwrapper.py
+++ b/src/finn/core/modelwrapper.py
@@ -417,3 +417,13 @@ class ModelWrapper:
     def get_non_finn_nodes(self):
         """Returns a list of nodes where domain != 'finn'."""
         return list(filter(lambda x: x.domain != "finn", self.graph.node))
+
+    def get_node_index(self, node):
+        n_ind = 0
+        try:
+            for n in self.graph.node:
+                if n == node:
+                    return n_ind
+                n_ind += 1
+        except ValueError:
+            return None

--- a/src/finn/core/modelwrapper.py
+++ b/src/finn/core/modelwrapper.py
@@ -290,6 +290,17 @@ class ModelWrapper:
         except ValueError:
             return None
 
+    def find_consumers(self, tensor_name):
+        consumers = []
+        try:
+            for n in self._model_proto.graph.node:
+                for inp_tensor in n.input:
+                    if inp_tensor == tensor_name:
+                        consumers.append(n)
+            return consumers
+        except ValueError:
+            return None
+
     def get_all_tensor_names(self):
         """Returns a list of all (input, output and value_info) tensor names
         in the graph."""

--- a/src/finn/core/modelwrapper.py
+++ b/src/finn/core/modelwrapper.py
@@ -292,34 +292,36 @@ class ModelWrapper:
 
     def find_consumers(self, tensor_name):
         consumers = []
-        try:
-            for n in self._model_proto.graph.node:
-                for inp_tensor in n.input:
-                    if inp_tensor == tensor_name:
-                        consumers.append(n)
+        for n in self._model_proto.graph.node:
+            for inp_tensor in n.input:
+                if inp_tensor == tensor_name:
+                    consumers.append(n)
+        if consumers != []:
             return consumers
-        except ValueError:
+        else:
             return None
 
     def find_successors(self, node):
         successors = []
-        try:
-            for outp_tensor in node.output:
-                tensor_consumer_list = self.find_consumers(outp_tensor)
+        for outp_tensor in node.output:
+            tensor_consumer_list = self.find_consumers(outp_tensor)
+            if tensor_consumer_list is not None:
                 for consumer in tensor_consumer_list:
                     successors.append(consumer)
+        if successors != []:
             return successors
-        except ValueError:
+        else:
             return None
 
     def find_predecessors(self, node):
         predecessors = []
-        try:
-            for inp_tensor in node.input:
-                producer = self.find_producer(inp_tensor)
+        for inp_tensor in node.input:
+            producer = self.find_producer(inp_tensor)
+            if producer is not None:
                 predecessors.append(producer)
+        if predecessors != []:
             return predecessors
-        except ValueError:
+        else:
             return None
 
     def get_all_tensor_names(self):

--- a/src/finn/core/modelwrapper.py
+++ b/src/finn/core/modelwrapper.py
@@ -289,6 +289,8 @@ class ModelWrapper:
             return None
 
     def find_consumers(self, tensor_name):
+        """Finds and returns a list of the nodes that consume tensor with
+        given name."""
         consumers = []
         for n in self._model_proto.graph.node:
             for inp_tensor in n.input:
@@ -300,6 +302,8 @@ class ModelWrapper:
             return None
 
     def find_successors(self, node):
+        """Finds and returns a list of the nodes that are successors of
+        given node."""
         successors = []
         for outp_tensor in node.output:
             tensor_consumer_list = self.find_consumers(outp_tensor)
@@ -312,6 +316,8 @@ class ModelWrapper:
             return None
 
     def find_predecessors(self, node):
+        """Finds and returns a list of the nodes that are predecessors of
+        given node."""
         predecessors = []
         for inp_tensor in node.input:
             producer = self.find_producer(inp_tensor)
@@ -419,6 +425,7 @@ class ModelWrapper:
         return list(filter(lambda x: x.domain != "finn", self.graph.node))
 
     def get_node_index(self, node):
+        """Returns current index of given node."""
         n_ind = 0
         try:
             for n in self.graph.node:

--- a/tests/core/test_modelwrapper.py
+++ b/tests/core/test_modelwrapper.py
@@ -116,3 +116,8 @@ def test_modelwrapper_graph_order():
     assert model.find_predecessors(Round_node) == [Neg_node]
     assert model.find_predecessors(Ceil_node) == [Neg_node]
     assert model.find_predecessors(Add_node) == [Round_node, Ceil_node]
+
+    assert model.get_node_index(Neg_node) == 0
+    assert model.get_node_index(Round_node) == 1
+    assert model.get_node_index(Ceil_node) == 2
+    assert model.get_node_index(Add_node) == 3

--- a/tests/core/test_modelwrapper.py
+++ b/tests/core/test_modelwrapper.py
@@ -107,15 +107,15 @@ def test_modelwrapper_graph_order():
     assert model.find_consumers("ceil1") == [Add_node]
     assert model.find_consumers("out1") is None
 
-    assert model.find_successors(Neg_node) == [Round_node, Ceil_node]
-    assert model.find_successors(Round_node) == [Add_node]
-    assert model.find_successors(Ceil_node) == [Add_node]
-    assert model.find_successors(Add_node) is None
+    assert model.find_direct_successors(Neg_node) == [Round_node, Ceil_node]
+    assert model.find_direct_successors(Round_node) == [Add_node]
+    assert model.find_direct_successors(Ceil_node) == [Add_node]
+    assert model.find_direct_successors(Add_node) is None
 
-    assert model.find_predecessors(Neg_node) is None
-    assert model.find_predecessors(Round_node) == [Neg_node]
-    assert model.find_predecessors(Ceil_node) == [Neg_node]
-    assert model.find_predecessors(Add_node) == [Round_node, Ceil_node]
+    assert model.find_direct_predecessors(Neg_node) is None
+    assert model.find_direct_predecessors(Round_node) == [Neg_node]
+    assert model.find_direct_predecessors(Ceil_node) == [Neg_node]
+    assert model.find_direct_predecessors(Add_node) == [Round_node, Ceil_node]
 
     assert model.get_node_index(Neg_node) == 0
     assert model.get_node_index(Round_node) == 1


### PR DESCRIPTION
Add modelwrapper functions to get a list of consumers of a given tensor (find_consumers), a list of successors (find_successors) and predecessors (find_predecessors) of a given node. Add a modelwrapper function to return the current node index of a given node. Integrate unit tests into test_modelwrapper.py.