### PR TITLE
freeze protobuf to 3.20.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ setupext-janitor>=1.1.2
 toposort==1.5
 vcdvcd==1.0.5
 wget==3.2
+protobuf==3.20.1


### PR DESCRIPTION
protobuf 4.21 breaks onnx so freezing it as a workaround

see discussion here:
https://github.com/protocolbuffers/protobuf/issues/10051