### PR TITLE
Skip streaming eltwise conversion if static inputs

### DIFF
--- a/src/finn/transformation/fpgadataflow/convert_to_hls_layers.py
+++ b/src/finn/transformation/fpgadataflow/convert_to_hls_layers.py
@@ -1165,9 +1165,15 @@ class InferAddStreamsLayer(Transformation):
                 result = node.output[0]
                 in0_shape = model.get_tensor_shape(in0)
                 in1_shape = model.get_tensor_shape(in1)
+                in0_static = not (model.get_initializer(in0) is None)
+                in1_static = not (model.get_initializer(in1) is None)
 
                 # skip if different shapes on inputs
                 if in0_shape != in1_shape:
+                    continue
+                # skip if any of inputs have initializers
+                # (this node is meant for adding two dynamic streams)
+                if in0_static or in1_static:
                     continue
 
                 idt0 = model.get_tensor_datatype(in0)
@@ -1694,6 +1700,10 @@ class InferConcatLayer(Transformation):
                 )
                 if not dt_coherent:
                     continue
+                # skip conversion if any inputs are static
+                all_static = all([model.get_initializer(x) is None for x in node.input])
+                if not all_static:
+                    continue
                 # skip conversion if inputs are not integers
                 if not dt0.is_integer():
                     continue
@@ -1739,9 +1749,15 @@ class InferStreamingEltwise(Transformation):
                 result = node.output[0]
                 in0_shape = model.get_tensor_shape(in0)
                 in1_shape = model.get_tensor_shape(in1)
+                in0_static = not (model.get_initializer(in0) is None)
+                in1_static = not (model.get_initializer(in1) is None)
 
                 # skip if different shapes on inputs
                 if in0_shape != in1_shape:
+                    continue
+                # skip if any of inputs have initializers
+                # (this node is meant for two dynamic streams)
+                if in0_static or in1_static:
                     continue
 
                 idt0 = model.get_tensor_datatype(in0)


### PR DESCRIPTION
The HLS layers `StreamingEltwise`, `StreamingConcat` and `AddStreams` are not meant to work on static inputs, only on dynamic ones. This PR adds a fix to avoid converting to hardware (HLS) layers if any static inputs are detected in relevant `convert_to_hls` calls.

A future consideration here might be to support converting tensors with static initializers to memory streamer components (`memstream`) with a separate `convert_to_hls` transformation.