### PR TITLE
Move end2end examples to be fully on-FPGA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,6 @@ MANIFEST
 # datasets for testing
 /dataset/
 /data/
+
+# Google Drive key for dashboard
+/gdrive-key/

--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,6 @@ MANIFEST
 
 # PYNQ board files
 /board_files/
+
+# datasets for testing
+/dataset/

--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,4 @@ MANIFEST
 
 # datasets for testing
 /dataset/
+/data/

--- a/docker/Dockerfile.finn_ci
+++ b/docker/Dockerfile.finn_ci
@@ -65,7 +65,7 @@ RUN apt update; apt install nano
 RUN pip install pytest-dependency
 RUN pip install pytest-xdist
 RUN pip install pytest-parallel
-RUN pip install mnist
+RUN pip install -e git+https://github.com/fbcotter/dataset_loading.git@0.0.4#egg=dataset_loading
 
 ENV PYTHONPATH "${PYTHONPATH}:/workspace/finn/src"
 ENV PYTHONPATH "${PYTHONPATH}:/workspace/pyverilator"

--- a/docker/Dockerfile.finn_ci
+++ b/docker/Dockerfile.finn_ci
@@ -65,6 +65,7 @@ RUN apt update; apt install nano
 RUN pip install pytest-dependency
 RUN pip install pytest-xdist
 RUN pip install pytest-parallel
+RUN pip install mnist
 
 ENV PYTHONPATH "${PYTHONPATH}:/workspace/finn/src"
 ENV PYTHONPATH "${PYTHONPATH}:/workspace/pyverilator"

--- a/docker/Dockerfile.finn_dev
+++ b/docker/Dockerfile.finn_dev
@@ -63,6 +63,7 @@ RUN pip install sphinx_rtd_theme==0.5.0
 RUN pip install pytest-xdist==2.0.0
 RUN pip install pytest-parallel==0.1.0
 RUN pip install netron==4.4.7
+RUN pip install mnist
 
 # switch user
 RUN groupadd -g $GID $GNAME

--- a/docker/Dockerfile.finn_dev
+++ b/docker/Dockerfile.finn_dev
@@ -56,7 +56,7 @@ RUN pip install sphinx==3.1.2
 RUN pip install sphinx_rtd_theme==0.5.0
 RUN pip install pytest-xdist==2.0.0
 RUN pip install pytest-parallel==0.1.0
-RUN pip install netron==4.4.7
+RUN pip install netron
 RUN pip install -e git+https://github.com/fbcotter/dataset_loading.git@0.0.4#egg=dataset_loading
 
 # switch user

--- a/docker/Dockerfile.finn_dev
+++ b/docker/Dockerfile.finn_dev
@@ -63,7 +63,7 @@ RUN pip install sphinx_rtd_theme==0.5.0
 RUN pip install pytest-xdist==2.0.0
 RUN pip install pytest-parallel==0.1.0
 RUN pip install netron==4.4.7
-RUN pip install mnist
+RUN pip install -e git+https://github.com/fbcotter/dataset_loading.git@0.0.4#egg=dataset_loading
 
 # switch user
 RUN groupadd -g $GID $GNAME

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 bitstring==3.1.7
 docrep==0.2.7
 future==0.18.2
+gspread==3.6.0
 numpy==1.18.0
 onnx==1.6.0
 onnxruntime==1.2.0

--- a/src/finn/custom_op/fpgadataflow/labelselect_batch.py
+++ b/src/finn/custom_op/fpgadataflow/labelselect_batch.py
@@ -34,6 +34,7 @@ from finn.core.datatype import DataType
 from finn.custom_op.fpgadataflow import HLSCustomOp
 from onnx import TensorProto, helper
 from finn.util.data_packing import npy_to_rtlsim_input, rtlsim_output_to_npy
+from finn.util.basic import roundup_to_integer_multiple
 
 
 class LabelSelect_Batch(HLSCustomOp):
@@ -46,6 +47,10 @@ class LabelSelect_Batch(HLSCustomOp):
             # If not provided compute min size
             labels = self.get_nodeattr("Labels")
             odt = DataType.get_smallest_possible(labels - 1)
