### PR TITLE
Added features to tlastmarker and updated the insertion transform

### DIFF
--- a/src/finn/custom_op/fpgadataflow/tlastmarker.py
+++ b/src/finn/custom_op/fpgadataflow/tlastmarker.py
@@ -51,8 +51,8 @@ class TLastMarker(HLSCustomOp):
             "StreamWidth": ("i", True, 0),
             # width of individual element in stream, in bits
             "ElemWidth": ("i", True, 0),
-            # Protocol: external or kernel2kernel
-            # Vitis docs recommend using qdma_axis for external, ap_axiu for kernel2kernel
+            # Protocol: external or internal
+            # Vitis docs recommend using qdma_axis for external, ap_axiu for internal
             "Protocol": ("s", False, "external"),
         }
         my_attrs.update(super().get_nodeattr_types())
@@ -93,7 +93,7 @@ class TLastMarker(HLSCustomOp):
         if direction == "out":
             if protocol == "external":
                 out_stream_dtype = "qdma_axis<%d,0,0,0>" % stream_width
-            elif protocol == "kernel2kernel:
+            elif protocol == "internal:
                 out_stream_dtype = "ap_axiu<%d,0,0,0>" % stream_width
             else:
                 raise Exception("Unrecognized Protocol in TLastMarker")
@@ -102,7 +102,7 @@ class TLastMarker(HLSCustomOp):
             out_stream_dtype = "ap_uint<%d>" % stream_width
             if protocol == "external":
                 in_stream_dtype = "qdma_axis<%d,0,0,0>" % stream_width
-            elif protocol == "kernel2kernel:
+            elif protocol == "internal:
                 in_stream_dtype = "ap_axiu<%d,0,0,0>" % stream_width
             else:
                 raise Exception("Unrecognized Protocol in TLastMarker")

--- a/src/finn/custom_op/fpgadataflow/tlastmarker.py
+++ b/src/finn/custom_op/fpgadataflow/tlastmarker.py
@@ -93,7 +93,7 @@ class TLastMarker(HLSCustomOp):
         if direction == "out":
             if protocol == "external":
                 out_stream_dtype = "qdma_axis<%d,0,0,0>" % stream_width
-            elif protocol == "internal:
+            elif protocol == "internal":
                 out_stream_dtype = "ap_axiu<%d,0,0,0>" % stream_width
             else:
                 raise Exception("Unrecognized Protocol in TLastMarker")
@@ -102,7 +102,7 @@ class TLastMarker(HLSCustomOp):
             out_stream_dtype = "ap_uint<%d>" % stream_width
             if protocol == "external":
                 in_stream_dtype = "qdma_axis<%d,0,0,0>" % stream_width
-            elif protocol == "internal:
+            elif protocol == "internal":
                 in_stream_dtype = "ap_axiu<%d,0,0,0>" % stream_width
             else:
                 raise Exception("Unrecognized Protocol in TLastMarker")

--- a/src/finn/transformation/fpgadataflow/insert_tlastmarker.py
+++ b/src/finn/transformation/fpgadataflow/insert_tlastmarker.py
@@ -37,8 +37,10 @@ import numpy as np
 
 
 class InsertTLastMarker(Transformation):
-    """Ensure that the graph is terminated with a TLastMarker node, inserting
-    one if necessary."""
+    """Ensure that the graph is started/terminated with a TLastMarker node, inserting
+    one if necessary. Use constructor args to determine type of TLastMarker to be inserted.
+    More information available on the TLastMarker documentation.
+    """
 
     def __init__(self, both=False, external=True, dynamic=True):
         super().__init__()
@@ -78,7 +80,7 @@ class InsertTLastMarker(Transformation):
                 NumIters=num_iters,
                 StreamWidth=stream_width,
                 ElemWidth=elem_width,
-                DynIters=("true" if self.dyniters else "false"),
+                DynIters=(1 if self.dyniters else 0),
                 Direction="out",
                 Protocol=("external" if self.external else "internal"),
                 domain="finn",
@@ -117,7 +119,7 @@ class InsertTLastMarker(Transformation):
                     NumIters=num_iters,
                     StreamWidth=stream_width,
                     ElemWidth=elem_width,
-                    DynIters=("true" if self.dyniters else "false"),
+                    DynIters=(1 if self.dyniters else 0),
                     Direction="in",
                     Protocol=("external" if self.external else "internal"),
                     domain="finn",

