### PR TITLE
Clone and install particular version of Verilator

### DIFF
--- a/docker/Dockerfile.finn
+++ b/docker/Dockerfile.finn
@@ -46,7 +46,6 @@ RUN apt-get update && \
     libsm6 \
     libxext6 \
     libxrender-dev \
-    verilator \
     nano \
     zsh \
     rsync \
@@ -61,6 +60,16 @@ RUN apt-get update && \
     lsb-core
 RUN echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config
 RUN locale-gen "en_US.UTF-8"
+
+# install Verilator from source to get the right version
+RUN apt-get install -y git perl python3 make autoconf g++ flex bison ccache libgoogle-perftools-dev numactl perl-doc libfl2 libfl-dev zlibc zlib1g zlib1g-dev
+RUN git clone https://github.com/verilator/verilator
+RUN cd verilator && \
+    git checkout v4.012 && \
+    autoconf && \
+    ./configure && \
+    make -j4 && \
+    make install
 
 # install XRT
 RUN wget https://www.xilinx.com/bin/public/openDownload?filename=$XRT_DEB_VERSION.deb -O /tmp/$XRT_DEB_VERSION.deb


### PR DESCRIPTION
While working on another feature I ran into a bug that required a newer version of Verilator than what was available in the Ubuntu 18.04 distribution channels (which the FINN Docker is based on) provided. This PR removes the `apt-get install verilator` in the FINN Dockerfile and replaces that with a manual clone, compile and installation of Verilator at a particular version (currently 4.012).