### PR TITLE
Future-proofing pypi/pip installability

### DIFF
--- a/docker/Dockerfile.finn_ci
+++ b/docker/Dockerfile.finn_ci
@@ -36,8 +36,8 @@ WORKDIR /workspace
 RUN apt-get update
 RUN apt-get -y upgrade
 RUN apt-get install -y build-essential libglib2.0-0 libsm6 libxext6 libxrender-dev
-RUN apt-get install -y verilator zsh
-RUN apt-get -y install sshpass wget unzip
+RUN apt-get install -y verilator zsh nano
+RUN apt-get install -y sshpass wget unzip
 RUN echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config
 
 # XRT deps
@@ -63,14 +63,11 @@ RUN git clone https://bitbucket.org/maltanar/oh-my-xilinx.git /workspace/oh-my-x
 COPY requirements.txt .
 RUN pip install -r requirements.txt
 RUN rm requirements.txt
-RUN apt update; apt install nano
 RUN pip install pytest-dependency
 RUN pip install pytest-xdist
 RUN pip install pytest-parallel
 RUN pip install -e git+https://github.com/fbcotter/dataset_loading.git@0.0.4#egg=dataset_loading
 
-ENV PYTHONPATH "${PYTHONPATH}:/workspace/finn/src"
-ENV PYTHONPATH "${PYTHONPATH}:/workspace/pyverilator"
 ENV VIVADO_IP_CACHE "$BUILD_PATH/vivado_ip_cache"
 ENV PATH "${PATH}:/workspace/oh-my-xilinx"
 ENV OHMYXILINX "/workspace/oh-my-xilinx"

--- a/docker/Dockerfile.finn_dev
+++ b/docker/Dockerfile.finn_dev
@@ -34,8 +34,6 @@ ARG GNAME
 ARG UNAME
 ARG UID
 ARG PASSWD
-ARG JUPYTER_PORT
-ARG NETRON_PORT
 
 WORKDIR /workspace
 
@@ -86,8 +84,6 @@ RUN git clone https://bitbucket.org/maltanar/oh-my-xilinx.git /workspace/oh-my-x
 
 # for this developer-oriented Docker container we assume the FINN repo is cloned and mounted from the host
 # at /workspace/finn -- see run-docker.sh for an example of how to do this.
-ENV PYTHONPATH "${PYTHONPATH}:/workspace/finn/src"
-ENV PYTHONPATH "${PYTHONPATH}:/workspace/pyverilator"
 ENV PATH "${PATH}:/workspace/oh-my-xilinx:/home/$UNAME/.local/bin"
 ENV OHMYXILINX "/workspace/oh-my-xilinx"
 
@@ -102,9 +98,6 @@ COPY docker/quicktest.sh /usr/local/bin/
 RUN chmod 755 /usr/local/bin/finn_entrypoint.sh
 RUN chmod 755 /usr/local/bin/quicktest.sh
 USER $UNAME
-
-EXPOSE $JUPYTER_PORT
-EXPOSE $NETRON_PORT
 
 ENTRYPOINT ["finn_entrypoint.sh"]
 CMD ["bash"]

--- a/docker/finn_entrypoint.sh
+++ b/docker/finn_entrypoint.sh
@@ -46,7 +46,8 @@ git -C /workspace/pyverilator checkout $PYVERILATOR_COMMIT --quiet
 gecho "oh-my-xilinx @ $OMX_COMMIT"
 git -C /workspace/oh-my-xilinx pull --quiet
 git -C /workspace/oh-my-xilinx checkout $OMX_COMMIT --quiet
-# run pip install for finn
+# cleanup and run pip install for finn
+python $FINN_ROOT/setup.py clean --dist --eggs
 pip install --user -e $FINN_ROOT
 
 if [ ! -z "$VIVADO_PATH" ];then

