### PR TITLE
Move to new Brevitas export flow

### DIFF
--- a/docker/finn_entrypoint.sh
+++ b/docker/finn_entrypoint.sh
@@ -12,7 +12,7 @@ gecho () {
 
 # checkout the correct dependency repo commits
 # the repos themselves are cloned in the Dockerfile
-BREVITAS_COMMIT=f9a27226d4acf1661dd38bc449f71f89e0983cce
+BREVITAS_COMMIT=b22a0f2eb6ac9f700c86cd1a998d7d5db996cc93
 CNPY_COMMIT=4e8810b1a8637695171ed346ce68f6984e585ef4
 HLSLIB_COMMIT=cfafe11a93b79ab1af7529d68f08886913a6466e
 PYVERILATOR_COMMIT=c97a5ba41bbc7c419d6f25c74cdf3bdc3393174f

--- a/docker/finn_entrypoint.sh
+++ b/docker/finn_entrypoint.sh
@@ -12,7 +12,7 @@ gecho () {
 
 # checkout the correct dependency repo commits
 # the repos themselves are cloned in the Dockerfile
-BREVITAS_COMMIT=302ec0490f1ddc956f1df6d0ccd2228f0d50bb65
+BREVITAS_COMMIT=85e28ac2e6570e91216d042212a7d1a28ec6e394
 CNPY_COMMIT=4e8810b1a8637695171ed346ce68f6984e585ef4
 HLSLIB_COMMIT=cfafe11a93b79ab1af7529d68f08886913a6466e
 PYVERILATOR_COMMIT=c97a5ba41bbc7c419d6f25c74cdf3bdc3393174f

--- a/docker/finn_entrypoint.sh
+++ b/docker/finn_entrypoint.sh
@@ -12,7 +12,7 @@ gecho () {
 
 # checkout the correct dependency repo commits
 # the repos themselves are cloned in the Dockerfile
-BREVITAS_COMMIT=b22a0f2eb6ac9f700c86cd1a998d7d5db996cc93
+BREVITAS_COMMIT=302ec0490f1ddc956f1df6d0ccd2228f0d50bb65
 CNPY_COMMIT=4e8810b1a8637695171ed346ce68f6984e585ef4
 HLSLIB_COMMIT=cfafe11a93b79ab1af7529d68f08886913a6466e
 PYVERILATOR_COMMIT=c97a5ba41bbc7c419d6f25c74cdf3bdc3393174f

--- a/src/finn/util/pytorch.py
+++ b/src/finn/util/pytorch.py
@@ -28,7 +28,6 @@
 import torch
 
 from torch.nn import Module, Sequential
-from brevitas.quant_tensor import QuantTensor
 
 
 class Normalize(Module):
@@ -65,17 +64,3 @@ class NormalizePreProc(Module):
 
     def forward(self, x):
         return self.features(x)
-
-
-class BrevitasDebugHook:
-    def __init__(self):
-        self.outputs = {}
-
-    def __call__(self, module, module_in, module_out):
-        tensor = module_out
-        if isinstance(module_out, QuantTensor):
-            tensor = module_out[0]
-        self.outputs[module.export_debug_name] = tensor.detach().numpy()
-
-    def clear(self):
-        self.outputs = {}

--- a/tests/brevitas/test_brevitas_avg_pool_export.py
+++ b/tests/brevitas/test_brevitas_avg_pool_export.py
@@ -45,7 +45,7 @@ def test_brevitas_avg_pool_export(
     scale = np.ones((1, channels, 1, 1))
     output_scale = torch.from_numpy(scale).float()
     input_quant_tensor = pack_quant_tensor(
-        tensor=input_tensor, scale=output_scale, bit_width=ibw_tensor
+        tensor=input_tensor, scale=output_scale, bit_width=ibw_tensor, signed=signed
     )
     bo.export_finn_onnx(b_avgpool, ishape, export_onnx_path, input_t=input_quant_tensor)
     model = ModelWrapper(export_onnx_path)
@@ -65,7 +65,7 @@ def test_brevitas_avg_pool_export(
     inp = gen_finn_dt_tensor(dtype, ishape)
     input_tensor = torch.from_numpy(inp).float()
     input_quant_tensor = pack_quant_tensor(
-        tensor=input_tensor, scale=output_scale, bit_width=ibw_tensor
+        tensor=input_tensor, scale=output_scale, bit_width=ibw_tensor, signed=signed
     )
     b_avgpool.eval()
     expected = b_avgpool.forward(input_quant_tensor).tensor.detach().numpy()
@@ -84,7 +84,7 @@ def test_brevitas_avg_pool_export(
     input_tensor = torch.from_numpy(inp_tensor).float()
     input_scale = torch.from_numpy(scale).float()
     input_quant_tensor = pack_quant_tensor(
-        tensor=input_tensor, scale=input_scale, bit_width=ibw_tensor
+        tensor=input_tensor, scale=input_scale, bit_width=ibw_tensor, signed=signed
     )
     # export again to set the scale values correctly
     bo.export_finn_onnx(b_avgpool, ishape, export_onnx_path, input_t=input_quant_tensor)

--- a/tests/brevitas/test_brevitas_relu_act_export.py
+++ b/tests/brevitas/test_brevitas_relu_act_export.py
@@ -15,7 +15,7 @@ from finn.transformation.infer_shapes import InferShapes
 export_onnx_path = "test_brevitas_relu_act_export.onnx"
 
 
-@pytest.mark.parametrize("abits", [1, 2, 4, 8])
+@pytest.mark.parametrize("abits", [2, 4, 8])
 @pytest.mark.parametrize("max_val", [1.0, 1.5, 1 - 2 ** (-7)])
 @pytest.mark.parametrize(
     "scaling_impl_type", [ScalingImplType.CONST, ScalingImplType.PARAMETER]
@@ -70,7 +70,7 @@ scaling_impl.learned_value": torch.tensor(
     os.remove(export_onnx_path)
 
 
-@pytest.mark.parametrize("abits", [1, 2, 4, 8])
+@pytest.mark.parametrize("abits", [2, 4, 8])
 @pytest.mark.parametrize("max_val", [1.0, 1.5, 1 - 2 ** (-7)])
 @pytest.mark.parametrize("scaling_per_channel", [True, False])
 def test_brevitas_act_export_relu_imagenet(abits, max_val, scaling_per_channel):


### PR DESCRIPTION
Move to the new Brevitas export flow (see https://github.com/Xilinx/brevitas/pull/187) to keep up-to-date and take advantage of new features. Current version in the PR passes the whole FINN test, but need to check a few more things since this is a reasonably big change:
- [x] how this affects in-progress work on MobileNet-v1 and ResNet-50
- [x] debug infrastructure (#216 )
- [x] passes full test suite