+            # ensure a datatype divisible by 8-bits in case this is the last node
+            bw = roundup_to_integer_multiple(odt.bitwidth(), 8)
+            new_odt_name = odt.name.replace(str(odt.bitwidth()), str(bw))
+            odt = DataType[new_odt_name]
             odt_name = odt.name
             self.set_nodeattr("outputDataType", odt_name)
 

--- a/src/finn/custom_op/fpgadataflow/thresholding_batch.py
+++ b/src/finn/custom_op/fpgadataflow/thresholding_batch.py
@@ -73,6 +73,8 @@ class Thresholding_Batch(HLSCustomOp):
             # [4] is four vectors (like a FC layer with batch=4)
             # [1, 4, 4] is four * four vectors (like a conv layer with batch=1)
             "numInputVectors": ("ints", False, [1]),
+            # initialization value for the thresholding accumulator
+            "ActVal": ("i", False, 0),
         }
         my_attrs.update(super().get_nodeattr_types())
         return my_attrs
@@ -321,7 +323,7 @@ class Thresholding_Batch(HLSCustomOp):
                 threshold_tensor.shape[-1],
                 tdt_hls,
                 odt_hls,
-                export_odt.min(),
+                self.get_nodeattr("ActVal"),
                 "std::less_equal<%s>" % tdt_hls,
             )
         )

--- a/src/finn/transformation/fpgadataflow/create_stitched_ip.py
+++ b/src/finn/transformation/fpgadataflow/create_stitched_ip.py
@@ -54,7 +54,7 @@ class CreateStitchedIP(Transformation):
     The packaged block design IP can be found under the ip subdirectory.
     """
 
-    def __init__(self, fpgapart, clk_ns=10.0, ip_name="finn_design", vitis=False):
+    def __init__(self, fpgapart, clk_ns, ip_name="finn_design", vitis=False):
         super().__init__()
         self.fpgapart = fpgapart
         self.clk_ns = clk_ns

--- a/src/finn/transformation/fpgadataflow/make_pynq_driver.py
+++ b/src/finn/transformation/fpgadataflow/make_pynq_driver.py
@@ -124,6 +124,13 @@ class MakePYNQDriver(Transformation):
 
         with open(driver_py, "w") as f:
             f.write(driver)
+
+        # add validate.py to run full top-1 test (only for suitable networks)
+        validate_py = pynq_driver_dir + "/validate.py"
+        validate_src = templates.pynq_validation_template
+        with open(validate_py, "w") as f:
+            f.write(validate_src)
+
         # copy all the dependencies into the driver folder
         shutil.copytree(
             get_finn_root() + "/src/finn/util", pynq_driver_dir + "/finn/util"

--- a/src/finn/transformation/fpgadataflow/templates.py
+++ b/src/finn/transformation/fpgadataflow/templates.py
@@ -436,3 +436,55 @@ open_project $VITIS_PROJ_PATH$/_x/link/vivado/vpl/prj/prj.xpr
 open_run impl_1
 report_utilization -hierarchical -hierarchical_depth 5 -file $VITIS_PROJ_PATH$/synth_report.xml -format xml
 """
+
+pynq_validation_template = """
+import argparse
+from driver import FINNAccelDriver
+import numpy as np
+
+if __name__ == "__main__":
+  parser = argparse.ArgumentParser(description='Validate top-1 accuracy for FINN accelerator')
+  parser.add_argument('--batchsize', help='number of samples for inference', type=int, default=100)
+  parser.add_argument('--dataset', help='dataset to use (mnist of cifar10)', required=True)
+  # parse arguments
+  args = parser.parse_args()
+  bsize = args.batchsize
+  dataset = args.dataset
+
+  if dataset == "mnist":
+    from dataset_loading import mnist
+    trainx, trainy, testx, testy, valx, valy = mnist.load_mnist_data("/tmp", download=True, one_hot=False)
+  elif dataset == "cifar10":
+    from dataset_loading import cifar
+    trainx, trainy, testx, testy, valx, valy = cifar.load_cifar_data("/tmp", download=True, one_hot=False)
+  else:
+    raise Exception("Unrecognized dataset")
+
+  test_imgs = testx
+  test_labels = testy
+
+  ok = 0
+  nok = 0
+  total = test_imgs.shape[0]
+  driver = FINNAccelDriver(bsize, "resizer.bit", "zynq-iodma")
+
+  n_batches = int(total / bsize)
+
+  test_imgs = test_imgs.reshape(n_batches, bsize, -1)
+  test_labels = test_labels.reshape(n_batches, bsize)
+
+  for i in range(n_batches):
+    ibuf_normal = test_imgs[i].reshape(driver.ibuf_packed_device.shape)
+    exp = test_labels[i]
+    driver.copy_input_data_to_device(ibuf_normal)
+    driver.execute()
+    obuf_normal = np.empty_like(driver.obuf_packed_device)
+    driver.copy_output_data_from_device(obuf_normal)
+    ret = np.bincount(obuf_normal.flatten() == exp.flatten())
+    nok += ret[0]
+    ok += ret[1]
+    print("batch %d / %d : total OK %d NOK %d" % (i, n_batches, ok, nok))
+
+  acc = 100.0 * ok / (total)
+  print("Final accuracy: %f" % acc)
+"""

