### PR TITLE
[absorb]: used find_consumers instead of find_consumer

### DIFF
--- a/src/finn/transformation/streamline/absorb.py
+++ b/src/finn/transformation/streamline/absorb.py
@@ -323,7 +323,7 @@ class AbsorbTransposeIntoMultiThreshold(Transformation):
                     mt_cand = model.find_consumers(n.output[0])
                     try:
                         mt_cand = mt_cand[0]
-                    except ValueError:
+                    except TypeError:
                         continue
                     if mt_cand.op_type == "MultiThreshold" and not model.is_fork_node(
                         mt_cand
@@ -331,7 +331,7 @@ class AbsorbTransposeIntoMultiThreshold(Transformation):
                         final_t_cand = model.find_consumers(mt_cand.output[0])
                         try:
                             final_t_cand = final_t_cand[0]
-                        except ValueError:
+                        except TypeError:
                             continue
                         if final_t_cand.op_type == "Transpose":
                             perms = list(

--- a/src/finn/transformation/streamline/absorb.py
+++ b/src/finn/transformation/streamline/absorb.py
@@ -320,11 +320,19 @@ class AbsorbTransposeIntoMultiThreshold(Transformation):
             if n.op_type == "Transpose" and not model.is_fork_node(n):
                 perms = list(get_by_name(n.attribute, "perm").ints)
                 if perms == [0, 3, 1, 2]:
-                    mt_cand = model.find_consumer(n.output[0])
+                    mt_cand = model.find_consumers(n.output[0])
+                    try:
+                        mt_cand = mt_cand[0]
+                    except ValueError:
+                        continue
                     if mt_cand.op_type == "MultiThreshold" and not model.is_fork_node(
                         mt_cand
                     ):
-                        final_t_cand = model.find_consumer(mt_cand.output[0])
+                        final_t_cand = model.find_consumers(mt_cand.output[0])
+                        try:
+                            final_t_cand = final_t_cand[0]
+                        except ValueError:
+                            continue
                         if final_t_cand.op_type == "Transpose":
                             perms = list(
                                 get_by_name(final_t_cand.attribute, "perm").ints


### PR DESCRIPTION
Used find_consumers instead of find_consumer. For non-linear graphs, we must take into account that the output of a node can be linked to the second input of the successive node (e.g. when the successive node is a 'join-node').