### PR TITLE
Adding new build step and accounting for runtime writeable weights

### DIFF
--- a/src/finn/builder/build_dataflow_config.py
+++ b/src/finn/builder/build_dataflow_config.py
@@ -119,6 +119,7 @@ default_build_dataflow_steps = [
     "step_create_dataflow_partition",
     "step_target_fps_parallelization",
     "step_apply_folding_config",
+    "step_minimize_bit_width",
     "step_generate_estimate_reports",
     "step_hls_codegen",
     "step_hls_ipgen",
@@ -140,6 +141,7 @@ estimate_only_dataflow_steps = [
     "step_create_dataflow_partition",
     "step_target_fps_parallelization",
     "step_apply_folding_config",
+    "step_minimize_bit_width",
     "step_generate_estimate_reports",
 ]
 

--- a/src/finn/builder/build_dataflow_config.py
+++ b/src/finn/builder/build_dataflow_config.py
@@ -233,6 +233,12 @@ class DataflowBuildConfig:
     #: flexibility, and makes it possible to have runtime-writable thresholds.
     standalone_thresholds: Optional[bool] = False
 
+    #: (Optional) Whether optimizations that minimize the bit width of the
+    #: weights and accumulator will be applied. Because this optimization relies
+    #: on the the values of the weights, it will only be applied if runtime-
+    #: writeable weights is not enabled.
+    minimize_bit_width: Optional[bool] = True
+
     #: Target board, only needed for generating full bitfiles where the FINN
     #: design is integrated into a shell.
     #: e.g. "Pynq-Z1" or "U250"

--- a/src/finn/builder/build_dataflow_steps.py
+++ b/src/finn/builder/build_dataflow_steps.py
@@ -118,6 +118,8 @@ from finn.util.basic import (
 from finn.util.pyverilator import verilator_fifosim
 from finn.util.test import execute_parent
 
+from finn.transformation.fpgadataflow.minimize_accumulator_width import MinimizeAccumulatorWidth
+from finn.transformation.fpgadataflow.minimize_weight_bit_width import MinimizeWeightBitWidth
 
 def verify_step(
     model: ModelWrapper,
@@ -474,6 +476,14 @@ def step_generate_estimate_reports(model: ModelWrapper, cfg: DataflowBuildConfig
         estimate_network_performance["estimated_latency_ns"] = est_latency_ns
         with open(report_dir + "/estimate_network_performance.json", "w") as f:
             json.dump(estimate_network_performance, f, indent=2)
+    return model
+
+
+def step_minimize_bit_width(model: ModelWrapper, cfg: DataflowBuildConfig):
+    """Tighten the weight and accumulator bit widths for each layer."""
+    if cfg.minimize_bit_width:
+        model = model.transform(MinimizeWeightBitWidth())
+        model = model.transform(MinimizeAccumulatorWidth())
     return model
 
 

--- a/src/finn/custom_op/fpgadataflow/matrixvectoractivation.py
+++ b/src/finn/custom_op/fpgadataflow/matrixvectoractivation.py
@@ -353,12 +353,12 @@ class MatrixVectorActivation(HLSCustomOp):
         acc_datatype = self.get_accumulator_datatype()
         # if accDataType is not set, then it will default to INT32, which would
         # be a large overestimate in most (if not all) cases. In this scenario,
-        # we would use the minimum accumulator as determined by the data types.
+        # we would use the minimum accumulator as determined by the data types
+        # bound, derived in https://arxiv.org/abs/2301.13376
         alpha = math.log(MW, 2) + W + A - 1 - int(idt.signed())
-        phi = lambda x_: math.log(1 + pow(2, -x_), 2)
         acc_bits = min(
             acc_datatype.bitwidth(),
-            np.ceil(alpha + phi(alpha) + 1)
+            np.ceil(alpha + math.log(1 + pow(2, -alpha), 2) + 1)
         )
         acc_luts = acc_bits
         # thresholds and threshold comparators

--- a/src/finn/custom_op/fpgadataflow/vectorvectoractivation.py
+++ b/src/finn/custom_op/fpgadataflow/vectorvectoractivation.py
@@ -104,69 +104,72 @@ class VectorVectorActivation(HLSCustomOp):
         return my_attrs
 
     def minimize_accumulator_width(self, model):
-        weights = model.get_initializer(self.onnx_node.input[1])
-        k_h, k_w = self.get_nodeattr("Kernel")
-        fm = self.get_nodeattr("Channels")
-        # put weights into the shape expected by calculate_matvec_accumulator_range
-        weights = weights.reshape(fm, k_h * k_w).transpose()
-        if len(self.onnx_node.input) > 2:
-            thresholds = model.get_initializer(self.onnx_node.input[2])
-        else:
-            thresholds = None
-        idt = self.get_input_datatype()
-        # calculate minimum and maximum values of accumulator
-        (acc_min, acc_max) = calculate_matvec_accumulator_range(weights, idt)
-        if thresholds is not None:
-            threshold_tensor = self.get_hls_compatible_threshold_tensor(thresholds)
-            # set threshold datatype (and accumulator datatype implicitly)
-            min_threshold = thresholds.min()
-            max_threshold = thresholds.max()
-            # clip threshold values
-            clip_upper = None
-            clip_lower = None
-            if max_threshold > acc_max + 1:
-                clip_upper = acc_max + 1
-            if min_threshold < acc_min:
-                clip_lower = acc_min
-            if (clip_lower is not None) or (clip_upper is not None):
-                warnings.warn("Clipping some thresholds in %s" % self.onnx_node.name)
-                thresholds = np.clip(thresholds, clip_lower, clip_upper)
-                model.set_initializer(self.onnx_node.input[2], thresholds)
+        """Minimize the accumulator bit width according to the weight values,
+        input data types, and size of dot product"""
+        if not self.get_nodeattr("runtime_writeable_weights"):
+            weights = model.get_initializer(self.onnx_node.input[1])
+            k_h, k_w = self.get_nodeattr("Kernel")
+            fm = self.get_nodeattr("Channels")
+            # put weights into the shape expected by calculate_matvec_accumulator_range
+            weights = weights.reshape(fm, k_h * k_w).transpose()
+            if len(self.onnx_node.input) > 2:
+                thresholds = model.get_initializer(self.onnx_node.input[2])
+            else:
+                thresholds = None
+            idt = self.get_input_datatype()
+            # calculate minimum and maximum values of accumulator
+            (acc_min, acc_max) = calculate_matvec_accumulator_range(weights, idt)
+            if thresholds is not None:
                 threshold_tensor = self.get_hls_compatible_threshold_tensor(thresholds)
+                # set threshold datatype (and accumulator datatype implicitly)
                 min_threshold = thresholds.min()
                 max_threshold = thresholds.max()
-            # get range required by threshold values
-            tdt_min = min(acc_min, min_threshold)
-            tdt_max = max(acc_max, max_threshold)
-            if tdt_min < 0:
-                if abs(tdt_min) > tdt_max:
-                    tdt = DataType.get_smallest_possible(tdt_min)
+                # clip threshold values
+                clip_upper = None
+                clip_lower = None
+                if max_threshold > acc_max + 1:
+                    clip_upper = acc_max + 1
+                if min_threshold < acc_min:
+                    clip_lower = acc_min
+                if (clip_lower is not None) or (clip_upper is not None):
+                    warnings.warn("Clipping some thresholds in %s" % self.onnx_node.name)
+                    thresholds = np.clip(thresholds, clip_lower, clip_upper)
+                    model.set_initializer(self.onnx_node.input[2], thresholds)
+                    threshold_tensor = self.get_hls_compatible_threshold_tensor(thresholds)
+                    min_threshold = thresholds.min()
+                    max_threshold = thresholds.max()
+                # get range required by threshold values
+                tdt_min = min(acc_min, min_threshold)
+                tdt_max = max(acc_max, max_threshold)
+                if tdt_min < 0:
+                    if abs(tdt_min) > tdt_max:
+                        tdt = DataType.get_smallest_possible(tdt_min)
+                    else:
+                        tdt = DataType.get_smallest_possible(-tdt_max - 1)
                 else:
-                    tdt = DataType.get_smallest_possible(-tdt_max - 1)
+                    tdt = DataType.get_smallest_possible(tdt_max)
+                assert np.vectorize(tdt.allowed)(
+                    threshold_tensor
+                ).all(), "Thresholds in %s can't be expressed with type %s" % (
+                    self.onnx_node.name,
+                    str(tdt),
+                )
+                self.set_nodeattr("accDataType", tdt.name)
             else:
-                tdt = DataType.get_smallest_possible(tdt_max)
-            assert np.vectorize(tdt.allowed)(
-                threshold_tensor
-            ).all(), "Thresholds in %s can't be expressed with type %s" % (
-                self.onnx_node.name,
-                str(tdt),
-            )
-            self.set_nodeattr("accDataType", tdt.name)
-        else:
-            if acc_min < 0:
-                if abs(acc_min) > acc_max:
-                    adt = DataType.get_smallest_possible(acc_min)
+                if acc_min < 0:
+                    if abs(acc_min) > acc_max:
+                        adt = DataType.get_smallest_possible(acc_min)
+                    else:
+                        adt = DataType.get_smallest_possible(-acc_max - 1)
                 else:
-                    adt = DataType.get_smallest_possible(-acc_max - 1)
-            else:
-                adt = DataType.get_smallest_possible(acc_max)
-            # ensure a datatype divisible by 8-bits in case this is the last node
-            bw = roundup_to_integer_multiple(adt.bitwidth(), 8)
-            new_adt_name = adt.name.replace(str(adt.bitwidth()), str(bw))
-            adt = DataType[new_adt_name]
-            self.set_nodeattr("accDataType", adt.name)
-            # for no-activation nodes, output dt = acc dt
-            self.set_nodeattr("outputDataType", adt.name)
+                    adt = DataType.get_smallest_possible(acc_max)
+                # ensure a datatype divisible by 8-bits in case this is the last node
+                bw = roundup_to_integer_multiple(adt.bitwidth(), 8)
+                new_adt_name = adt.name.replace(str(adt.bitwidth()), str(bw))
+                adt = DataType[new_adt_name]
+                self.set_nodeattr("accDataType", adt.name)
+                # for no-activation nodes, output dt = acc dt
+                self.set_nodeattr("outputDataType", adt.name)
         return DataType[self.get_nodeattr("accDataType")]
 
     def minimize_weight_bit_width(self, model):

--- a/src/finn/custom_op/fpgadataflow/vectorvectoractivation.py
+++ b/src/finn/custom_op/fpgadataflow/vectorvectoractivation.py
@@ -1199,12 +1199,12 @@ class VectorVectorActivation(HLSCustomOp):
         k_h, k_w = self.get_nodeattr("Kernel")
         # if accDataType is not set, then it will default to INT32, which would
         # be a large overestimate in most (if not all) cases. In this scenario,
-        # we would use the minimum accumulator as determined by the data types.
+        # we would use the minimum accumulator as determined by the data types
+        # bound, derived in https://arxiv.org/abs/2301.13376
         alpha = math.log(k_h * k_w, 2) + W + A - 1 - int(idt.signed())
-        phi = lambda x_: math.log(1 + pow(2, -x_), 2)
         acc_bits = min(
             acc_datatype.bitwidth(),
-            np.ceil(alpha + phi(alpha) + 1)
+            np.ceil(alpha + math.log(1 + pow(2, -alpha), 2) + 1)
         )
         acc_luts = acc_bits
         # thresholds and threshold comparators

--- a/src/finn/custom_op/fpgadataflow/vectorvectoractivation.py
+++ b/src/finn/custom_op/fpgadataflow/vectorvectoractivation.py
@@ -117,7 +117,8 @@ class VectorVectorActivation(HLSCustomOp):
             else:
                 thresholds = None
             idt = self.get_input_datatype()
-            # calculate minimum and maximum values of accumulator
+            # calculate minimum and maximum values of accumulator according to the
+            # weight values using the bounds derived in https://arxiv.org/abs/2301.13376
             (acc_min, acc_max) = calculate_matvec_accumulator_range(weights, idt)
             if thresholds is not None:
                 threshold_tensor = self.get_hls_compatible_threshold_tensor(thresholds)

--- a/src/finn/transformation/fpgadataflow/convert_to_hls_layers.py
+++ b/src/finn/transformation/fpgadataflow/convert_to_hls_layers.py
@@ -40,10 +40,6 @@ from qonnx.transformation.infer_shapes import InferShapes
 from qonnx.util.basic import get_by_name
 from qonnx.util.onnx import nchw_to_nhwc
 
-from finn.transformation.fpgadataflow.minimize_accumulator_width import (
-    MinimizeAccumulatorWidth,
-)
-
 
 class InferConvInpGen(Transformation):
     """Convert Im2Col layers to ConvolutionInputGenerator layers."""
@@ -761,7 +757,6 @@ class InferBinaryMatrixVectorActivation(Transformation):
                     graph.node.remove(n)
                     graph_modified = True
         if graph_modified:
-            model = model.transform(MinimizeAccumulatorWidth())
             model = model.transform(InferShapes())
             model = model.transform(InferDataTypes())
         return (model, graph_modified)
@@ -904,7 +899,6 @@ class InferQuantizedMatrixVectorActivation(Transformation):
                         graph.node.remove(n)
                         graph_modified = True
         if graph_modified:
-            model = model.transform(MinimizeAccumulatorWidth())
             model = model.transform(InferShapes())
             model = model.transform(InferDataTypes())
         return (model, graph_modified)
@@ -1057,7 +1051,6 @@ class InferVectorVectorActivation(Transformation):
                         graph.node.remove(n)
                         graph_modified = True
         if graph_modified:
-            model = model.transform(MinimizeAccumulatorWidth())
             model = model.transform(InferShapes())
             model = model.transform(InferDataTypes())
         return (model, graph_modified)
@@ -1135,7 +1128,7 @@ class InferThresholdingLayer(Transformation):
                     PE=pe,
                     numSteps=thl_thres_shape[1],
                     inputDataType=idt.name,
-                    weightDataType=idt.name,  # will be set by MinimizeAccumulatorWidth
+                    weightDataType=idt.name,  # can be tightened by MinimizeAccumulatorWidth
                     outputDataType=odt.name,
                     numInputVectors=list(thl_in_shape[:-1]),
                     ActVal=actval,
@@ -1148,7 +1141,6 @@ class InferThresholdingLayer(Transformation):
                 graph_modified = True
 
         if graph_modified:
-            model = model.transform(MinimizeAccumulatorWidth())
             model = model.transform(InferShapes())
             model = model.transform(InferDataTypes())
         return (model, graph_modified)


### PR DESCRIPTION
- Updating `MinimizeAccumulatorWidth` to account for runtime-writeable weights
- Adding new builder step `step_minimize_bit_width` to default finn flows
- Moving `MinimizeAccumulatorWidth` and `MinimizeWeightBitWidth` to new builder step
- Removing `MinimizeAccumulatorWidth` from `convert_to_hls_layers`
- Adding unit test for new builder step in end2end flow