### PR TITLE
Hotfix: delete numpy.str in datapacking

### DIFF
--- a/docker/Dockerfile.finn
+++ b/docker/Dockerfile.finn
@@ -84,7 +84,7 @@ RUN rm requirements.txt
 # extra Python package dependencies (for testing and interaction)
 RUN pip install pygments==2.4.1
 RUN pip install ipykernel==5.5.5
-RUN pip install jupyter==1.0.0
+RUN pip install jupyter==1.0.0 --ignore-installed
 RUN pip install markupsafe==2.0.1
 RUN pip install matplotlib==3.3.1 --ignore-installed
 RUN pip install pytest-dependency==0.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ onnxoptimizer
 onnxruntime==1.11.1
 pre-commit==2.9.2
 protobuf==3.20.2
+psutil==5.9.4
 pyscaffold==3.2.1
 scipy==1.5.2
 setupext-janitor>=1.1.2

--- a/src/finn/util/data_packing.py
+++ b/src/finn/util/data_packing.py
@@ -265,7 +265,7 @@ def numpy_to_hls_code(
     # define a function to convert a single element into a C++ init string
     # a single element can be a hex string if we are using packing
     def elem2str(x):
-        if type(x) == str or type(x) == np.str_ or type(x) == np.str:
+        if type(x) == str or type(x) == np.str_:
             return '%s("%s", 16)' % (hls_dtype, x)
         elif type(x) == np.float32:
             if dtype.is_integer():


### PR DESCRIPTION
Delete check for np.str in datapacking, because aliases of built-in types in numpy are deprecated,