### PR TITLE
Avoid using impl_style=vivado for the input FIFO

### DIFF
--- a/src/finn/transformation/fpgadataflow/create_stitched_ip.py
+++ b/src/finn/transformation/fpgadataflow/create_stitched_ip.py
@@ -310,6 +310,14 @@ class CreateStitchedIP(Transformation):
                 behavior. It is strongly recommended to insert FIFOs prior to
                 calling CreateStitchedIP."""
             )
+        if model.graph.node[0].op_type == "StreamingFIFO":
+            firstfifo = getCustomOp(model.graph.node[0])
+            if firstfifo.get_nodeattr("impl_style") == "vivado":
+                warnings.warn(
+                    """First FIFO has impl_style=vivado, which may cause
+                    simulation glitches (e.g. dropping the first input sample
+                    after reset)."""
+                )
         for node in model.graph.node:
             # ensure that all nodes are fpgadataflow, and that IPs are generated
             assert is_fpgadataflow_node(

--- a/src/finn/transformation/fpgadataflow/insert_fifo.py
+++ b/src/finn/transformation/fpgadataflow/insert_fifo.py
@@ -209,13 +209,9 @@ class InsertFIFO(Transformation):
                         graph.value_info.append(fifo_output_tensor)
                         model.set_tensor_datatype(fifo_output_tensor.name, dtype)
 
-                        if (
-                            self.max_qsrl_depth is None
-                            or fifo_depth <= self.max_qsrl_depth
-                        ):
-                            impl_style = "rtl"
-                        else:
-                            impl_style = "vivado"
+                        # only use rtl-style FIFOs to avoid simulation bug
+                        # (top-level IOs should not have impl_style=vivado)
+                        impl_style = "rtl"
 
                         fifo_node = oh.make_node(
                             "StreamingFIFO",
@@ -271,13 +267,9 @@ class InsertFIFO(Transformation):
                         graph.value_info.append(fifo_input_tensor)
                         model.set_tensor_datatype(fifo_input_tensor.name, dtype)
 
-                        if (
-                            self.max_qsrl_depth is None
-                            or fifo_depth <= self.max_qsrl_depth
-                        ):
-                            impl_style = "rtl"
-                        else:
-                            impl_style = "vivado"
+                        # only use rtl-style FIFOs to avoid simulation bug
+                        # (top-level IOs should not have impl_style=vivado)
+                        impl_style = "rtl"
 
                         fifo_node = oh.make_node(
                             "StreamingFIFO",

--- a/src/finn/transformation/fpgadataflow/set_fifo_depths.py
+++ b/src/finn/transformation/fpgadataflow/set_fifo_depths.py
@@ -412,8 +412,13 @@ class InsertAndSetFIFODepths(Transformation):
                 node_inst = getCustomOp(node)
                 node_inst.set_nodeattr("depth", depth)
                 node_inst.set_nodeattr("depth_monitor", 0)
+                # exception for top-level IO FIFOs which cause a bug in simulation
+                # (top-level IOs should not have impl_style=vivado)
+                toplevel_in = node.input[0] in [x.name for x in model.graph.input]
+                toplevel_out = node.output[0] in [x.name for x in model.graph.output]
+                toplevel_style_exception = toplevel_in or toplevel_out
                 # Set FIFO implementation/ram styles
-                if depth > self.max_qsrl_depth:
+                if (depth > self.max_qsrl_depth) and (not toplevel_style_exception):
                     node_inst.set_nodeattr("impl_style", "vivado")
                     node_inst.set_nodeattr("ram_style", self.vivado_ram_style)
                 else:


### PR DESCRIPTION
This PR depends on/incorporates #744 

If the first node in the graph is a FIFO with `impl_style=vivado` this can cause a glitch during stitched-IP Verilator simulation (which is used for verification as well as in FIFO sizing and throughput testing) that drops the first input sample after reset. 

This PR provides a workaround by using `impl_style=rtl` for the first FIFO as part of the `InsertAndSetFIFODepths` (for simulation-style FIFO sizing) and `InsertFIFO` (for characterization-style and premade json config) transformations. An additional warning is also raised in `CreateStitchedIP` if an input FIFO with `impl_style=vivado` is detected.