--- a/src/finn/transformation/infer_data_layouts.py
+++ b/src/finn/transformation/infer_data_layouts.py
@@ -75,6 +75,17 @@ def _infer_node_data_layout(model, node):
             inp_layout = model.get_tensor_layout(node.input[0])
             out_layout = [inp_layout[i] for i in perm]
             model.set_tensor_layout(node.output[0], out_layout)
+        elif node.op_type == "Unsqueeze":
+            inp_layout = model.get_tensor_layout(node.input[0])
+            # add dummy dimension at the output
+            out_layout = inp_layout + ["x"]
+            model.set_tensor_layout(node.output[0], out_layout)
+        elif node.op_type == "Squeeze":
+            inp_layout = model.get_tensor_layout(node.input[0])
+            assert inp_layout[-1] == "x"
+            # remove dummy dimension
+            out_layout = inp_layout[:-1]
+            model.set_tensor_layout(node.output[0], out_layout)
         else:
             # try to guess based on number of output dims
             for o in node.output:

--- a/src/finn/transformation/streamline/reorder.py
+++ b/src/finn/transformation/streamline/reorder.py
@@ -533,7 +533,7 @@ class MoveScalarLinearPastInvariants(Transformation):
                 if prod0 is None:
                     continue
 
-                if prod0.op_type == "Mul" or prod0.op_type == "Add":
+                if prod0.op_type in ["Mul", "Add", "Div"]:
                     # check if second input of producer is an initializer
                     init0 = model.get_initializer(prod0.input[1])
                     # if either initializer is None, skip

--- a/src/finn/util/gdrive.py
+++ b/src/finn/util/gdrive.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2020, Xilinx
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of FINN nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import gspread
+import os
+import warnings
+from datetime import datetime
+
+
+def upload_to_end2end_dashboard(data_dict):
+    gdrive_key = "/workspace/finn/gdrive-key/service_account.json"
+    if not os.path.isfile(gdrive_key):
+        warnings.warn("Google Drive key not found, skipping dashboard upload")
+        return
+    gc = gspread.service_account(filename=gdrive_key)
+    spreadsheet = gc.open("finn-end2end-dashboard")
+    worksheet = spreadsheet.get_worksheet(0)
+    keys = list(data_dict.keys())
+    vals = list(data_dict.values())
+    # check against existing header
+    existing_keys = worksheet.row_values(1)
+    if existing_keys != keys:
+        # create new worksheet
+        dtstr = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        worksheet = spreadsheet.add_worksheet(
+            title="Dashboard " + dtstr, rows=10, cols=len(keys), index=0
+        )
+        # create header row with keys
+        worksheet.update("A1:1", [keys])
+        # freeze and make header bold
+        worksheet.freeze(rows=1)
+        worksheet.format("A1:1", {"textFormat": {"bold": True}})
+    # insert values into new row
+    worksheet.insert_row([], index=2)
+    worksheet.update("A2:2", [vals])

--- a/src/finn/util/test.py
+++ b/src/finn/util/test.py
@@ -145,7 +145,6 @@ def get_example_input(topology):
     elif topology == "cnv":
         fn = pk.resource_filename("finn", "data/cifar10/cifar10-test-data-class3.npz")
         input_tensor = np.load(fn)["arr_0"].astype(np.float32)