--- a/docker/finn_entrypoint.sh
+++ b/docker/finn_entrypoint.sh
@@ -12,8 +12,8 @@ gecho () {
 
 # checkout the correct dependency repo commits
 # the repos themselves are cloned in the Dockerfile
-FINN_BASE_COMMIT=3c379063610f7b9add083c1b73fb087fa1dc166b
-BREVITAS_COMMIT=b75e0408d9759ed519296e3af29b9c16fb94b0b8
+FINN_BASE_COMMIT=f3569f7e809de39af68851c049cfa90291e29f96
+BREVITAS_COMMIT=aff49758ec445d77c75721c7de3091a2a1797ca8
 CNPY_COMMIT=4e8810b1a8637695171ed346ce68f6984e585ef4
 HLSLIB_COMMIT=cfafe11a93b79ab1af7529d68f08886913a6466e
 PYVERILATOR_COMMIT=06c29ecf3ba0361e3d0a75c98f6918ba67bf0e27
@@ -46,6 +46,8 @@ git -C /workspace/pyverilator checkout $PYVERILATOR_COMMIT --quiet
 gecho "oh-my-xilinx @ $OMX_COMMIT"
 git -C /workspace/oh-my-xilinx pull --quiet
 git -C /workspace/oh-my-xilinx checkout $OMX_COMMIT --quiet
+# run pip install for finn
+pip install --user -e $FINN_ROOT
 
 if [ ! -z "$VIVADO_PATH" ];then
   # source Vivado env.vars

--- a/docker/finn_entrypoint.sh
+++ b/docker/finn_entrypoint.sh
@@ -42,6 +42,7 @@ git -C /workspace/finn-hlslib checkout $HLSLIB_COMMIT --quiet
 gecho "PyVerilator @ $PYVERILATOR_COMMIT"
 git -C /workspace/pyverilator pull --quiet
 git -C /workspace/pyverilator checkout $PYVERILATOR_COMMIT --quiet
+pip install --user -e /workspace/pyverilator
 # oh-my-xilinx
 gecho "oh-my-xilinx @ $OMX_COMMIT"
 git -C /workspace/oh-my-xilinx pull --quiet

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ onnx==1.7.0
 onnxruntime==1.4.0
 pre-commit==2.6.0
 scipy==1.5.2
+setupext-janitor>=1.1.2
 toposort==1.5
 vcdvcd==1.0.5
 wget==3.2

--- a/run-docker.sh
+++ b/run-docker.sh
@@ -138,8 +138,6 @@ docker build -f docker/Dockerfile.finn_dev --tag=$DOCKER_TAG \
              --build-arg UNAME=$DOCKER_UNAME \
              --build-arg UID=$DOCKER_UID \
              --build-arg PASSWD=$DOCKER_PASSWD \
-             --build-arg JUPYTER_PORT=$JUPYTER_PORT \
-             --build-arg NETRON_PORT=$NETRON_PORT \
              .
 # Launch container with current directory mounted
 # important to pass the --init flag here for correct Vivado operation, see:
@@ -159,6 +157,8 @@ DOCKER_EXEC+="-e PYNQ_USERNAME=$PYNQ_USERNAME "
 DOCKER_EXEC+="-e PYNQ_PASSWORD=$PYNQ_PASSWORD "
 DOCKER_EXEC+="-e PYNQ_TARGET_DIR=$PYNQ_TARGET_DIR "
 DOCKER_EXEC+="-e NUM_DEFAULT_WORKERS=$NUM_DEFAULT_WORKERS "
+DOCKER_EXEC+="-e JUPYTER_PORT=$JUPYTER_PORT "
+DOCKER_EXEC+="-e NETRON_PORT=$NETRON_PORT "
 DOCKER_EXEC+="-p $JUPYTER_PORT:$JUPYTER_PORT "
 DOCKER_EXEC+="-p $NETRON_PORT:$NETRON_PORT "
 if [ ! -z "$VIVADO_PATH" ];then

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,8 +36,8 @@ description = A Framework for Fast, Scalable Quantized Neural Network Inference
 author = Yaman Umuroglu
 author-email = yamanu@xilinx.com
 license = new-bsd
-long-description = file: README.rst
-long-description-content-type = text/x-rst; charset=UTF-8
+long-description = file: README.md
+long-description-content-type = text/markdown
 url = https://xilinx.github.io/finn/
 project-urls =
     Documentation = https://finn.readthedocs.io/
@@ -48,6 +48,7 @@ platforms = any
 classifiers =
     Development Status :: 4 - Beta
     Programming Language :: Python
+    Operating System :: POSIX :: Linux
 
 [options]
 zip_safe = False


### PR DESCRIPTION
`finn-base` is available through PyPI and pip-installable, and the intention is to do the same for this repository one day. This PR sets up `setup.cfg` and dependency handling in a slightly better way for the future.