### PR TITLE
remove unused dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 bitstring==3.1.7
 clize==4.1.1
 dataclasses-json==0.5.7
-docrep==0.2.7
 gspread==3.6.0
 numpy==1.22.0
 onnx==1.13.0


### PR DESCRIPTION
This library was added as a Brevitas dependency here: https://github.com/Xilinx/finn/commit/e73ce9aa72783daa2d4d3ed5f2b801ca7bd1a1b7

But Brevitas has since moved on and does not require this dependency anymore: https://github.com/Xilinx/brevitas/commit/75c3e1bf9e511f0a919f4d5e4dddf14fba8b53d1