-        input_tensor = input_tensor / 255
         return input_tensor
     else:
         raise Exception("Unknown topology, can't return example input")

--- a/src/finn/util/test.py
+++ b/src/finn/util/test.py
@@ -77,6 +77,11 @@ def get_test_model_untrained(netname, wbits, abits):
     return get_test_model(netname, wbits, abits, pretrained=False)
 
 
+def get_topk(vec, k):
+    "Return indices of the top-k values in given array vec (treated as 1D)."
+    return np.flip(vec.flatten().argsort())[:k]
+
+
 def soft_verify_topk(invec, idxvec, k):
     """Check that the topK indices provided actually point to the topK largest
     values in the input vector"""

--- a/src/finn/util/test.py
+++ b/src/finn/util/test.py
@@ -162,7 +162,7 @@ def get_trained_network_and_ishape(topology, wbits, abits):
     return (model, ishape)
 
 
-def execute_parent(parent_path, child_path, input_tensor_npy):
+def execute_parent(parent_path, child_path, input_tensor_npy, return_full_ctx=False):
     """Execute parent model containing a single StreamingDataflowPartition by
     replacing it with the model at child_path and return result."""
 
@@ -173,5 +173,7 @@ def execute_parent(parent_path, child_path, input_tensor_npy):
     sdp_node = getCustomOp(sdp_node)
     sdp_node.set_nodeattr("model", child_path)
     ret = execute_onnx(parent_model, {iname: input_tensor_npy}, True)
-    y = ret[oname]
-    return y
+    if return_full_ctx:
+        return ret
+    else:
+        return ret[oname]

--- a/tests/end2end/test_end2end_bnn_pynq.py
+++ b/tests/end2end/test_end2end_bnn_pynq.py
@@ -343,6 +343,8 @@ class TestEnd2End:
     @pytest.mark.vivado
     @pytest.mark.parametrize("kind", ["zynq", "alveo"])
     def test_ipgen(self, topology, wbits, abits, kind):
+        if kind == "alveo" and ("VITIS_PATH" not in os.environ):
+            pytest.skip("VITIS_PATH not set")
         prev_chkpt_name = get_checkpoint_name(topology, wbits, abits, "fold")
         model = load_test_checkpoint_or_skip(prev_chkpt_name)
         test_fpga_part = get_build_env(kind, target_clk_ns)["part"]
@@ -355,6 +357,8 @@ class TestEnd2End:
     @pytest.mark.vivado
     @pytest.mark.parametrize("kind", ["zynq", "alveo"])
     def test_ipstitch_rtlsim(self, topology, wbits, abits, kind):
+        if kind == "alveo" and ("VITIS_PATH" not in os.environ):
+            pytest.skip("VITIS_PATH not set")
         prev_chkpt_name = get_checkpoint_name(topology, wbits, abits, "ipgen_" + kind)
         model = load_test_checkpoint_or_skip(prev_chkpt_name)
         test_fpga_part = get_build_env(kind, target_clk_ns)["part"]
@@ -375,7 +379,9 @@ class TestEnd2End:
                 "rtlsim_trace", "%s_w%da%d.vcd" % (topology, wbits, abits)
             )
             os.environ["RTLSIM_TRACE_DEPTH"] = "3"
