### PR TITLE
Decoupled and runtime-writable thresholds

### DIFF
--- a/src/finn/custom_op/fpgadataflow/templates.py
+++ b/src/finn/custom_op/fpgadataflow/templates.py
@@ -371,7 +371,7 @@ void Thresholding_Stream_Batch(hls::stream<TI> &in,
   // alternatively: number of vertical matrix chunks
   unsigned const NF = NumChannels / PE;
 
-  ThresholdsActivation<1, PE, NumSteps, TT, TO, ActVal> internal_thr;
+  ThresholdsActivation<1, PE, NumSteps, TT, TO, ActVal, std::less_equal<TT>> internal_thr;
   #pragma HLS ARRAY_PARTITION variable=internal_thr.m_thresholds complete dim=0
 
   // everything merged into a common iteration space (one "big" loop instead

--- a/src/finn/custom_op/fpgadataflow/templates.py
+++ b/src/finn/custom_op/fpgadataflow/templates.py
@@ -371,9 +371,6 @@ void Thresholding_Stream_Batch(hls::stream<TI> &in,
   // alternatively: number of vertical matrix chunks
   unsigned const NF = NumChannels / PE;
 
-  unsigned nf = 0;
-  unsigned tile = 0; // invariant: tile = nf*SF + sf
-
   ThresholdsActivation<1, PE, NumSteps, TT, TO, ActVal> internal_thr;
   #pragma HLS ARRAY_PARTITION variable=internal_thr.m_thresholds complete dim=0
 
@@ -399,6 +396,7 @@ void Thresholding_Stream_Batch(hls::stream<TI> &in,
       auto const thr_slicer = Slice<TT>()(pe_slicer(pe, 0));
       for (unsigned nt = 0; nt < NumSteps; nt++)
       {
+      #pragma HLS UNROLL
         internal_thr.m_thresholds[pe][0][nt] = thr_slicer(nt, 0);
       }
 
@@ -406,10 +404,6 @@ void Thresholding_Stream_Batch(hls::stream<TI> &in,
       outElem(pe,0,1) = internal_thr.activate(0, pe, act(pe,0));
     }
     out.write(outElem);
-    if (++nf == NF)
-    {
-      nf = 0;
-    }
   }
 }
 """

--- a/src/finn/custom_op/fpgadataflow/thresholding_batch.py
+++ b/src/finn/custom_op/fpgadataflow/thresholding_batch.py
@@ -407,8 +407,14 @@ class Thresholding_Batch(HLSCustomOp):
             # (1, tmem, pe, n_thres_steps) -(1, tmem, pe * n_thres_steps)
             pe = self.get_nodeattr("PE")
             n_thres_steps = self.get_nodeattr("numSteps")
+            decoupled_thres_pe_flipped = np.flip(decoupled_thres, axis=-2)
             decoupled_thres = decoupled_thres.reshape(1, -1, pe * n_thres_steps)
             decoupled_thres = decoupled_thres.copy()
+            decoupled_thres_pe_flipped = decoupled_thres_pe_flipped.reshape(
+                1, -1, pe * n_thres_steps
+            )
+            decoupled_thres_pe_flipped = decoupled_thres_pe_flipped.copy()
+
             if weight_file_mode == "decoupled_npy":
                 # save weight stream into npy for cppsim
                 np.save(weight_file_name, decoupled_thres)
@@ -418,7 +424,7 @@ class Thresholding_Batch(HLSCustomOp):
                 # pad to nearest 4 bits to get hex strings
                 weight_width_padded = roundup_to_integer_multiple(weight_width, 4)
                 weight_tensor_pe_flipped = pack_innermost_dim_as_hex_string(
-                    decoupled_thres, tdt, weight_width_padded, prefix=""
+                    decoupled_thres_pe_flipped, tdt, weight_width_padded, prefix=""
                 )
                 weight_stream = weight_tensor_pe_flipped.flatten()
                 weight_stream = weight_stream.copy()
@@ -435,7 +441,7 @@ class Thresholding_Batch(HLSCustomOp):
                 weight_width_padded = words_per_memwidth * 32
                 # first, pack and ensure padding to 32 bits
                 weight_tensor_pe_flipped = pack_innermost_dim_as_hex_string(
-                    decoupled_thres, tdt, weight_width_padded, prefix=""
+                    decoupled_thres_pe_flipped, tdt, weight_width_padded, prefix=""
                 )
                 weight_stream = weight_tensor_pe_flipped.flatten()
                 weight_stream = weight_stream.copy()

--- a/src/finn/custom_op/fpgadataflow/thresholding_batch.py
+++ b/src/finn/custom_op/fpgadataflow/thresholding_batch.py
@@ -75,6 +75,10 @@ class Thresholding_Batch(HLSCustomOp):
             "numInputVectors": ("ints", False, [1]),
             # initialization value for the thresholding accumulator
             "ActVal": ("i", False, 0),
+            # memory mode for the thresholds
+            # const -- embedded thresholds, default
+            # decoupled -- streaming thresholds with  streamer packaged inside IP
+            "mem_mode": ("s", False, "const"),
         }
         my_attrs.update(super().get_nodeattr_types())
         return my_attrs
@@ -190,6 +194,11 @@ class Thresholding_Batch(HLSCustomOp):
     def get_outstream_width(self):
         o_bits = self.get_output_datatype().bitwidth()
         return o_bits * self.get_nodeattr("PE")
+
+    def get_ap_int_max_w(self):
+        temp_value = super().get_ap_int_max_w()
+        weightstream = self.get_weightstream_width()
+        return max([weightstream, temp_value])
 
     def get_folded_input_shape(self):
         ich = self.get_nodeattr("NumChannels")

--- a/src/finn/custom_op/fpgadataflow/thresholding_batch.py
+++ b/src/finn/custom_op/fpgadataflow/thresholding_batch.py
@@ -433,12 +433,11 @@ class Thresholding_Batch(HLSCustomOp):
             # save decoupled weights for cppsim
             weight_filename_sim = "{}/thresholds.npy".format(code_gen_dir)
             self.make_weight_file(thresholds, "decoupled_npy", weight_filename_sim)
-            if mem_mode == "decoupled":
-                # also save weights as Verilog .dat file
-                weight_filename_rtl = "{}/memblock_0.dat".format(code_gen_dir)
-                self.make_weight_file(
-                    thresholds, "decoupled_verilog_dat", weight_filename_rtl
-                )
+            # also save weights as Verilog .dat file
+            weight_filename_rtl = "{}/memblock_0.dat".format(code_gen_dir)
+            self.make_weight_file(
+                thresholds, "decoupled_verilog_dat", weight_filename_rtl
+            )
         else:
             raise Exception("Unrecognized mem_mode")
 

--- a/src/finn/transformation/fpgadataflow/convert_to_hls_layers.py
+++ b/src/finn/transformation/fpgadataflow/convert_to_hls_layers.py
@@ -841,7 +841,9 @@ class InferThresholdingLayer(Transformation):
                     backend="fpgadataflow",
                     NumChannels=ifc,
                     PE=pe,
+                    numSteps=thl_threshold.shape[1],
                     inputDataType=idt.name,
+                    weightDataType=idt.name,  # will be set by MinimizeAccumulatorWidth
                     outputDataType=odt.name,
                     numInputVectors=list(thl_in_shape[:-1]),
                     ActVal=actval,
@@ -852,6 +854,7 @@ class InferThresholdingLayer(Transformation):
                 graph_modified = True
 
         if graph_modified:
+            model = model.transform(MinimizeAccumulatorWidth())
             model = model.transform(InferShapes())
             model = model.transform(InferDataTypes())
         return (model, graph_modified)

--- a/src/finn/transformation/fpgadataflow/convert_to_hls_layers.py
+++ b/src/finn/transformation/fpgadataflow/convert_to_hls_layers.py
@@ -780,6 +780,10 @@ class InferVVAU(Transformation):
 class InferThresholdingLayer(Transformation):
     """Convert any MultiThreshold into a standalone thresholding HLS layer."""
 
+    def __init__(self, mem_mode="const"):
+        super().__init__()
+        self.mem_mode = mem_mode
+
     def apply(self, model):
         graph = model.graph
         node_ind = 0
@@ -847,6 +851,7 @@ class InferThresholdingLayer(Transformation):
                     outputDataType=odt.name,
                     numInputVectors=list(thl_in_shape[:-1]),
                     ActVal=actval,
+                    mem_mode=self.mem_mode,
                 )
                 graph.node.insert(insert_point, new_node)
                 # remove old node

--- a/src/finn/transformation/fpgadataflow/convert_to_hls_layers.py
+++ b/src/finn/transformation/fpgadataflow/convert_to_hls_layers.py
@@ -795,6 +795,7 @@ class InferThresholdingLayer(Transformation):
                 thl_threshold = node.input[1]
                 thl_output = node.output[0]
                 thl_in_shape = model.get_tensor_shape(thl_input)
+                thl_thres_shape = model.get_tensor_shape(thl_threshold)
                 idt = model.get_tensor_datatype(thl_input)
 
                 # skip conversion for layers with float input
@@ -845,7 +846,7 @@ class InferThresholdingLayer(Transformation):
                     backend="fpgadataflow",
                     NumChannels=ifc,
                     PE=pe,
-                    numSteps=thl_threshold.shape[1],
+                    numSteps=thl_thres_shape[1],
                     inputDataType=idt.name,
                     weightDataType=idt.name,  # will be set by MinimizeAccumulatorWidth
                     outputDataType=odt.name,

--- a/tests/fpgadataflow/test_fpgadataflow_thresholding.py
+++ b/tests/fpgadataflow/test_fpgadataflow_thresholding.py
@@ -46,6 +46,13 @@ from finn.transformation.fpgadataflow.prepare_rtlsim import PrepareRTLSim
 from finn.util.basic import gen_finn_dt_tensor
 from finn.custom_op.registry import getCustomOp
 from finn.analysis.fpgadataflow.exp_cycles_per_layer import exp_cycles_per_layer
+import os
+from finn.util.pyverilator import axilite_read
+from finn.transformation.fpgadataflow.create_stitched_ip import CreateStitchedIP
+from finn.core.rtlsim_exec import rtlsim_exec
+
+test_fpga_part = "xc7z020clg400-1"
+target_clk_ns = 5
 
 
 def make_single_thresholding_modelwrapper(T, pe, idt, odt, actval, mem_mode):
@@ -132,7 +139,7 @@ def test_fpgadataflow_thresholding(idt, act, nf, ich, exec_mode, mem_mode):
     elif exec_mode == "rtlsim":
         model = model.transform(SetExecMode("rtlsim"))
         model = model.transform(GiveUniqueNodeNames())
-        model = model.transform(PrepareIP("xc7z020clg400-1", 5))
+        model = model.transform(PrepareIP(test_fpga_part, target_clk_ns))
         model = model.transform(HLSSynthIP())
         model = model.transform(PrepareRTLSim())
     else:
@@ -169,3 +176,73 @@ def test_fpgadataflow_thresholding(idt, act, nf, ich, exec_mode, mem_mode):
         exp_cycles = exp_cycles_dict[node.name]
         assert np.isclose(exp_cycles, cycles_rtlsim, atol=10)
         assert exp_cycles != 0
+
+
+@pytest.mark.vivado
+def test_runtime_thresholds_single_layer():
+    mem_mode = "decoupled"
+    act = DataType.UINT2
+    idt = DataType.UINT8
+    nf = 2
+    ich = 16
+    pe = ich // nf
+    assert ich % pe == 0
+
+    # generate input data
+    in_tensor = gen_finn_dt_tensor(idt, (1, ich))
+
+    odt = act
+    n_steps = act.get_num_possible_values() - 1
+    T = np.random.randint(idt.min(), idt.max() + 1, (ich, n_steps)).astype(np.float32)
+    # provide non-decreasing thresholds
+    T = np.sort(T, axis=1)
+
+    if odt == DataType.BIPOLAR:
+        actval = 0
+    else:
+        actval = odt.min()
+
+    model = make_single_thresholding_modelwrapper(T, pe, idt, odt, actval, mem_mode)
+    op_inst = getCustomOp(model.graph.node[0])
+    op_inst.set_nodeattr("runtime_writeable_weights", 1)
+    op_inst.make_weight_file(T, "decoupled_runtime", "old_weights.dat")
+    with open("old_weights.dat", "r") as f:
+        old_weight_stream = f.read().strip()
+    os.remove("old_weights.dat")
+    old_weight_stream = map(lambda x: int(x, 16), old_weight_stream.split("\n"))
+    old_weight_stream = list(old_weight_stream)
+    # need to create stitched IP for runtime weight testing
+    model = model.transform(GiveUniqueNodeNames())
+    model = model.transform(PrepareIP(test_fpga_part, target_clk_ns))
+    model = model.transform(HLSSynthIP())
+    model = model.transform(CreateStitchedIP(test_fpga_part, target_clk_ns))
+    model = model.transform(PrepareRTLSim())
+    model.set_metadata_prop("exec_mode", "rtlsim")
+    # add two copies of the input tensor as the first one is just used to
+    # "flush out" the pipeline (as mvau already starts receiving old weights while
+    # we read/write new ones and reads seem to cause a disturbance too)
+    in_tensor = np.tile(in_tensor, (2, 1))
+    exec_ctx = {"inp": in_tensor}
+    extracted_weight_stream = []
+
+    def read_weights(sim):
+        addr = 0
+        for i in range(len(old_weight_stream)):
+            extracted_weight_stream.append(
+                axilite_read(sim, addr, basename="s_axilite_0_")
+            )
+            addr += 4
+
+    rtlsim_exec(model, exec_ctx, pre_hook=read_weights)
+    assert extracted_weight_stream == old_weight_stream
+    y = exec_ctx["outp"]
+    # only use second batch element in output; first will be invalid due to
+    # old weights (see above)
+    expected = multithreshold(in_tensor, T)[1]
+    if act == DataType.BIPOLAR:
+        # binary to bipolar
+        expected = 2 * expected - 1
+    else:
+        # signed offset
+        expected += act.min()
+    assert (y[1] == expected).all()

--- a/tests/fpgadataflow/test_fpgadataflow_thresholding.py
+++ b/tests/fpgadataflow/test_fpgadataflow_thresholding.py
@@ -181,9 +181,9 @@ def test_fpgadataflow_thresholding(idt, act, nf, ich, exec_mode, mem_mode):
 @pytest.mark.vivado
 def test_runtime_thresholds_single_layer():
     mem_mode = "decoupled"
-    act = DataType.UINT2
-    idt = DataType.UINT8
-    nf = 2
+    act = DataType.INT4
+    idt = DataType.INT16
+    nf = 8
     ich = 16
     pe = ich // nf
     assert ich % pe == 0
@@ -235,9 +235,9 @@ def test_runtime_thresholds_single_layer():
 
     rtlsim_exec(model, exec_ctx, pre_hook=read_weights)
     assert extracted_weight_stream == old_weight_stream
-    y = exec_ctx["outp"]
     # only use second batch element in output; first will be invalid due to
     # old weights (see above)
+    y = exec_ctx["outp"][1]
     expected = multithreshold(in_tensor, T)[1]
     if act == DataType.BIPOLAR:
         # binary to bipolar
@@ -245,4 +245,4 @@ def test_runtime_thresholds_single_layer():
     else:
         # signed offset
         expected += act.min()
-    assert (y[1] == expected).all()
+    assert (y == expected).all()

--- a/tests/fpgadataflow/test_fpgadataflow_thresholding.py
+++ b/tests/fpgadataflow/test_fpgadataflow_thresholding.py
@@ -64,7 +64,9 @@ def make_single_thresholding_modelwrapper(T, pe, idt, odt, actval):
         backend="fpgadataflow",
         NumChannels=NumChannels,
         PE=pe,
+        numSteps=T.shape[1],
         inputDataType=idt.name,
+        weightDataType=idt.name,  # will be set by MinimizeAccumulatorWidth
         outputDataType=odt.name,
         ActVal=actval,
     )


### PR DESCRIPTION
Introduce a decoupled variant of the standalone thresholding layer, using the same `memstream` component as the decoupled `StreamingFCLayer` to separte compute and memory. Supports runtime-writable thresholds.