### PR TITLE
Fixed off by one error in SIMD check for StreamingFCLayer_Batch.

### DIFF
--- a/src/finn/custom_op/fpgadataflow/streamingfclayer_batch.py
+++ b/src/finn/custom_op/fpgadataflow/streamingfclayer_batch.py
@@ -1016,10 +1016,10 @@ class StreamingFCLayer_Batch(HLSCustomOp):
         if var == "ipgen":
             SIMD = self.get_nodeattr("SIMD")
             MW = self.get_nodeattr("MW")
-            condition = SIMD > (MW / 1024)
+            condition = SIMD >= (MW / 1024)
             msg = (
                 f"HLS synthesis of StreamingFCLayer_Batch requires: "
-                f"SIMD > MW / 1024. This is not fulfilled with: SIMD={SIMD} "
+                f"SIMD >= MW / 1024. This is not fulfilled with: SIMD={SIMD} "
                 f"and MW={MW} for node: {self.onnx_node.name}."
             )
             assert condition, msg


### PR DESCRIPTION
Hi,
unfortunately I had a typo in the last SIMD check, which resulted in a off by one error.
In actuality buffers with a size of 1024 are still possible as one can see in the log of the original issue here: https://forums.xilinx.com/t5/High-Level-Synthesis-HLS/ARRAY-PARTITION-COMPLETE-has-exceeded-the-threshold-1024/td-p/862145
