### PR TITLE
Install XRT from .deb

### DIFF
--- a/docker/Dockerfile.finn_ci
+++ b/docker/Dockerfile.finn_ci
@@ -55,10 +55,9 @@ RUN apt-get install -y zip
 RUN echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config
 
 # XRT deps
-RUN wget https://raw.githubusercontent.com/Xilinx/XRT/master/src/runtime_src/tools/scripts/xrtdeps.sh
-RUN apt-get update
-RUN bash xrtdeps.sh -docker
-RUN rm xrtdeps.sh
+ARG XRT_DEB_VERSION="xrt_202010.2.7.766_18.04-amd64-xrt"
+RUN wget https://www.xilinx.com/bin/public/openDownload?filename=$XRT_DEB_VERSION.deb -O /tmp/$XRT_DEB_VERSION.deb
+RUN apt install -y /tmp/$XRT_DEB_VERSION.deb
 
 # cloning dependency repos
 # finn-base

--- a/docker/Dockerfile.finn_ci
+++ b/docker/Dockerfile.finn_ci
@@ -55,9 +55,16 @@ RUN apt-get install -y zip
 RUN echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config
 
 # XRT deps
+# install vitis deps if required
+ARG INSTALL_XRT_DEPS="0"
 ARG XRT_DEB_VERSION="xrt_202010.2.7.766_18.04-amd64-xrt"
-RUN wget https://www.xilinx.com/bin/public/openDownload?filename=$XRT_DEB_VERSION.deb -O /tmp/$XRT_DEB_VERSION.deb
-RUN apt install -y /tmp/$XRT_DEB_VERSION.deb
+RUN if [ "$INSTALL_XRT_DEPS" = "1" ] ; then \
+    echo "Installing XRT: $XRT_DEB_VERSION"; \
+    wget https://www.xilinx.com/bin/public/openDownload?filename=$XRT_DEB_VERSION.deb -O /tmp/$XRT_DEB_VERSION.deb; \
+    apt install -y /tmp/$XRT_DEB_VERSION.deb; \
+  else \
+    echo "Skipping installation of XRT dependencies"; \
+  fi
 
 # cloning dependency repos
 # finn-base

--- a/docker/Dockerfile.finn_dev
+++ b/docker/Dockerfile.finn_dev
@@ -122,12 +122,11 @@ RUN chmod 755 /usr/local/bin/finn_entrypoint.sh
 RUN chmod 755 /usr/local/bin/quicktest.sh
 # install vitis deps if required
 ARG INSTALL_XRT_DEPS
+ARG XRT_DEB_VERSION
 RUN if [ "$INSTALL_XRT_DEPS" = "1" ] ; then \
-    echo "Installing XRT dependencies"; \
-    wget https://raw.githubusercontent.com/Xilinx/XRT/master/src/runtime_src/tools/scripts/xrtdeps.sh; \
-    apt-get update; \
-    bash xrtdeps.sh -docker; \
-    rm xrtdeps.sh; \
+    echo "Installing XRT: $XRT_DEB_VERSION"; \
+    wget https://www.xilinx.com/bin/public/openDownload?filename=$XRT_DEB_VERSION.deb -O /tmp/$XRT_DEB_VERSION.deb; \
+    apt install -y /tmp/$XRT_DEB_VERSION.deb; \
   else \
     echo "Skipping installation of XRT dependencies"; \
   fi

--- a/docker/finn_entrypoint.sh
+++ b/docker/finn_entrypoint.sh
@@ -4,10 +4,15 @@ export SHELL=/bin/bash
 export FINN_ROOT=/workspace/finn
 
 GREEN='\033[0;32m'
+RED='\033[0;31m'
 NC='\033[0m' # No Color
 
 gecho () {
   echo -e "${GREEN}$1${NC}"
+}
+
+recho () {
+  echo -e "${RED}ERROR: $1${NC}"
 }
 
 # checkout the correct dependency repo commits
@@ -92,10 +97,13 @@ fi
 if [ ! -z "$VITIS_PATH" ];then
   # source Vitis env.vars
   export XILINX_VITIS=$VITIS_PATH
+  export XILINX_XRT=/opt/xilinx/xrt
   source $VITIS_PATH/settings64.sh
   if [ ! -z "$XILINX_XRT" ];then
     # source XRT
     source $XILINX_XRT/setup.sh
+  else
+    recho "XRT not found on $XILINX_XRT, did the installation fail?"
   fi
 fi
 exec "$@"

--- a/docs/finn/getting_started.rst
+++ b/docs/finn/getting_started.rst
@@ -118,7 +118,8 @@ Prior to running the `run-docker.sh` script, there are several environment varia
 These are summarized below:
 
 * ``VIVADO_PATH`` points to your Vivado installation on the host
-* (optional, for Vitis & Alveo only) ``VITIS_PATH``, ``PLATFORM_REPO_PATHS`` and ``XILINX_XRT`` respectively point to your Vitis installation, the Vitis platform files, and Xilinx XRT
+* (optional, for Vitis & Alveo only) ``VITIS_PATH``, and ``PLATFORM_REPO_PATHS`` respectively point to your Vitis installation, and the Vitis platform files.
+* (optional, for Vitis & Alveo only) ``XRT_DEB_VERSION`` specifies the .deb to be installed for XRT inside the container (see default value in ``run-docker.sh``).
 * (optional) ``JUPYTER_PORT`` (default 8888) changes the port for Jupyter inside Docker
 * (optional) ``JUPYTER_PASSWD_HASH`` (default "") Set the Jupyter notebook password hash. If set to empty string, token authentication will be used (token printed in terminal on launch).
 * (optional) ``LOCALHOST_URL`` (default localhost) sets the base URL for accessing e.g. Netron from inside the container. Useful when running FINN remotely.
