### PR TITLE
Partition input vivado DWC bugfix

### DIFF
--- a/src/finn/custom_op/fpgadataflow/streamingdatawidthconverter_batch.py
+++ b/src/finn/custom_op/fpgadataflow/streamingdatawidthconverter_batch.py
@@ -408,8 +408,13 @@ class StreamingDataWidthConverter_Batch(HLSCustomOp):
             )
             cmd.append(
                 "set_property -dict "
-                "[list CONFIG.S_TDATA_NUM_BYTES.VALUE_SRC PROPAGATED] "
+                "[list CONFIG.S_TDATA_NUM_BYTES.VALUE_SRC USER] "
                 "[get_bd_cells /%s/dwc]" % node_name
+            )
+            cmd.append(
+                "set_property -dict "
+                "[list CONFIG.S_TDATA_NUM_BYTES {%d}] [get_bd_cells /%s/dwc]"
+                % (np.ceil(self.get_instream_width() / 8), node_name)
             )
             cmd.append(
                 "set_property -dict "


### PR DESCRIPTION
# Problem
Partitions are assembled in bd. If the input of a bd is a vivado lib datawidth converted and its parameter `CONFIG.S_TDATA_NUM_BYTES.VALUE_SRC`  is set to `PROPAGATED`, the actual input width information is lost and the partition assumes an input width of 1 byte which probably will cause a bottleneck.

# Solution
Set vivado DWC input width explicitly