### PR TITLE
Implement IP caching

### DIFF
--- a/src/finn/custom_op/fpgadataflow/convolutioninputgenerator.py
+++ b/src/finn/custom_op/fpgadataflow/convolutioninputgenerator.py
@@ -88,6 +88,23 @@ class ConvolutionInputGenerator(HLSCustomOp):
         my_attrs.update(super().get_nodeattr_types())
         return my_attrs
 
+    def get_structural_parameters(self):
+        # node is cache-able, collect parameters influencing HLS
+        # any array of ints must be converted to tuple so the dict is hashable
+        ret = dict()
+        ret["ConvKernelDim"] = tuple(self.get_nodeattr("ConvKernelDim"))
+        ret["IFMChannels"] = self.get_nodeattr("IFMChannels")
+        ret["IFMDim"] = tuple(self.get_nodeattr("IFMDim"))
+        ret["OFMDim"] = tuple(self.get_nodeattr("OFMDim"))
+        ret["SIMD"] = self.get_nodeattr("SIMD")
+        ret["Stride"] = tuple(self.get_nodeattr("Stride"))
+        ret["Dilation"] = tuple(self.get_nodeattr("Dilation"))
+        ret["inputDataType"] = self.get_nodeattr("inputDataType")
+        ret["outputDataType"] = self.get_nodeattr("outputDataType")
+        ret["depthwise"] = self.get_nodeattr("depthwise")
+        ret["ram_style"] = self.get_nodeattr("ram_style")
+        return ret
+
     def get_nodeattr(self, name):
         # overriding get_nodeattr to check for square kernel/img.. requirement
         # since this can't be done with the attribute restriction in nodeattr_types

--- a/src/finn/custom_op/fpgadataflow/convolutioninputgenerator1d.py
+++ b/src/finn/custom_op/fpgadataflow/convolutioninputgenerator1d.py
@@ -91,6 +91,23 @@ class ConvolutionInputGenerator1D(HLSCustomOp):
         my_attrs.update(super().get_nodeattr_types())
         return my_attrs
 
+    def get_structural_parameters(self):
+        # node is cache-able, collect parameters influencing HLS
+        # any array of ints must be converted to tuple so the dict is hashable
+        ret = dict()
+        ret["ConvKernelDim"] = tuple(self.get_nodeattr("ConvKernelDim"))
+        ret["IFMChannels"] = self.get_nodeattr("IFMChannels")
+        ret["IFMDim"] = tuple(self.get_nodeattr("IFMDim"))
+        ret["OFMDim"] = tuple(self.get_nodeattr("OFMDim"))
+        ret["SIMD"] = self.get_nodeattr("SIMD")
+        ret["Stride"] = tuple(self.get_nodeattr("Stride"))
+        ret["Dilation"] = tuple(self.get_nodeattr("Dilation"))
+        ret["inputDataType"] = self.get_nodeattr("inputDataType")
+        ret["outputDataType"] = self.get_nodeattr("outputDataType")
+        ret["depthwise"] = self.get_nodeattr("depthwise")
+        ret["ram_style"] = self.get_nodeattr("ram_style")
+        return ret
+
     def get_normal_input_shape(self):
         ifm_dim_h, ifm_dim_w = self.get_nodeattr("IFMDim")
         ifm_ch = self.get_nodeattr("IFMChannels")

--- a/src/finn/custom_op/fpgadataflow/downsampler.py
+++ b/src/finn/custom_op/fpgadataflow/downsampler.py
@@ -31,6 +31,18 @@ class DownSampler(HLSCustomOp):
         my_attrs.update(super().get_nodeattr_types())
         return my_attrs
 
+    def get_structural_parameters(self):
+        # node is cache-able, collect parameters influencing HLS
+        # any array of ints must be converted to tuple so the dict is hashable
+        ret = dict()
+        ret["NumChannels"] = self.get_nodeattr("NumChannels")
+        ret["ImgDim"] = self.get_nodeattr("ImgDim")
+        ret["SIMD"] = self.get_nodeattr("SIMD")
+        ret["Stride"] = self.get_nodeattr("Stride")
+        ret["inputDataType"] = self.get_nodeattr("inputDataType")
+        ret["numInputVectors"] = tuple(self.get_nodeattr("numInputVectors"))
+        return ret
+
     def get_downsampled_odim(self):
         "Return the down sampled spatial size of the output."
         idim = self.get_nodeattr("ImgDim")

