### PR TITLE
Updated driver generation transform and template

### DIFF
--- a/src/finn/transformation/fpgadataflow/make_pynq_driver.py
+++ b/src/finn/transformation/fpgadataflow/make_pynq_driver.py
@@ -109,7 +109,7 @@ class MakePYNQDriver(Transformation):
         driver = driver.replace("$OUTPUT_SHAPE_PACKED$", mss(o_tensor_shape_packed))
 
         # clock settings for driver
-        clk_ns = float(model.get_metadata_prop("clk_ns"))
+        clk_ns = model.get_metadata_prop("clk_ns")
         # default to 10ns / 100 MHz if property not set
         if clk_ns is None:
             clk_ns = 10.0

--- a/src/finn/transformation/fpgadataflow/make_pynq_driver.py
+++ b/src/finn/transformation/fpgadataflow/make_pynq_driver.py
@@ -28,6 +28,7 @@
 
 import os
 import shutil
+import warnings
 
 from finn.custom_op.registry import getCustomOp
 from finn.transformation import Transformation
@@ -53,7 +54,7 @@ class MakePYNQDriver(Transformation):
     def apply(self, model):
         vivado_pynq_proj = model.get_metadata_prop("vivado_pynq_proj")
         if vivado_pynq_proj is None or (not os.path.isdir(vivado_pynq_proj)):
-            raise Exception("No PYNQ project found, apply MakePYNQProject first.")
+            warnings.warn("No PYNQ project found, apply MakePYNQProject first.")
 
         # create a temporary folder for the generated driver
         pynq_driver_dir = make_build_dir(prefix="pynq_driver_")
@@ -109,6 +110,11 @@ class MakePYNQDriver(Transformation):
 
         # clock settings for driver
         clk_ns = float(model.get_metadata_prop("clk_ns"))
+        # default to 10ns / 100 MHz if property not set
+        if clk_ns is None:
+            clk_ns = 10.0
+        else:
+            clk_ns = float(clk_ns)
         fclk_mhz = 1 / (clk_ns * 0.001)
         # TODO change according to PYNQ board?
         driver = driver.replace("$CLK_NAME$", "fclk0_mhz")

--- a/src/finn/transformation/fpgadataflow/templates.py
+++ b/src/finn/transformation/fpgadataflow/templates.py
@@ -107,6 +107,7 @@ class FINNAccelDriver():
     def __init__(self, N, bitfile, platform="zynq"):
         \"\"\"Instantiate the FINN accelerator driver.
         Gets batchsize (N) as integer and path to bitfile as string.\"\"\"
+        self.platform = platform
         self.N = N
         # input FINN DataType
         self.idt = $INPUT_FINN_DATATYPE$
@@ -127,7 +128,7 @@ class FINNAccelDriver():
             # clock frequency
             self.fclk_mhz = $CLOCK_FREQ_MHZ$
             # set the clock frequency as specified by user during transformations
-            if fclk_mhz > 0:
+            if self.fclk_mhz > 0:
                 Clocks.$CLK_NAME$ = self.fclk_mhz
             self.dma = self.ol.axi_dma_0
             self.ctrl_regs = self.ol.resize_accel_0


### PR DESCRIPTION
Provides a path to driver generation for Alveo builds, where it has to be called before IODMA insertion, so I changed the missing pynq project from an exception to a warning.

This transform hasn't been tested yet on zynq or alveo. I'm hoping that by submitting the PR it will get tested on Zynq by the regression test.