### PR TITLE
DuplicateStreams_Batch requires to overload get_verilog…

### DIFF
--- a/src/finn/custom_op/fpgadataflow/duplicatestreams_batch.py
+++ b/src/finn/custom_op/fpgadataflow/duplicatestreams_batch.py
@@ -359,3 +359,8 @@ class DuplicateStreams_Batch(HLSCustomOp):
         self.code_gen_dict["$PRAGMAS$"].append(
             "#pragma HLS INTERFACE ap_ctrl_none port=return"
         )
+
+    def get_verilog_top_module_intf_names(self):
+        intf_names = super().get_verilog_top_module_intf_names()
+        intf_names["m_axis"] = ["out0_V_V", "out1_V_V"]
+        return intf_names


### PR DESCRIPTION
As DuplicateStreams_Batch has two outputs (one assumed by default), it requires to overload get_verilog_top_module_intf_names() to create stitched IP