-        rtlsim_chkpt = get_checkpoint_name(topology, wbits, abits, "ipstitch_rtlsim_" + kind)
+        rtlsim_chkpt = get_checkpoint_name(
+            topology, wbits, abits, "ipstitch_rtlsim_" + kind
+        )
         model.save(rtlsim_chkpt)
         parent_chkpt = get_checkpoint_name(topology, wbits, abits, "dataflow_parent")
         (input_tensor_npy, output_tensor_npy) = get_golden_io_pair(
@@ -391,7 +397,11 @@ class TestEnd2End:
     @pytest.mark.vivado
     @pytest.mark.parametrize("kind", ["zynq", "alveo"])
     def test_throughput_rtlsim(self, topology, wbits, abits, kind):
-        prev_chkpt_name = get_checkpoint_name(topology, wbits, abits, "ipstitch_rtlsim_" + kind)
+        if kind == "alveo" and ("VITIS_PATH" not in os.environ):
+            pytest.skip("VITIS_PATH not set")
+        prev_chkpt_name = get_checkpoint_name(
+            topology, wbits, abits, "ipstitch_rtlsim_" + kind
+        )
         model = load_test_checkpoint_or_skip(prev_chkpt_name)
         n_nodes = len(model.graph.node)
         perf_est = model.analysis(dataflow_performance)

--- a/tests/end2end/test_end2end_bnn_pynq.py
+++ b/tests/end2end/test_end2end_bnn_pynq.py
@@ -233,7 +233,7 @@ def measure_top1_accuracy(model_chkpt, dataset, parent_chkpt=None):
     else:
         parent_model = ModelWrapper(parent_chkpt)
         parent_iname = parent_model.graph.input[0].name
-        ishape = model.get_tensor_shape(parent_iname)
+        ishape = parent_model.get_tensor_shape(parent_iname)
     ok = 0
     nok = 0
     n_batches = testx.shape[0]

--- a/tests/end2end/test_end2end_bnn_pynq.py
+++ b/tests/end2end/test_end2end_bnn_pynq.py
@@ -450,9 +450,7 @@ class TestEnd2End:
         oname = parent_model.graph.output[0].name
         sdp_node = parent_model.get_nodes_by_op_type("StreamingDataflowPartition")[0]
         sdp_node = getCustomOp(sdp_node)
-        sdp_chkpt = get_checkpoint_name(topology, wbits, abits, "deploy")
-        load_test_checkpoint_or_skip(sdp_chkpt)
-        sdp_node.set_nodeattr("model", sdp_chkpt)
+        sdp_node.set_nodeattr("model", prev_chkpt_name)
         ret = execute_onnx(parent_model, {iname: input_tensor_npy}, True)
         y = ret[oname]
         assert np.isclose(y, output_tensor_npy).all()

--- a/tests/end2end/test_end2end_bnn_pynq.py
+++ b/tests/end2end/test_end2end_bnn_pynq.py
@@ -397,6 +397,8 @@ class TestEnd2End:
     @pytest.mark.slow
     @pytest.mark.parametrize("kind", ["zynq"])
     def test_rtlsim_top1(self, topology, wbits, abits, kind):
+        if "TEST_RTLSIM_TOP1" not in os.environ:
+            pytest.skip("TEST_RTLSIM_TOP1 not set")
         if "fc" not in topology:
             pytest.skip("Top-1 rtlsim test currently for MNIST only")
         rtlsim_chkpt = get_checkpoint_name(

--- a/tests/end2end/test_end2end_bnn_pynq.py
+++ b/tests/end2end/test_end2end_bnn_pynq.py
@@ -358,10 +358,8 @@ class TestEnd2End:
 
     @pytest.mark.slow
     @pytest.mark.vivado
-    @pytest.mark.parametrize("kind", ["zynq", "alveo"])
+    @pytest.mark.parametrize("kind", ["zynq"])
     def test_ipstitch_rtlsim(self, topology, wbits, abits, kind):
-        if kind == "alveo" and ("VITIS_PATH" not in os.environ):
-            pytest.skip("VITIS_PATH not set")
         prev_chkpt_name = get_checkpoint_name(topology, wbits, abits, "ipgen_" + kind)
         model = load_test_checkpoint_or_skip(prev_chkpt_name)
         test_fpga_part = get_build_env(kind, target_clk_ns)["part"]
@@ -423,10 +421,8 @@ class TestEnd2End:
 
     @pytest.mark.slow
     @pytest.mark.vivado
-    @pytest.mark.parametrize("kind", ["zynq", "alveo"])
+    @pytest.mark.parametrize("kind", ["zynq"])
     def test_throughput_rtlsim(self, topology, wbits, abits, kind):
-        if kind == "alveo" and ("VITIS_PATH" not in os.environ):
-            pytest.skip("VITIS_PATH not set")
         prev_chkpt_name = get_checkpoint_name(
             topology, wbits, abits, "ipstitch_rtlsim_" + kind
         )
@@ -483,7 +479,7 @@ class TestEnd2End:
         model.save(get_checkpoint_name(topology, wbits, abits, "deploy_" + kind))
 
     @pytest.mark.parametrize("kind", ["zynq", "alveo"])
-    def test_run_on_pynq(self, topology, wbits, abits, kind):
+    def test_run_on_hw(self, topology, wbits, abits, kind):
         prev_chkpt_name = get_checkpoint_name(topology, wbits, abits, "deploy_" + kind)
         model = load_test_checkpoint_or_skip(prev_chkpt_name)  # NOQA
         cfg = get_build_env(kind, target_clk_ns)

--- a/tests/end2end/test_end2end_bnn_pynq.py
+++ b/tests/end2end/test_end2end_bnn_pynq.py
@@ -119,6 +119,10 @@ def fold_tfc(model):
         fcl_inst.set_nodeattr("inFIFODepth", ififo)
         fcl_inst.set_nodeattr("outFIFODepth", ofifo)
         fcl_inst.set_nodeattr("ram_style", ramstyle)
+    # set parallelism for input quantizer to be same as first layer's SIMD
+    inp_qnt_node = model.get_nodes_by_op_type("Thresholding_Batch")[0]
+    inp_qnt = getCustomOp(inp_qnt_node)
+    inp_qnt.set_nodeattr("PE", 49)
     return model
 
 

--- a/tests/end2end/test_end2end_bnn_pynq.py
+++ b/tests/end2end/test_end2end_bnn_pynq.py
@@ -94,6 +94,7 @@ from finn.transformation.insert_topk import InsertTopK
 from finn.core.datatype import DataType
 from dataset_loading import mnist, cifar
 from datetime import datetime
+import subprocess
 
 build_dir = "/tmp/" + os.environ["FINN_INST_NAME"]
 target_clk_ns = 10
@@ -290,6 +291,11 @@ class TestEnd2End:
         bo.export_finn_onnx(model, ishape, chkpt_name)
         dtstr = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         update_dashboard_data(topology, wbits, abits, "datetime", dtstr)
+        finn_commit = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], cwd="/workspace/finn"
+        )
+        finn_commit = finn_commit.decode("utf-8").strip()
+        update_dashboard_data(topology, wbits, abits, "finn-commit", finn_commit)
         assert os.path.isfile(chkpt_name)
 
     def test_import_and_tidy(self, topology, wbits, abits):