@@ -162,7 +163,7 @@ We use *host* to refer to the PC running the FINN Docker environment, which will
 
 On the target side:
 
-1. Install Xilinx XRT and set up the ``XILINX_XRT`` environment variable to point to your installation, for instance ``/opt/xilinx/xrt``.
+1. Install Xilinx XRT.
 2. Install the Vitis platform files for Alveo and set up the ``PLATFORM_REPO_PATHS`` environment variable to point to your installation, for instance ``/opt/xilinx/platforms``.
 3. Create a conda environment named *finn-pynq-alveo* by following this guide `to set up PYNQ for Alveo <https://pynq.readthedocs.io/en/latest/getting_started/alveo_getting_started.html>`_. It's best to follow the recommended environment.yml (set of package versions) in this guide.
 4. Activate the environment with `conda activate finn-pynq-alveo` and install the bitstring package with ``pip install bitstring``.
@@ -173,7 +174,7 @@ On the target side:
 On the host side:
 
 1. Install Vitis 2020.1 and set up the ``VITIS_PATH`` environment variable to point to your installation.
-2. Install Xilinx XRT and set up the ``XILINX_XRT`` environment variable to point to your installation. *This must be the same path as the target's XRT (target step 1)*
+2. Install Xilinx XRT. Ensure that the ``XRT_DEB_VERSION`` environment variable reflects which version of XRT you have installed.
 3. Install the Vitis platform files for Alveo and set up the ``PLATFORM_REPO_PATHS`` environment variable to point to your installation. *This must be the same path as the target's platform files (target step 2)*
 4. Set up the ``ALVEO_*`` environment variables accordingly for your target, see description of environment variables above.
 5. `Set up public key authentication <https://www.digitalocean.com/community/tutorials/how-to-configure-ssh-key-based-authentication-on-a-linux-server>`_. Copy your private key to the ``finn/ssh_keys`` folder on the host to get password-less deployment and remote execution.

--- a/run-docker.sh
+++ b/run-docker.sh
@@ -59,11 +59,6 @@ else
     recho "This is required to be able to use Vitis."
     exit -1
   fi
-  if [ -z "$XILINX_XRT" ];then
-    recho "Please set XILINX_XRT pointing to your XRT installation."
-    recho "This is required to be able to use Vitis."
-    exit -1
-  fi
 fi
 
 DOCKER_GID=$(id -g)
@@ -108,8 +103,8 @@ SCRIPTPATH=$(dirname "$SCRIPT")
 : ${ALVEO_PASSWORD=""}
 : ${ALVEO_BOARD="U250"}
 : ${ALVEO_TARGET_DIR="/tmp"}
-: ${XILINX_XRT="/opt/xilinx/xrt"}
 : ${PLATFORM_REPO_PATHS="/opt/xilinx/platforms"}
+: ${XRT_DEB_VERSION="xrt_202010.2.7.766_18.04-amd64-xrt"}
 : ${FINN_HOST_BUILD_DIR="/tmp/$DOCKER_INST_NAME"}
 
 DOCKER_INTERACTIVE=""
@@ -184,6 +179,7 @@ docker build -f docker/Dockerfile.finn_dev --tag=$DOCKER_TAG \
              --build-arg UID=$DOCKER_UID \
              --build-arg PASSWD=$DOCKER_PASSWD \
              --build-arg INSTALL_XRT_DEPS=$INSTALL_XRT_DEPS \
+             --build-arg XRT_DEB_VERSION=$XRT_DEB_VERSION \
              .
 cd $OLD_PWD
 # Launch container with current directory mounted
@@ -219,16 +215,10 @@ if [ ! -z "$VITIS_PATH" ];then
     recho "PLATFORM_REPO_PATHS must be set for Vitis/Alveo flows"
     exit -1
   fi
-  if [ -z "$XILINX_XRT" ];then
-    recho "XILINX_XRT must be set for Vitis/Alveo flows"
-    exit -1
-  fi
   DOCKER_EXEC+="-v $VITIS_PATH:$VITIS_PATH "
   DOCKER_EXEC+="-v $PLATFORM_REPO_PATHS:$PLATFORM_REPO_PATHS "
-  DOCKER_EXEC+="-v $XILINX_XRT:$XILINX_XRT "
   DOCKER_EXEC+="-e VITIS_PATH=$VITIS_PATH "
   DOCKER_EXEC+="-e PLATFORM_REPO_PATHS=$PLATFORM_REPO_PATHS "
-  DOCKER_EXEC+="-e XILINX_XRT=$XILINX_XRT "
   DOCKER_EXEC+="-e ALVEO_IP=$ALVEO_IP "
   DOCKER_EXEC+="-e ALVEO_USERNAME=$ALVEO_USERNAME "
   DOCKER_EXEC+="-e ALVEO_PASSWORD=$ALVEO_PASSWORD "


### PR DESCRIPTION
Use a debfile-based installation for XRT instead of sourcing directly from host system. The previous method sometimes caused issues with library dependencies.