### PR TITLE
Feature/convolution input generator kernel stride

### DIFF
--- a/src/finn/custom_op/im2col.py
+++ b/src/finn/custom_op/im2col.py
@@ -21,8 +21,6 @@ def get_im2col_indices_nchw(
     """Returns im2col indices."""
     # First figure out what the size of the output should be
     N, C, H, W = x_shape
-    assert (H + 2 * padding - field_height) % stride_y == 0
-    assert (W + 2 * padding - field_width) % stride_x == 0
     out_height = compute_conv_output_dim(H, field_height, stride_y, padding)
     out_width = compute_conv_output_dim(W, field_width, stride_x, padding)
 

--- a/tests/fpgadataflow/test_fpgadataflow_convinputgenerator.py
+++ b/tests/fpgadataflow/test_fpgadataflow_convinputgenerator.py
@@ -126,7 +126,7 @@ def prepare_inputs(input_tensor):
 # input datatype
 @pytest.mark.parametrize("idt", [DataType.BIPOLAR, DataType.INT2])
 # kernel size
-@pytest.mark.parametrize("k", [2, 4])
+@pytest.mark.parametrize("k", [2, 3, 4])
 # input dimension
 @pytest.mark.parametrize("ifm_dim", [4, 6, 8])
 # input channels


### PR DESCRIPTION

In order to add support for sliding window generator with kernel_size % stride != 0, `ConvolutionInputGenerator` make `ConvolutionInputGenerator_kernel_stride` HLS function call in those cases only (kernel_size % stride != 0) as this function is not as optimal as `ConvolutionInputGenerator`.

Remove verification for k % stride == 0 in several places.

**Problem:**
cppsim (finn) passes and `ConvolutionInputGenerator_kernel_stride` passes Vivado HLS cosim (hlslib test with same parameters) and has been implemented in hardware proving correct behavior. However, rtlsim in finn does not pass. 

Ideas of how to solve this:
- modify working HLS function: probably, It will be tricky to fix this and at the same time get the same performance and flexibility the current transform achieves
-  This is just a workaround: modify ` execute_node` of ` ConvolutionInputGenerator`  HLSCustomOp to execute cppsim for kernel_size%stride !=0 even if self.get_nodeattr("exec_mode") is "rtlsim". A warning could also be added to notify this situation
- use Vivado HLS cosim for these cases. Slower but it may be worth the effort to have HLS cosim as a backup as a simulator