--- a/tests/fpgadataflow/test_convert_to_hls_layers_synthetic.py
+++ b/tests/fpgadataflow/test_convert_to_hls_layers_synthetic.py
@@ -52,7 +52,7 @@ from finn.transformation.fpgadataflow.prepare_cppsim import PrepareCppSim
 from finn.transformation.fpgadataflow.compile_cppsim import CompileCppSim
 from finn.transformation.fpgadataflow.set_exec_mode import SetExecMode
 from finn.transformation.streamline.absorb import (
-    AbsorbScalarMulIntoTopK,
+    AbsorbScalarMulAddIntoTopK,
     AbsorbConsecutiveTransposes,
 )
 from finn.transformation.streamline.collapse_repeated import (
@@ -192,7 +192,7 @@ def test_convert_to_hls_layers_synthetic(ch, ifmdim, idt):
     model = model.transform(to_hls.InferGlobalAccPoolLayer())
     model = model.transform(MoveScalarLinearPastInvariants())
     model = model.transform(InsertTopK())
-    model = model.transform(AbsorbScalarMulIntoTopK())
+    model = model.transform(AbsorbScalarMulAddIntoTopK())
     model = model.transform(InferDataTypes())
     model = model.transform(to_hls.InferLabelSelectLayer())
     model = model.transform(AbsorbConsecutiveTransposes())


### PR DESCRIPTION
Previously the FINN end2end examples (BNN-PYNQ networks, TFC/SFC/LFC and CNV) were set up in such a way that a few layers were still outside the dataflow partition (i.e. not converted to HLS). Due to our lacking heterogeneous execution model this resulted in big performance penalties when doing top-1 validation on the dataset, and just using the networks in general.

Using a combination of the network updates pushed to latest Brevitas, additional input preprocessing + quantization information and an additional Top-1 layer at the end, this PR moves all the end-to-end examples to be fully on the FPGA.

Also adds preliminary support for posting end2end results to a Google Drive dashboard.