### PR TITLE
Separate HLS codegen and ipgen steps

### DIFF
--- a/docs/finn/command_line.rst
+++ b/docs/finn/command_line.rst
@@ -62,21 +62,22 @@ as it go through numerous steps:
   Building dataflow accelerator from /home/maltanar/sandbox/build_dataflow/model.onnx
   Outputs will be generated at output_tfc_w1a1_Pynq-Z1
   Build log is at output_tfc_w1a1_Pynq-Z1/build_dataflow.log
-  Running step: step_tidy_up [1/15]
-  Running step: step_streamline [2/15]
-  Running step: step_convert_to_hls [3/15]
-  Running step: step_create_dataflow_partition [4/15]
-  Running step: step_target_fps_parallelization [5/15]
-  Running step: step_apply_folding_config [6/15]
-  Running step: step_generate_estimate_reports [7/15]
-  Running step: step_hls_ipgen [8/15]
-  Running step: step_set_fifo_depths [9/15]
-  Running step: step_create_stitched_ip [10/15]
-  Running step: step_measure_rtlsim_performance [11/15]
-  Running step: step_make_pynq_driver [12/15]
-  Running step: step_out_of_context_synthesis [13/15]
-  Running step: step_synthesize_bitfile [14/15]
-  Running step: step_deployment_package [15/15]
+  Running step: step_tidy_up [1/16]
+  Running step: step_streamline [2/16]
+  Running step: step_convert_to_hls [3/16]
+  Running step: step_create_dataflow_partition [4/16]
+  Running step: step_target_fps_parallelization [5/16]
+  Running step: step_apply_folding_config [6/16]
+  Running step: step_generate_estimate_reports [7/16]
+  Running step: step_hls_codegen [8/16]
+  Running step: step_hls_ipgen [9/16]
+  Running step: step_set_fifo_depths [10/16]
+  Running step: step_create_stitched_ip [11/16]
+  Running step: step_measure_rtlsim_performance [12/16]
+  Running step: step_make_pynq_driver [13/16]
+  Running step: step_out_of_context_synthesis [14/16]
+  Running step: step_synthesize_bitfile [15/16]
+  Running step: step_deployment_package [16/16]
 
 
 You can read a brief description of what each step does on

--- a/src/finn/builder/build_dataflow_config.py
+++ b/src/finn/builder/build_dataflow_config.py
@@ -109,6 +109,7 @@ default_build_dataflow_steps = [
     "step_target_fps_parallelization",
     "step_apply_folding_config",
     "step_generate_estimate_reports",
+    "step_hls_codegen",
     "step_hls_ipgen",
     "step_set_fifo_depths",
     "step_create_stitched_ip",
@@ -129,6 +130,10 @@ estimate_only_dataflow_steps = [
     "step_apply_folding_config",
     "step_generate_estimate_reports",
 ]
+
+#: List of steps to run for a dataflow build including HLS code generation, but
+#: without any synthesis.
+hls_codegen_dataflow_steps = estimate_only_dataflow_steps + ["step_hls_codegen"]
 
 
 @dataclass_json

--- a/src/finn/builder/build_dataflow_steps.py
+++ b/src/finn/builder/build_dataflow_steps.py
@@ -292,12 +292,19 @@ def step_generate_estimate_reports(model: ModelWrapper, cfg: DataflowBuildConfig
     return model
 
 
-def step_hls_ipgen(model: ModelWrapper, cfg: DataflowBuildConfig):
-    "Run Vivado HLS synthesis on any HLSCustomOp nodes to generate IP blocks."
+def step_hls_codegen(model: ModelWrapper, cfg: DataflowBuildConfig):
+    "Generate Vivado HLS code to prepare HLSCustomOp nodes for IP generation."
 
     model = model.transform(
         PrepareIP(cfg._resolve_fpga_part(), cfg._resolve_hls_clk_period())
     )
+    return model
+
+
+def step_hls_ipgen(model: ModelWrapper, cfg: DataflowBuildConfig):
+    """Run Vivado HLS synthesis on generated code for HLSCustomOp nodes,
+    in order to generate IP blocks."""
+
     model = model.transform(HLSSynthIP())
     model = model.transform(ReplaceVerilogRelPaths())
     report_dir = cfg.output_dir + "/report"
@@ -543,6 +550,7 @@ build_dataflow_step_lookup = {
     "step_target_fps_parallelization": step_target_fps_parallelization,
     "step_apply_folding_config": step_apply_folding_config,
     "step_generate_estimate_reports": step_generate_estimate_reports,
+    "step_hls_codegen": step_hls_codegen,
     "step_hls_ipgen": step_hls_ipgen,
     "step_set_fifo_depths": step_set_fifo_depths,
     "step_create_stitched_ip": step_create_stitched_ip,


### PR DESCRIPTION
For `build_dataflow`, seperate out the HLS code generation and IP synthesis as two different steps. This allows running the build flow to target HLS code generation only without any synthesis, in a way this is the "last exit before toll" for large or highly-unfolded networks where even HLS IP gen takes a long time.