### PR TITLE
Post transform cleanups

### DIFF
--- a/docker/quicktest.sh
+++ b/docker/quicktest.sh
@@ -16,6 +16,11 @@ elif [ $1 = "rtlsim" ]; then
 elif [ $1 = "end2end" ]; then
   echo "Running end2end test suite with no parallelism"
   python setup.py test --addopts "-k end2end"
+elif [ $1 = "full" ]; then
+  echo "Running full test suite, each step with appropriate parallelism"
+  $0 main;
+  $0 rtlsim;
+  $0 end2end;
 else
   echo "Unrecognized argument to quicktest.sh"
 fi

--- a/src/finn/custom_op/fpgadataflow/streamingfclayer_batch.py
+++ b/src/finn/custom_op/fpgadataflow/streamingfclayer_batch.py
@@ -77,7 +77,7 @@ class StreamingFCLayer_Batch(HLSCustomOp):
             "weightDataType": ("s", True, ""),
             "outputDataType": ("s", True, ""),
             # FINN DataType for accumulator -- auto-computed and updated
-            "accDataType": ("s", False, "DataType.INT32"),
+            "accDataType": ("s", False, "INT32"),
             # use xnor-popcount for binary weights/inputs, thus treating them
             # as bipolar
             "binaryXnorMode": ("i", False, 0),

--- a/src/finn/custom_op/fpgadataflow/streamingfclayer_batch.py
+++ b/src/finn/custom_op/fpgadataflow/streamingfclayer_batch.py
@@ -483,6 +483,10 @@ class StreamingFCLayer_Batch(HLSCustomOp):
                     adt = DataType.get_smallest_possible(0 - acc_max)
             else:
                 adt = DataType.get_smallest_possible(acc_max)
+            # ensure a datatype divisible by 8-bits in case this is the last node
+            bw = roundup_to_integer_multiple(adt.bitwidth(), 8)
+            new_adt_name = adt.name.replace(str(adt.bitwidth()), str(bw))
+            adt = DataType[new_adt_name]
             self.set_nodeattr("accDataType", adt.name)
             # for no-activation nodes, output dt = acc dt
             self.set_nodeattr("outputDataType", adt.name)

--- a/src/finn/transformation/fpgadataflow/create_dataflow_partition.py
+++ b/src/finn/transformation/fpgadataflow/create_dataflow_partition.py
@@ -112,6 +112,7 @@ class CreateDataflowPartition(Transformation):
                     "dataflow_partition" + str(target_partition_id) + "_"
                 )
                 df_model_filename = df_model_dir + "/df_model.onnx"
+                df_model.cleanup()
                 df_model.save(df_model_filename)
                 # remove all dataflow nodes from the non-dataflow model
                 # keep track of where the dataflow part starts

--- a/src/finn/transformation/general.py
+++ b/src/finn/transformation/general.py
@@ -189,6 +189,9 @@ class SortGraph(Transformation):
     # Probably this is faster than copying initializers and more robust in general
 
     def apply(self, model):
+        if len(model.graph.node) == 1:
+            # single-node graph, nothing to sort
+            return (model, False)
         # Gather graph structure
         graph_dependencies = {}
         node_list = [
@@ -214,7 +217,7 @@ class SortGraph(Transformation):
         for new_idx, sorted_idx in enumerate(sorted_node_indexes):
             model.graph.node.insert(new_idx, node_list[sorted_idx])
 
-        return model, False
+        return (model, False)
 
 
 class ConvertSubToAdd(Transformation):

--- a/src/finn/util/basic.py
+++ b/src/finn/util/basic.py
@@ -156,13 +156,19 @@ def make_build_dir(prefix=""):
 
 
 def get_by_name(container, name, name_field="name"):
-    """Return item from container by .name field if it exists, None otherwise"""
+    """Return item from container by .name field if it exists, None otherwise.
+    Will throw an Exception if multiple items are found, since this violates the
+    ONNX standard."""
     names = [getattr(x, name_field) for x in container]
-    try:
-        ind = names.index(name)
-        return container[ind]
-    except ValueError:
+
+    inds = [i for i, e in enumerate(names) if e == name]
+    if len(inds) > 1:
+        raise Exception("Found multiple get_by_name matches, undefined behavior")
+    elif len(inds) == 0:
         return None
+    else:
+        ind = inds[0]
+        return container[ind]
 
 
 def remove_by_name(container, name, name_field="name"):

--- a/tests/fpgadataflow/test_convert_to_hls_layers_fc.py
+++ b/tests/fpgadataflow/test_convert_to_hls_layers_fc.py
@@ -89,7 +89,6 @@ def test_convert_to_hls_layers_tfc_w1a1():
     assert fc3.op_type == "StreamingFCLayer_Batch"
     assert model.get_tensor_shape(fc3.input[0]) == [1, 64]
     assert model.get_tensor_shape(fc3.input[1]) == [64, 10]
-    os.remove(export_onnx_path)
 
     fc0w = getCustomOp(fc0)
     fc0w.set_nodeattr("SIMD", 784)


### PR DESCRIPTION
Introduce some clean-up transforms (remove unused tensors, static inputs and sort graph) after every applied transform, can be disabled by setting the optional argument `model.transform(trn(), cleanup=False)`