### PR TITLE
Fix OOC synth, add System Verilog support

### DIFF
--- a/src/finn/transformation/fpgadataflow/create_stitched_ip.py
+++ b/src/finn/transformation/fpgadataflow/create_stitched_ip.py
@@ -534,8 +534,9 @@ class CreateStitchedIP(Transformation):
         tcl.append("ipx::save_core [ipx::find_open_core %s]" % block_vlnv)
         # export list of used Verilog files (for rtlsim later on)
         tcl.append(
-            "set all_v_files [get_files -filter {FILE_TYPE == Verilog "
-            + "&& USED_IN_SYNTHESIS == 1} ]"
+            "set all_v_files [get_files -filter {USED_IN_SYNTHESIS == 1 "
+            + "&& (FILE_TYPE == Verilog || FILE_TYPE == SystemVerilog "
+            + "|| FILE_TYPE ==\"Verilog Header\")}]"
         )
         v_file_list = "%s/all_verilog_srcs.txt" % vivado_stitch_proj_dir
         tcl.append("set fp [open %s w]" % v_file_list)

--- a/src/finn/transformation/fpgadataflow/synth_ooc.py
+++ b/src/finn/transformation/fpgadataflow/synth_ooc.py
@@ -52,7 +52,7 @@ class SynthOutOfContext(Transformation):
         top_module_name = model.get_metadata_prop("wrapper_filename")
         top_module_name = file_to_basename(top_module_name).strip(".v")
         build_dir = make_build_dir("synth_out_of_context_")
-        verilog_extensions = [".v", ".vh"]
+        verilog_extensions = [".v", ".sv", ".vh"]
         with open(vivado_stitch_proj_dir + "/all_verilog_srcs.txt", "r") as f:
             all_verilog_srcs = f.read().split()
         for file in all_verilog_srcs:

--- a/src/finn/util/pyverilator.py
+++ b/src/finn/util/pyverilator.py
@@ -74,7 +74,8 @@ def pyverilate_stitched_ip(
     # are identical but in multiple directories (regslice_core.v)
 
     # remove duplicates from list by doing list -> set -> list
-    all_verilog_files = list(set(filter(lambda x: x.endswith(".v"), all_verilog_srcs)))
+    all_verilog_files = list(set(filter(lambda x: x.endswith(".v") or x.endswith(".sv"),
+                                        all_verilog_srcs)))
 
     # remove all but one instances of regslice_core.v
     filtered_verilog_files = []


### PR DESCRIPTION
**This does two things:**
1) OOC synthesis (via OMX scripts) was broken for designs that contain Verilog header files (.vh), which is the case for large FIFOs with impl. style 'vivado'.
2) Add support for System Verilog sources in rtlsim and OOC synthesis in preparation for RTL SWG.

**Depends on https://github.com/maltanar/oh-my-xilinx/pull/1** 
**->TODO: update OMX commit hash in "fetch-repos.sh" accordingly**