### PR TITLE
Infer data types after bit width minimization

### DIFF
--- a/src/finn/builder/build_dataflow_steps.py
+++ b/src/finn/builder/build_dataflow_steps.py
@@ -488,6 +488,8 @@ def step_minimize_bit_width(model: ModelWrapper, cfg: DataflowBuildConfig):
     if cfg.minimize_bit_width:
         model = model.transform(MinimizeWeightBitWidth())
         model = model.transform(MinimizeAccumulatorWidth())
+        # make sure the changed datatypes are propagated through the network
+        model = model.transform(InferDataTypes())
     return model
 
 


### PR DESCRIPTION
This PR adds an additional transformation to the minimize bit width builder step to ensure that the new data types are propagated through the network.