--- a/src/finn/custom_op/fpgadataflow/duplicatestreams_batch.py
+++ b/src/finn/custom_op/fpgadataflow/duplicatestreams_batch.py
@@ -57,6 +57,16 @@ class DuplicateStreams_Batch(HLSCustomOp):
         my_attrs.update(super().get_nodeattr_types())
         return my_attrs
 
+    def get_structural_parameters(self):
+        # node is cache-able, collect parameters influencing HLS
+        # any array of ints must be converted to tuple so the dict is hashable
+        ret = dict()
+        ret["NumChannels"] = self.get_nodeattr("NumChannels")
+        ret["PE"] = self.get_nodeattr("PE")
+        ret["inputDataType"] = self.get_nodeattr("inputDataType")
+        ret["numInputVectors"] = tuple(self.get_nodeattr("numInputVectors"))
+        return ret
+
     def get_normal_input_shape(self):
         ch = self.get_nodeattr("NumChannels")
         vecs = list(self.get_nodeattr("numInputVectors"))

--- a/src/finn/custom_op/fpgadataflow/hlscustomop.py
+++ b/src/finn/custom_op/fpgadataflow/hlscustomop.py
@@ -107,6 +107,16 @@ class HLSCustomOp(CustomOp):
             # ID of FPGA device to which this Op is allocated, in
             # a multi-FPGA setting
             "device_id": ("i", False, 0),
+            # IP building/caching parameters
+            # force disable IP synthesis, e.g. if this is a 
+            # node that has both HLS and RTL/Vivado implementations
+            # but the RTL/Vivado is currently active  
+            "disable_ip_synth": ("i", False, 0),
+            # we can use the key to search the IP cache for existing
+            # synthesis results either from a previous run of this node or
+            # from a run of an identical node somewhere else on the graph
+            # in case of cache miss, this node will run synth
+            "ip_cache_key": ("s", False, ""),
             # input and output FIFO depths
             "inFIFODepth": ("i", False, 2),
             "outFIFODepth": ("i", False, 2),
@@ -171,6 +181,14 @@ class HLSCustomOp(CustomOp):
                 if f.endswith(".v"):
                     verilog_files += [f]
         return verilog_files
