### PR TITLE
Feature/vitisbuild

### DIFF
--- a/src/finn/transformation/fpgadataflow/floorplan.py
+++ b/src/finn/transformation/fpgadataflow/floorplan.py
@@ -167,11 +167,14 @@ class Floorplan(Transformation):
                 pre_slr = pre_inst.get_nodeattr("slr")
                 axilite_intf_name = pre_inst.get_verilog_top_module_intf_names()["axilite"]
                 if node_slr == pre_slr:
-                    partition_id = pre_inst.get_nodeattr("partition_id")
-                    node_inst.set_nodeattr("partition_id", partition_id)
                     if len(axilite_intf_name) != '0':
+                        node_inst.set_nodeattr("partition_id", partition_cnt)
                         partition_cnt += 1
-                    break
+                    else:
+                        partition_id = pre_inst.get_nodeattr("partition_id")
+                        node_inst.set_nodeattr("partition_id", partition_id)
+
+                    
             else:
                 # no matching, new partition
                 node_inst.set_nodeattr("partition_id", partition_cnt)

--- a/src/finn/transformation/fpgadataflow/floorplan.py
+++ b/src/finn/transformation/fpgadataflow/floorplan.py
@@ -165,7 +165,7 @@ class Floorplan(Transformation):
             for pre_node in pre_nodes:
                 pre_inst = getCustomOp(pre_node)
                 pre_slr = pre_inst.get_nodeattr("slr")
-                axilite_intf_name = pre_inst.get_verilog_top_module_intf_names()["axilite"]
+                axilite_intf_name = node_inst.get_verilog_top_module_intf_names()["axilite"]
                 if node_slr == pre_slr:
                     if len(axilite_intf_name) != '0':
                         node_inst.set_nodeattr("partition_id", partition_cnt)

--- a/src/finn/transformation/fpgadataflow/floorplan.py
+++ b/src/finn/transformation/fpgadataflow/floorplan.py
@@ -165,14 +165,15 @@ class Floorplan(Transformation):
             for pre_node in pre_nodes:
                 pre_inst = getCustomOp(pre_node)
                 pre_slr = pre_inst.get_nodeattr("slr")
-                axilite_intf_name = node_inst.get_verilog_top_module_intf_names()["axilite"]
                 if node_slr == pre_slr:
-                    if len(axilite_intf_name) != '0':
+                    axilite_intf_name = pre_inst.get_verilog_top_module_intf_names()["axilite"]
+                    if len(axilite_intf_name) != 0:
                         node_inst.set_nodeattr("partition_id", partition_cnt)
                         partition_cnt += 1
                     else:
                         partition_id = pre_inst.get_nodeattr("partition_id")
                         node_inst.set_nodeattr("partition_id", partition_id)
+                break
 
                     
             else:

--- a/src/finn/transformation/fpgadataflow/floorplan.py
+++ b/src/finn/transformation/fpgadataflow/floorplan.py
@@ -151,6 +151,7 @@ class Floorplan(Transformation):
                 node_inst.set_nodeattr("partition_id", partition_cnt)
                 partition_cnt += 1
                 continue
+            
             elif not (
                 node.op_type == "MatrixVectorActivation"
                 and node_inst.get_nodeattr("mem_mode") is not None
@@ -164,9 +165,12 @@ class Floorplan(Transformation):
             for pre_node in pre_nodes:
                 pre_inst = getCustomOp(pre_node)
                 pre_slr = pre_inst.get_nodeattr("slr")
+                axilite_intf_name = pre_inst.get_verilog_top_module_intf_names()["axilite"]
                 if node_slr == pre_slr:
                     partition_id = pre_inst.get_nodeattr("partition_id")
                     node_inst.set_nodeattr("partition_id", partition_id)
+                    if len(axilite_intf_name) != '0':
+                        partition_cnt += 1
                     break
             else:
                 # no matching, new partition

--- a/src/finn/transformation/fpgadataflow/floorplan.py
+++ b/src/finn/transformation/fpgadataflow/floorplan.py
@@ -151,7 +151,7 @@ class Floorplan(Transformation):
                 node_inst.set_nodeattr("partition_id", partition_cnt)
                 partition_cnt += 1
                 continue
-            
+
             elif not (
                 node.op_type == "MatrixVectorActivation"
                 and node_inst.get_nodeattr("mem_mode") is not None
@@ -166,7 +166,9 @@ class Floorplan(Transformation):
                 pre_inst = getCustomOp(pre_node)
                 pre_slr = pre_inst.get_nodeattr("slr")
                 if node_slr == pre_slr:
-                    axilite_intf_name = pre_inst.get_verilog_top_module_intf_names()["axilite"]
+                    axilite_intf_name = pre_inst.get_verilog_top_module_intf_names()[
+                        "axilite"
+                    ]
                     if len(axilite_intf_name) != 0:
                         node_inst.set_nodeattr("partition_id", partition_cnt)
                         partition_cnt += 1
@@ -175,7 +177,6 @@ class Floorplan(Transformation):
                         node_inst.set_nodeattr("partition_id", partition_id)
                 break
 
-                    
             else:
                 # no matching, new partition
                 node_inst.set_nodeattr("partition_id", partition_cnt)


### PR DESCRIPTION
I modified the Floorplan transformation to attribute a new `partition_id` each times a non-dma node with an axilite interface is detected. This is to work around Vitis not authorizing more than one axilite interface per Xilinx Object file.