### PR TITLE
Enable float inputs for Thresholding_Batch

### DIFF
--- a/src/finn/custom_op/fpgadataflow/thresholding_batch.py
+++ b/src/finn/custom_op/fpgadataflow/thresholding_batch.py
@@ -329,10 +329,6 @@ class Thresholding_Batch(HLSCustomOp):
         if not self.get_input_datatype().signed():
             # ensure all thresholds are nonnegative
             assert (orig_thres_matrix >= 0).all()
-        # ensure all thresholds are integer
-        assert np.equal(
-            np.mod(orig_thres_matrix, 1), 0
-        ).all(), "Need int threshold tensor"
         ret = orig_thres_matrix
         # workaround for vivado_hls threshold bug
         if ret[0][0] == 0:

--- a/src/finn/transformation/fpgadataflow/convert_to_hls_layers.py
+++ b/src/finn/transformation/fpgadataflow/convert_to_hls_layers.py
@@ -883,10 +883,6 @@ class InferThresholdingLayer(Transformation):
                 thl_thres_shape = model.get_tensor_shape(thl_threshold)
                 idt = model.get_tensor_datatype(thl_input)
 
-                # skip conversion for layers with float input
-                if not idt.is_integer():
-                    continue
-
                 # check layout of inputs/outputs, and convert if needed
                 # check layout and convert if necessary
                 thl_in_layout = model.get_tensor_layout(thl_input)


### PR DESCRIPTION
Related: https://gitter.im/xilinx-finn/community?at=6114e1d869ca4d0a51463df0

Related PR in finn-hlslib: https://github.com/Xilinx/finn-hlslib/pull/57

This PR enables use of `Thresholding_Batch`es for float inputs. More info in the finn-hlslib PR.