+
+    def get_structural_parameters(self):
+        "Return dict of HLS-relevant parameters and their values"
+        return None
+
+    def set_synth_enablement(self):
+        "Set the disable_ip_synth attribute"
+        self.set_nodeattr("disable_ip_synth", 0)
 
     def prepare_rtlsim(self):
         """Creates a Verilator emulation library for the RTL code generated

--- a/src/finn/custom_op/fpgadataflow/streamingfclayer_batch.py
+++ b/src/finn/custom_op/fpgadataflow/streamingfclayer_batch.py
@@ -1406,3 +1406,27 @@ class StreamingFCLayer_Batch(HLSCustomOp):
             thres_count = out_features
             ret_dict[thres_param_type] = thres_count
         return ret_dict
+
+    def get_structural_parameters(self):
+        # if we have internal parameters, node is not cache-able
+        internal_weights = self.get_nodeattr("mem_mode") == "const"
+        internal_thresholds = self.get_nodeattr("noActivation") == 0
+        if internal_weights or internal_thresholds:
+            return None
+        # node is cache-able, collect parameters influencing HLS
+        # any array of ints must be converted to tuple so the dict is hashable
+        ret = dict()
+        ret["SIMD"] = self.get_nodeattr("SIMD")
+        ret["PE"] = self.get_nodeattr("PE")
+        ret["MW"] = self.get_nodeattr("MW")
+        ret["MH"] = self.get_nodeattr("MH")
+        ret["resType"] = self.get_nodeattr("resType")
+        ret["ActVal"] = self.get_nodeattr("ActVal")
+        ret["inputDataType"] = self.get_nodeattr("inputDataType")
+        ret["weightDataType"] = self.get_nodeattr("weightDataType")
+        ret["outputDataType"] = self.get_nodeattr("outputDataType")
+        ret["numInputVectors"] = tuple(self.get_nodeattr("numInputVectors"))
+        ret["binaryXnorMode"] = self.get_nodeattr("binaryXnorMode")
+        return ret
+
+

--- a/src/finn/custom_op/fpgadataflow/thresholding_batch.py
+++ b/src/finn/custom_op/fpgadataflow/thresholding_batch.py
@@ -947,3 +947,22 @@ class Thresholding_Batch(HLSCustomOp):
         thres_count = out_features * num_steps
         ret_dict[thres_param_type] = thres_count
         return ret_dict
+
+    def get_structural_parameters(self):
+        # if we have internal parameters, node is not cache-able
+        internal_thresholds = self.get_nodeattr("mem_mode") == "const"
+        if internal_thresholds:
+            return None
+        # node is cache-able, collect parameters influencing HLS
+        # any array of ints must be converted to tuple so the dict is hashable
+        ret = dict()
+        ret["PE"] = self.get_nodeattr("PE")
+        ret["NumChannels"] = self.get_nodeattr("NumChannels")
+        ret["ActVal"] = self.get_nodeattr("ActVal")
+        ret["NumSteps"] = self.get_nodeattr("NumSteps")
+        ret["inputDataType"] = self.get_nodeattr("inputDataType")
+        ret["weightDataType"] = self.get_nodeattr("weightDataType")
+        ret["outputDataType"] = self.get_nodeattr("outputDataType")
+        ret["numInputVectors"] = tuple(self.get_nodeattr("numInputVectors"))
+        return ret
+

--- a/src/finn/transformation/fpgadataflow/cache_ip.py
+++ b/src/finn/transformation/fpgadataflow/cache_ip.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2020, Xilinx
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of FINN nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import os
+import finn.custom_op.registry as registry
+from finn.custom_op.registry import getCustomOp
+from finn.transformation.base import Transformation
+from finn.transformation.fpgadataflow.hlssynth_ip import HLSSynthIP
+from finn.util.basic import make_build_dir
+from finn.util.fpgadataflow import is_fpgadataflow_node
+import warnings
+import json
+
+class CacheIP(Transformation):
+    """Parse nodes, calculating cache key for each and identifying
+    the minimal subset of nodes which require synthesis to fill the cache.
+    The subsequent transformation is HLSSynthIP"""
+
+    def __init__(self):
+        super().__init__()
+
+    def apply(self, model):
+        cache = dict()
+        nodes4synth = []
+        # traverse graph and set cache keys
+        for node in model.graph.node:
+            if is_fpgadataflow_node(node) is True:
+                node_inst = getCustomOp(node)
+                # compute and store cache key for the node
+                param = node_inst.get_structural_parameters()
+                if param is not None:
+                    key = str(hash(frozenset(param.items())))
+                    node_inst.set_nodeattr("ip_cache_key", str(key))
+                    # if the key is not in the cache, add the node name to 
+                    # the list of to-be-synthesized nodes, and create an empty entry
+                    # in the cache for the key
+                    if not key in cache.keys():
+                        nodes4synth.append(node.name)
+                        cache[key] = []
+        # mark nodes not targeted for synthesis
+        for node in model.graph.node:
+            if not node.name in nodes4synth:
+                getCustomOp(node).set_nodeattr("disable_ip_synth", 1)
+        # run IP synthesis with no cache (will only run for nodes in nodes4synth)
+        # we provide no cache file so everything not marked will synthesize
+        model = model.transform(HLSSynthIP())
+        # scan resulting model, gather parameters into the cache, and un-mark
+        import pdb; pdb.set_trace()
+        for node in model.graph.node:
+            node_inst = getCustomOp(node)
+            if node.name in nodes4synth:
+                node_inst = getCustomOp(node)
+                key = node_inst.get_nodeattr("ip_cache_key")
+                ip_path = node_inst.get_nodeattr("ip_path")
+                ipgen_path = node_inst.get_nodeattr("ipgen_path")
+                vlnv = node_inst.get_nodeattr("ip_vlnv")
+                cache[key] = [ip_path, ipgen_path, vlnv]
+            else:
+                node_inst.set_synth_enablement()
+        # save cache into a json and point to it from a model attribute
+        import pdb; pdb.set_trace()
+        code_gen_dir = make_build_dir(prefix="ip_cache_")
+        cache_file = code_gen_dir + "/ip_cache.json"
+        with open(cache_file, "w") as f:
+            json.dump(cache, f, indent=4)
+        model.set_metadata_prop("ip_cache", cache_file)
+        # done, return
+        return (model, False)

--- a/src/finn/util/create.py
+++ b/src/finn/util/create.py
@@ -103,6 +103,10 @@ def hls_mlp_maker(layer_spec):
         idt = lyr["idt"]
         tdt = lyr["tdt"]
         odt = lyr["odt"]
+        if "mem_mode" in lyr.keys():
+            mmode = lyr["mem_mode"]
+        else:
+            mmode = "const"
 
         if i == 0:
             global_in = helper.make_tensor_value_info(
@@ -159,6 +163,7 @@ def hls_mlp_maker(layer_spec):
             ActVal=actval,
             binaryXnorMode=binary_xnor_mode,
             noActivation=no_act,
+            mem_mode=mmode,
         )
 
         model.graph.node.append(FCLayer_node)

--- a/tests/transformation/test_ip_cache.py
+++ b/tests/transformation/test_ip_cache.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2020 Xilinx, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of Xilinx nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import pytest
+
+import finn.util.create as create
+from finn.core.datatype import DataType
+from finn.transformation.fpgadataflow.hlssynth_ip import HLSSynthIP
+from finn.transformation.fpgadataflow.prepare_ip import PrepareIP
+from finn.transformation.fpgadataflow.cache_ip import CacheIP
+from finn.transformation.general import (
+    GiveReadableTensorNames,
+    GiveUniqueNodeNames,
+)
+from finn.transformation.infer_shapes import InferShapes
+from finn.transformation.fpgadataflow.create_stitched_ip import CreateStitchedIP
+
+@pytest.mark.parametrize("bitwidth", [DataType.INT2])
+def test_ip_cache(bitwidth):
+    w = bitwidth
+    a = bitwidth
+    layer_spec = [
+        {"mw": 10, "mh": 10, "simd": 10, "pe": 10, "idt": a, "wdt": w, "act": None, "mem_mode": "decoupled"},
+        {"mw": 10, "mh": 10, "simd": 10, "pe": 10, "idt": a, "wdt": w, "act": None, "mem_mode": "decoupled"},
+        {"mw": 10, "mh": 10, "simd": 10, "pe": 10, "idt": a, "wdt": w, "act": None, "mem_mode": "decoupled"},
+        {"mw": 10, "mh": 10, "simd": 5, "pe": 10, "idt": a, "wdt": w, "act": a, "mem_mode": "decoupled"},
+        {"mw": 10, "mh": 10, "simd": 10, "pe": 10, "idt": a, "wdt": w, "act": a},
+    ]
+
+    model = create.hls_random_mlp_maker(layer_spec)
+
+    model = model.transform(InferShapes())
+    model = model.transform(GiveUniqueNodeNames())
+    model = model.transform(GiveReadableTensorNames())
+    model = model.transform(PrepareIP("xc7z020clg400-1", 5))
+    model = model.transform(CacheIP())
+    model = model.transform(HLSSynthIP(ip_cache_file=model.get_metadata_prop("ip_cache")))
+    model = model.transform(CreateStitchedIP("xc7z020clg400-1", 5))


### PR DESCRIPTION
This PR addresses #174 

I added the following features:

- two node attributes, `ip_cache_key` to store a key in an IP cache and 'disable_ip_synth' to instruct HLSSynthIP to skip a node
- an additional hlscustomop function , `get_structural_parameters()` which is meant to return a dict of the parameters which affect the generated hls; this dict can be hashed and turned into a cache key
- an additional hlscustomop function, `set_synth_enablement()` which the custom op can redefine if it wants to tell the HLSSynthIP to skip it for synthesis (for example for nodes which have HLS and RTL/Vivado implementations but are currently not configured to use the HLS)
- a new transform CacheIP which identifies unique IPs, synthesizes them, stores the relevant parameters into the cache, and adds a model attribute pointing to the cache file (a JSON)
- a test for the above

The test is by no means exhaustive but it does pass - graph is stitched in IPI with no issues. To be able to use the cache, each custom op should define the get_structural_parameters as appropriate for itself. By default nodes return no parameters and are therefore always synthesized from scratch. I implemented get_structural_parameters for FC layers only for this test.