### PR TITLE
Fix ZCU102 support in Vivado shell project

### DIFF
--- a/src/finn/transformation/fpgadataflow/templates.py
+++ b/src/finn/transformation/fpgadataflow/templates.py
@@ -111,6 +111,9 @@ set_param board.repoPaths $paths_param
 if {$BOARD == "ZCU104"} {
     set_property board_part xilinx.com:zcu104:part0:1.1 [current_project]
     set ZYNQ_TYPE "zynq_us+"
+} elseif {$BOARD == "ZCU102"} {
+    set_property board_part xilinx.com:zcu102:part0:3.3 [current_project]
+    set ZYNQ_TYPE "zynq_us+"
 } elseif {$BOARD == "Ultra96"} {
     set_property board_part em.avnet.com:ultra96v1:part0:1.2 [current_project]
     set ZYNQ_TYPE "zynq_us+"


### PR DESCRIPTION
The ZCU102 board is officially supported, but the board part setting was missing in the respective Tcl script template.