### PR TITLE
[Hotfix] Interpretation of dtype to check for signed integer

### DIFF
--- a/src/finn/util/data_packing.py
+++ b/src/finn/util/data_packing.py
@@ -220,7 +220,7 @@ def unpack_innermost_dim_from_hex_string(
         if conv_dtype == DataType["BIPOLAR"]:
             ar_list = [2 * x - 1 for x in ar_list]
         # interpret values as signed values
-        elif dtype.signed():
+        elif conv_dtype.signed() and conv_dtype.is_integer():
             mask = 2 ** (conv_dtype.bitwidth() - 1)
             ar_list = [-(x & mask) + (x & ~mask) for x in ar_list]
 


### PR DESCRIPTION
This function was changed in a recent PR merge, but it leads to wrong behavior when handling float dtypes (like in the CheckSum layer). The check was extended to not only check for signed but also if the dtype is an integer.