### PR TITLE
[Docker] Add -f option to groupadd for GID exists issue

### DIFF
--- a/docker/Dockerfile.finn_dev
+++ b/docker/Dockerfile.finn_dev
@@ -61,7 +61,7 @@ RUN pip install netron
 RUN pip install -e git+https://github.com/fbcotter/dataset_loading.git@0.0.4#egg=dataset_loading
 
 # switch user
-RUN groupadd -g $GID $GNAME
+RUN groupadd -g $GID $GNAME -f
 RUN useradd -M -u $UID $UNAME -g $GNAME
 RUN usermod -aG sudo $UNAME
 RUN echo "$UNAME:$PASSWD" | chpasswd


### PR DESCRIPTION
Add `-f` option to `groupadd` to avoid `groupadd: GID already exists` errors. This is known to be incompatible with Github Actions (GHA), so as long as the Dockerfile is not used by the GHA pipeline, this should be fine. An alternate option is the `-o` flag. The difference is `-f` uses a different GID, and `-o` duplicates it. Not really sure which is better.