### PR TITLE
Adding MinimizeWeightBitWidth() transformation

### DIFF
--- a/src/finn/custom_op/fpgadataflow/matrixvectoractivation.py
+++ b/src/finn/custom_op/fpgadataflow/matrixvectoractivation.py
@@ -652,8 +652,7 @@ class MatrixVectorActivation(HLSCustomOp):
 
     def minimize_weight_bit_width(self, model):
         """Minimize the bit width based on the values of the weights"""
-        runtime_writable = self.get_nodeattr("runtime_writeable_weights") == 0
-        if runtime_writable:
+        if not self.get_nodeattr("runtime_writeable_weights"):
             weights = model.get_initializer(self.onnx_node.input[1])
             w_min = weights.min()
             w_max = weights.max()

--- a/src/finn/custom_op/fpgadataflow/vectorvectoractivation.py
+++ b/src/finn/custom_op/fpgadataflow/vectorvectoractivation.py
@@ -171,8 +171,7 @@ class VectorVectorActivation(HLSCustomOp):
 
     def minimize_weight_bit_width(self, model):
         """Minimize the bit width based on the values of the weights"""
-        runtime_writable = self.get_nodeattr("runtime_writeable_weights") == 0
-        if runtime_writable:
+        if not self.get_nodeattr("runtime_writeable_weights"):
             weights = model.get_initializer(self.onnx_node.input[1])
             w_min = weights.min()
             w_max = weights.max()

--- a/src/finn/transformation/fpgadataflow/minimize_weight_bit_width.py
+++ b/src/finn/transformation/fpgadataflow/minimize_weight_bit_width.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2023, Xilinx
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of FINN nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from qonnx.custom_op.registry import getCustomOp
+from qonnx.transformation.base import Transformation
+
+from finn.util.fpgadataflow import is_fpgadataflow_node
+
+
+class MinimizeWeightBitWidth(Transformation):
+    """For relevant nodes, call the weight bit width minimization
+    functions to save on resources. May alter tensor weightDataType
+    if the node does not have runtime writeable weights."""
+
+    def __init__(self):
+        super().__init__()
+
+    def apply(self, model):
+        for node in model.graph.node:
+            if is_fpgadataflow_node(node) is True:
+                inst = getCustomOp(node)
+                if hasattr(inst, "minimize_weight_bit_width"):
+                    inst.minimize_weight_bit_width(model)
+        return (model, False)

--- a/src/finn/transformation/fpgadataflow/minimize_weight_bit_width.py
+++ b/src/finn/transformation/fpgadataflow/minimize_weight_bit_width.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, Xilinx
+# Copyright (C) 2023, Advanced Micro Devices, Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/finn/util/basic.py
+++ b/src/finn/util/basic.py
@@ -121,7 +121,7 @@ def make_build_dir(prefix=""):
     try:
         tmpdir = tempfile.mkdtemp(prefix=prefix)
         newdir = tmpdir.replace("/tmp", os.environ["FINN_BUILD_DIR"])
-        os.makedirs(newdir, exist_ok=True)
+        os.makedirs(newdir)
         return newdir
     except KeyError:
         raise Exception(

--- a/src/finn/util/basic.py
+++ b/src/finn/util/basic.py
@@ -121,7 +121,7 @@ def make_build_dir(prefix=""):
     try:
         tmpdir = tempfile.mkdtemp(prefix=prefix)
         newdir = tmpdir.replace("/tmp", os.environ["FINN_BUILD_DIR"])
-        os.makedirs(newdir)
+        os.makedirs(newdir, exist_ok=True)
         return newdir
     except KeyError:
         raise Exception(


### PR DESCRIPTION
Adding a MinimizeWeightBitWidth() transformation, which calls the weight bit width minimization functions to save on resources when a node does not have runtime writeable weights.