### PR TITLE
Fixed input clock/reset port name inference during stitching

### DIFF
--- a/src/finn/transformation/fpgadataflow/create_stitched_ip.py
+++ b/src/finn/transformation/fpgadataflow/create_stitched_ip.py
@@ -120,13 +120,13 @@ class CreateStitchedIP(Transformation):
                 "make_bd_pins_external [get_bd_pins %s/%s]"
                 % (inst_name, clock_intf_name)
             )
-            self.connect_cmds.append("set_property name ap_clk [get_bd_ports ap_clk_0]")
+            self.connect_cmds.append("set_property name ap_clk [get_bd_ports %s_0]" % (clock_intf_name))
             self.connect_cmds.append(
                 "make_bd_pins_external [get_bd_pins %s/%s]"
                 % (inst_name, reset_intf_name)
             )
             self.connect_cmds.append(
-                "set_property name ap_rst_n [get_bd_ports ap_rst_n_0]"
+                "set_property name ap_rst_n [get_bd_ports %s_0]" % (reset_intf_name)
             )
             self.clock_reset_are_external = True
             self.intf_names["clk"] = ["ap_clk"]


### PR DESCRIPTION
When stitching, the BD global clock/reset input ports are produced by making external the clock/reset of the first IP in the dataflow. The stitching logic assumed that the name of those clock/reset signals on the first ip is ap_clk/ap_rst_n and if this is not the case, the stitching fails.

The fix utilizes the known port names to infer the correct BD global clock/reset names after making the ports external.