### PR TITLE
Feature/vitisbuild

### DIFF
--- a/src/finn/transformation/fpgadataflow/hlssynth_ip.py
+++ b/src/finn/transformation/fpgadataflow/hlssynth_ip.py
@@ -64,7 +64,7 @@ class HLSSynthIP(NodeLocalTransformation):
                 ), """Node
                 attribute "code_gen_dir_ipgen" is empty. Please run
                 transformation PrepareIP first."""
-                if not os.path.isdir(inst.get_nodeattr("ipgen_path")):
+                if not os.path.isdir(inst.get_nodeattr("ipgen_path")) or not inst.get_nodeattr("code_gen_dir_ipgen") in inst.get_nodeattr("ipgen_path"):
                     # call the compilation function for this node
                     inst.ipgen_singlenode_code()
                 else:

--- a/src/finn/transformation/fpgadataflow/hlssynth_ip.py
+++ b/src/finn/transformation/fpgadataflow/hlssynth_ip.py
@@ -64,7 +64,11 @@ class HLSSynthIP(NodeLocalTransformation):
                 ), """Node
                 attribute "code_gen_dir_ipgen" is empty. Please run
                 transformation PrepareIP first."""
-                if not os.path.isdir(inst.get_nodeattr("ipgen_path")) or not inst.get_nodeattr("code_gen_dir_ipgen") in inst.get_nodeattr("ipgen_path"):
+                if not os.path.isdir(
+                    inst.get_nodeattr("ipgen_path")
+                ) or not inst.get_nodeattr("code_gen_dir_ipgen") in inst.get_nodeattr(
+                    "ipgen_path"
+                ):
                     # call the compilation function for this node
                     inst.ipgen_singlenode_code()
                 else:

--- a/src/finn/transformation/fpgadataflow/prepare_ip.py
+++ b/src/finn/transformation/fpgadataflow/prepare_ip.py
@@ -46,7 +46,11 @@ def _codegen_single_node(node, model, fpgapart, clk):
         # get the path of the code generation directory
         code_gen_dir = inst.get_nodeattr("code_gen_dir_ipgen")
         # ensure that there is a directory
-        if code_gen_dir == "" or not os.path.isdir(code_gen_dir) or not str(node.name) in code_gen_dir:
+        if (
+            code_gen_dir == ""
+            or not os.path.isdir(code_gen_dir)
+            or not str(node.name) in code_gen_dir
+        ):
             code_gen_dir = make_build_dir(
                 prefix="code_gen_ipgen_" + str(node.name) + "_"
             )

--- a/src/finn/transformation/fpgadataflow/prepare_ip.py
+++ b/src/finn/transformation/fpgadataflow/prepare_ip.py
@@ -46,7 +46,7 @@ def _codegen_single_node(node, model, fpgapart, clk):
         # get the path of the code generation directory
         code_gen_dir = inst.get_nodeattr("code_gen_dir_ipgen")
         # ensure that there is a directory
-        if code_gen_dir == "" or not os.path.isdir(code_gen_dir):
+        if code_gen_dir == "" or not os.path.isdir(code_gen_dir) or not str(node.name) in code_gen_dir:
             code_gen_dir = make_build_dir(
                 prefix="code_gen_ipgen_" + str(node.name) + "_"
             )


### PR DESCRIPTION
Small modifications to fix a bug sometimes occurring when using the auto FIFO sizing and VitisBuild. Due to the renaming of nodes and the conservation of cached IP folders, it could create a situation where two different FIFO nodes had the same IP name (even if they have different IP folder), which would create a collision during the creation of the stitched IP and incorrectly instantiate some FIFOs. These modifications force to regenerate the IPs in case the folders' names do not match the name of the corresponding ONNX node, ensuring that the aforementioned situation does not happen. 