--- a/src/finn/transformation/fpgadataflow/insert_tlastmarker.py
+++ b/src/finn/transformation/fpgadataflow/insert_tlastmarker.py
@@ -31,23 +31,32 @@ from onnx import helper as oh
 
 from finn.custom_op.registry import getCustomOp
 from finn.transformation import Transformation
+from finn.util.basic import get_by_name
+
+import numpy as np
 
 
 class InsertTLastMarker(Transformation):
     """Ensure that the graph is terminated with a TLastMarker node, inserting
     one if necessary."""
 
-    def __init__(self):
+    def __init__(self, both=False, external=True, dynamic=True):
         super().__init__()
+        self.dyniters = dynamic
+        self.external = external
+        self.both = both
 
     def apply(self, model):
         # TODO only makes sense for a pure fpgadataflow graph -- check!
         graph_out_name = model.graph.output[0].name
         final_node = model.find_producer(graph_out_name)
-        if final_node.op_type == "TLastMarker":
-            # TODO maybe check the correctness of properties
-            return (model, False)
-        else:
+        graph_modified = False
+        if final_node.op_type != "TLastMarker" and not (
+            final_node.op_type == "IODMA"
+            and get_by_name(final_node.attribute, "direction").s.decode("UTF-8")
+            == "out"
+        ):
+
             custom_op = getCustomOp(final_node)
             num_iters = int(custom_op.get_number_output_values())
             stream_width = int(custom_op.get_outstream_width())
@@ -69,8 +78,51 @@ class InsertTLastMarker(Transformation):
                 NumIters=num_iters,
                 StreamWidth=stream_width,
                 ElemWidth=elem_width,
+                DynIters=("true" if self.dyniters else "false"),
+                Direction="out",
+                Protocol=("external" if self.external else "internal"),
                 domain="finn",
                 backend="fpgadataflow",
             )
             model.graph.node.append(tlast_node)
-            return (model, True)
+            graph_modified = True
+        # if both is True, also insert marker on input
+        if self.both:
+            graph_in_name = model.graph.input[0].name
+            first_node = model.find_consumer(graph_in_name)
+            if first_node.op_type != "TLastMarker" and not (
+                first_node.op_type == "IODMA"
+                and get_by_name(first_node.attribute, "direction").s.decode("UTF-8")
+                == "in"
+            ):
+
+                custom_op = getCustomOp(first_node)
+                num_iters = np.prod(custom_op.get_folded_input_shape()[1:-1])
+                stream_width = int(custom_op.get_instream_width())
+                in_shape = model.get_tensor_shape(graph_in_name)
+                in_dtype = model.get_tensor_datatype(graph_in_name)
+                elem_width = in_dtype.bitwidth()
+                # make new buffer
+                first_node_in = oh.make_tensor_value_info(
+                    model.make_new_valueinfo_name(), TensorProto.FLOAT, in_shape
+                )
+                model.graph.value_info.append(first_node_in)
+                model.set_tensor_datatype(first_node_in.name, in_dtype)
+                # reroute final node output to first_node_in_name
+                first_node.input[0] = first_node_in.name
+                tlast_node = oh.make_node(
+                    "TLastMarker",
+                    [graph_in_name],
+                    [first_node_in.name],
+                    NumIters=num_iters,
+                    StreamWidth=stream_width,
+                    ElemWidth=elem_width,
+                    DynIters=("true" if self.dyniters else "false"),
+                    Direction="in",
+                    Protocol=("external" if self.external else "internal"),
+                    domain="finn",
+                    backend="fpgadataflow",
+                )
+                model.graph.node.insert(0, tlast_node)
+                graph_modified = True
+        return (model, graph_modified)


### PR DESCRIPTION
Added a number of features to the tlast marker:
- ability to use static or dynamic number of iterations. Dynamic is the default, and creates a axilite interface. static does not create an interface and uses the number of iterations specified in the attribute of the same name
- ability to use qdma_axis or ap_axiu for the stream interfaces. While they don't seem to differ, Vitis documentation makes a point of specifying that qdma_axis is to be used for streaming connections to the host, while ap_axiu is for kernel-to-kernel streaming
- ability to remove tlast instead of inserting it, if specified a "in" direction

These changes make the tlastmarker generally useful as a stream adapter for kernel to kernel/host communication in Vitis.

Depends on: #146 weakly, since the IODMA op name is checked for in the to_hls transform. This shouldnt cause any trouble though even if this PR is merged first