### PR TITLE
Disable casting individual weight values

### DIFF
--- a/src/finn/custom_op/fpgadataflow/vector_vector_activate_batch.py
+++ b/src/finn/custom_op/fpgadataflow/vector_vector_activate_batch.py
@@ -312,7 +312,8 @@ class Vector_Vector_Activate_Batch(HLSCustomOp):
         code_gen_dir = path
 
         """Saves weights into params.h"""
-        weight_hls_code = numpy_to_hls_code(weight_tensor, wdt, "weights", True, True)
+        weight_tensor = np.reshape(weight_tensor, weight_tensor.shape[:-1])
+        weight_hls_code = numpy_to_hls_code(weight_tensor, wdt, "weights", False, True)
         # write weights into params.h
         f_weights = open("{}/params.h".format(code_gen_dir), "w")
 


### PR DESCRIPTION
Write individual weight values as integer values in the weight array in params.h for a VVAU. This lowers the HLS synthesis time.