### PR TITLE
Fix SV enum bug for dynamic SWG

### DIFF
--- a/finn-rtllib/swg/swg_common.sv
+++ b/finn-rtllib/swg/swg_common.sv
@@ -29,6 +29,18 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *****************************************************************************/
 
+`ifndef FINN_SWG_ENUM_DEFINED
+`define FINN_SWG_ENUM_DEFINED
+typedef enum logic [2:0] {
+    STATE_START,
+    STATE_LOOP_SIMD,
+    STATE_LOOP_KW,
+    STATE_LOOP_KH,
+    STATE_LOOP_W,
+    STATE_LOOP_H
+}  state_e;
+`endif
+
 // loop controller used for both, "default" and "parallel", implementation styles
 module swg_controller #(
     int unsigned  LOOP_H_ITERATIONS,
@@ -61,14 +73,6 @@ module swg_controller #(
 );
 
     // state and counters
-    typedef enum logic [2:0] {
-        STATE_START,
-        STATE_LOOP_SIMD,
-        STATE_LOOP_KW,
-        STATE_LOOP_KH,
-        STATE_LOOP_W,
-        STATE_LOOP_H
-    }  state_e;
     state_e  State = INNERMOST_STATE;
     state_e  state_next;
 

--- a/finn-rtllib/swg/swg_common.sv
+++ b/finn-rtllib/swg/swg_common.sv
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (C) 2022, Advanced Micro Devices, Inc.
+ * Copyright (C) 2022-2023, Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -29,20 +29,10 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *****************************************************************************/
 
-`ifndef FINN_SWG_ENUM_DEFINED
-`define FINN_SWG_ENUM_DEFINED
-typedef enum logic [2:0] {
-    STATE_START,
-    STATE_LOOP_SIMD,
-    STATE_LOOP_KW,
-    STATE_LOOP_KH,
-    STATE_LOOP_W,
-    STATE_LOOP_H
-}  state_e;
-`endif
 
 // loop controller used for both, "default" and "parallel", implementation styles
-module swg_controller #(
+module swg_controller
+import swg::*; #(
     int unsigned  LOOP_H_ITERATIONS,
     int unsigned  LOOP_W_ITERATIONS,
     int unsigned  LOOP_KH_ITERATIONS,
@@ -62,7 +52,7 @@ module swg_controller #(
     int TAIL_INCR_H,
     int TAIL_INCR_LAST,
 
-    parameter INNERMOST_STATE
+    state_e INNERMOST_STATE
 )(
     input   logic  clk,
     input   logic  rst_n,

--- a/finn-rtllib/swg/swg_pkg.sv
+++ b/finn-rtllib/swg/swg_pkg.sv
@@ -1,0 +1,41 @@
+/******************************************************************************
+ * Copyright (C) 2023, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ *  3. Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION). HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *****************************************************************************/
+
+package swg;
+	typedef enum logic [2:0] {
+		STATE_START,
+		STATE_LOOP_SIMD,
+		STATE_LOOP_KW,
+		STATE_LOOP_KH,
+		STATE_LOOP_W,
+		STATE_LOOP_H
+	} state_e;
+endpackage : swg

--- a/finn-rtllib/swg/swg_template_axilite.v
+++ b/finn-rtllib/swg/swg_template_axilite.v
@@ -1,8 +1,35 @@
+/******************************************************************************
+ * Copyright (C) 2022-2023, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ *  3. Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION). HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *****************************************************************************/
 
-`timescale 1 ns / 1 ps
-
-module $TOP_MODULE_NAME$_axilite #
-(
+module $TOP_MODULE_NAME$_axilite #(
     // Users to add parameters here
 
     // User parameters ends
@@ -12,8 +39,7 @@ module $TOP_MODULE_NAME$_axilite #
     parameter integer C_S_AXI_DATA_WIDTH	= 32,
     // Width of S_AXI address bus
     parameter integer C_S_AXI_ADDR_WIDTH	= 6
-)
-(
+)(
     // Users to add ports here
     output wire [C_S_AXI_DATA_WIDTH-1:0]	cfg_reg0,
     output wire [C_S_AXI_DATA_WIDTH-1:0]	cfg_reg1,

--- a/finn-rtllib/swg/swg_template_default.sv
+++ b/finn-rtllib/swg/swg_template_default.sv
@@ -98,7 +98,7 @@ module $TOP_MODULE_NAME$_impl #(
         .TAIL_INCR_LAST($TAIL_INCR_LAST$),
         .INCR_BITWIDTH($INCR_BITWIDTH$),
         .IS_DEPTHWISE($IS_DEPTHWISE$),
-        .INNERMOST_STATE($INNERMOST_STATE$)
+        .INNERMOST_STATE(swg::$INNERMOST_STATE$)
     )
     controller_inst (
         .clk(ap_clk),

--- a/finn-rtllib/swg/swg_template_default_dynamic.sv
+++ b/finn-rtllib/swg/swg_template_default_dynamic.sv
@@ -1,3 +1,15 @@
+`ifndef FINN_SWG_ENUM_DEFINED
+`define FINN_SWG_ENUM_DEFINED
+typedef enum logic [2:0] {
+    STATE_START,
+    STATE_LOOP_SIMD,
+    STATE_LOOP_KW,
+    STATE_LOOP_KH,
+    STATE_LOOP_W,
+    STATE_LOOP_H
+}  state_e;
+`endif
+
 module $TOP_MODULE_NAME$_controller #(
     int unsigned  CNTR_BITWIDTH,
     int unsigned  INCR_BITWIDTH,
@@ -62,14 +74,6 @@ module $TOP_MODULE_NAME$_controller #(
     end
 
     // state and counters
-    typedef enum logic [2:0] {
-        STATE_START,
-        STATE_LOOP_SIMD,
-        STATE_LOOP_KW,
-        STATE_LOOP_KH,
-        STATE_LOOP_W,
-        STATE_LOOP_H
-    }  state_e;
     state_e  State = $INNERMOST_STATE$;
     state_e  state_next;
 

--- a/finn-rtllib/swg/swg_template_default_dynamic.sv
+++ b/finn-rtllib/swg/swg_template_default_dynamic.sv
@@ -1,14 +1,33 @@
-`ifndef FINN_SWG_ENUM_DEFINED
-`define FINN_SWG_ENUM_DEFINED
-typedef enum logic [2:0] {
-    STATE_START,
-    STATE_LOOP_SIMD,
-    STATE_LOOP_KW,
-    STATE_LOOP_KH,
-    STATE_LOOP_W,
-    STATE_LOOP_H
-}  state_e;
-`endif
+/******************************************************************************
+ * Copyright (C) 2022-2023, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ *  3. Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION). HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *****************************************************************************/
 
 module $TOP_MODULE_NAME$_controller #(
     int unsigned  CNTR_BITWIDTH,
@@ -38,6 +57,8 @@ module $TOP_MODULE_NAME$_controller #(
     input logic [INCR_BITWIDTH-1:0] cfg_incr_tail_h,
     input logic [INCR_BITWIDTH-1:0] cfg_incr_tail_last
 );
+
+    import  swg::*;
 
     // (dynamic) configuration registers
     logic [CNTR_BITWIDTH-1:0] Cfg_cntr_simd      = $LOOP_SIMD_ITERATIONS$;

--- a/finn-rtllib/swg/swg_template_parallel.sv
+++ b/finn-rtllib/swg/swg_template_parallel.sv
@@ -123,7 +123,7 @@ module $TOP_MODULE_NAME$_impl #(
         .TAIL_INCR_LAST($TAIL_INCR_LAST$),
         .INCR_BITWIDTH($INCR_BITWIDTH$),
         .IS_DEPTHWISE($IS_DEPTHWISE$),
-        .INNERMOST_STATE($INNERMOST_STATE$)
+        .INNERMOST_STATE(swg::$INNERMOST_STATE$)
     )
     controller_inst (
         .clk(ap_clk),

--- a/src/finn/custom_op/fpgadataflow/convolutioninputgenerator_rtl.py
+++ b/src/finn/custom_op/fpgadataflow/convolutioninputgenerator_rtl.py
@@ -617,13 +617,13 @@ class ConvolutionInputGenerator_rtl(HLSCustomOp):
             # skip innermost SIMD loop completely
             if loop_kw_iterations == 1:
                 # skip innermost KW loop completely
-                code_gen_dict["$INNERMOST_STATE$"] = [str(3)]  # STATE_LOOP_KH
+                code_gen_dict["$INNERMOST_STATE$"] = ["STATE_LOOP_KH"]
                 loop_kh_iterations -= 1  # -1 because state is initial state
             else:
-                code_gen_dict["$INNERMOST_STATE$"] = [str(2)]  # STATE_LOOP_KW
+                code_gen_dict["$INNERMOST_STATE$"] = ["STATE_LOOP_KW"]
                 loop_kw_iterations -= 1  # -1 because state is initial state
         else:
-            code_gen_dict["$INNERMOST_STATE$"] = [str(1)]  # STATE_LOOP_SIMD
+            code_gen_dict["$INNERMOST_STATE$"] = ["STATE_LOOP_SIMD"]
             loop_simd_iterations -= 1  # -1 because state is initial state
 
         cntr_bitwidth = math.ceil(
@@ -736,10 +736,10 @@ class ConvolutionInputGenerator_rtl(HLSCustomOp):
         loop_simd_iterations = 1
 
         if loop_w_iterations == 1:
-            code_gen_dict["$INNERMOST_STATE$"] = [str(5)]  # STATE_LOOP_H
+            code_gen_dict["$INNERMOST_STATE$"] = ["STATE_LOOP_H"]
             loop_h_iterations -= 1  # -1 because state is initial state
         else:
-            code_gen_dict["$INNERMOST_STATE$"] = [str(4)]  # STATE_LOOP_W
+            code_gen_dict["$INNERMOST_STATE$"] = ["STATE_LOOP_W"]
             loop_w_iterations -= 1  # -1 because state is initial state
 
         # set head and tail address increment values

--- a/src/finn/custom_op/fpgadataflow/convolutioninputgenerator_rtl.py
+++ b/src/finn/custom_op/fpgadataflow/convolutioninputgenerator_rtl.py
@@ -1064,6 +1064,9 @@ class ConvolutionInputGenerator_rtl(HLSCustomOp):
         shutil.copy2(
             os.environ["FINN_ROOT"] + "/finn-rtllib/swg/swg_common.sv", code_gen_dir
         )
+        shutil.copy2(
+            os.environ["FINN_ROOT"] + "/finn-rtllib/swg/swg_pkg.sv", code_gen_dir
+        )
 
         # set ipgen_path and ip_path so that HLS-Synth transformation
         # and stich_ip transformation do not complain
@@ -1082,6 +1085,7 @@ class ConvolutionInputGenerator_rtl(HLSCustomOp):
         code_gen_dir = self.get_nodeattr("code_gen_dir_ipgen")
         verilog_paths = [code_gen_dir]
         verilog_files = [
+            "swg_pkg.sv",
             self.get_nodeattr("gen_top_module") + "_wrapper.v",
             self.get_nodeattr("gen_top_module") + "_impl.sv",
             "swg_common.sv",
@@ -1106,6 +1110,7 @@ class ConvolutionInputGenerator_rtl(HLSCustomOp):
         code_gen_dir = self.get_nodeattr("code_gen_dir_ipgen")
 
         sourcefiles = [
+            "swg_pkg.sv",
             self.get_nodeattr("gen_top_module") + "_wrapper.v",
             self.get_nodeattr("gen_top_module") + "_impl.sv",
             "swg_common.sv",

--- a/src/finn/util/pyverilator.py
+++ b/src/finn/util/pyverilator.py
@@ -118,6 +118,8 @@ def prepare_stitched_ip_for_verilator(model):
             if not remove_entry:
                 filtered_verilog_files.append(vfile)
             remove_entry = True
+        elif "swg_pkg" in vfile:
+            continue
         else:
             filtered_verilog_files.append(vfile)
 
@@ -315,8 +317,10 @@ def pyverilate_stitched_ip(
     xpm_cdc = f"{vivado_path}/data/ip/xpm/xpm_cdc/hdl/xpm_cdc.sv"
     xpm_fifo = f"{vivado_path}/data/ip/xpm/xpm_fifo/hdl/xpm_fifo.sv"
 
+    swg_pkg = os.environ["FINN_ROOT"] + "/finn-rtllib/swg/swg_pkg.sv"
+
     sim = PyVerilator.build(
-        [top_module_file_name, xpm_fifo, xpm_memory, xpm_cdc],
+        [swg_pkg, top_module_file_name, xpm_fifo, xpm_memory, xpm_cdc],
         verilog_path=[vivado_stitch_proj_dir, verilog_header_dir],
         build_dir=build_dir,
         trace_depth=get_rtlsim_trace_depth(),

--- a/tests/fpgadataflow/test_fpgadataflow_convinputgenerator_rtl_dynamic.py
+++ b/tests/fpgadataflow/test_fpgadataflow_convinputgenerator_rtl_dynamic.py
@@ -189,6 +189,10 @@ cfg0 = {
     "ofm": 64,
     "depthwise": True,
     "pad_mode": "SAME_UPPER",
+    # run synthesis for one configuration
+    # this helped expose a bug in enum decls previously
+    # (which config the synth runs on does not matter)
+    "do_synth": True,
 }
 cfg1 = {
     "idims": [(32, 16), (16, 8)],
@@ -198,6 +202,7 @@ cfg1 = {
     "ofm": 8,
     "depthwise": False,
     "pad_mode": "SAME_UPPER",
+    "do_synth": False,
 }
 cfg2 = {
     "idims": [(64, 128), (2, 4)],
@@ -207,6 +212,7 @@ cfg2 = {
     "ofm": 64,
     "depthwise": True,
     "pad_mode": "SAME_UPPER",
+    "do_synth": False,
 }
 
 
@@ -215,6 +221,7 @@ cfg2 = {
 @pytest.mark.vivado
 @pytest.mark.fpgadataflow
 def test_fpgadataflow_conv_dynamic(cfg):
+    do_synth = cfg["do_synth"]
     pad_mode = cfg["pad_mode"]
     depthwise = cfg["depthwise"]
     idims = cfg["idims"]
@@ -292,7 +299,7 @@ def test_fpgadataflow_conv_dynamic(cfg):
     model = model.transform(GiveReadableTensorNames())
     model = model.transform(PrepareIP("xc7z020clg400-1", 5))
     model = model.transform(HLSSynthIP())
-    model = model.transform(CreateStitchedIP("xc7z020clg400-1", 5))
+    model = model.transform(CreateStitchedIP("xc7z020clg400-1", 5, vitis=do_synth))
     model.set_metadata_prop("exec_mode", "rtlsim")
 
     # loop through experiment configurations


### PR DESCRIPTION
When synthesizing DSWG instances with  the latest `dev` Vivado raises the following error:
```
ERROR: [Synth 8-9123] an enum variable may only be assigned the same enum typed variable or one of its values [/scratch/finn/build/code_gen_ipgen_ConvolutionInputGenerator_rtl_0_cf9bvsk5/ConvolutionInputGenerator_rtl_0_impl.sv:73]
```

This is due to a variable in the generated SystemVerilog code

```
    // state and counters
    typedef enum logic [2:0] {
        STATE_START,
        STATE_LOOP_SIMD,
        STATE_LOOP_KW,
        STATE_LOOP_KH,
        STATE_LOOP_W,
        STATE_LOOP_H
    }  state_e;
    state_e  State = 1; // this value of 1 is not safe to use for the enum, STATE_LOOP_SIMD should be used
```
The fix is to use the corresponding enum values (e.g. `STATE_LOOP_SIMD` instead of `1`). However, changing this in the codegen breaks the non-dynamic SWG since it uses the same value as a constructor parameter, so fixing that in turn requires moving the definition of the enum to the global scope. To avoid errors due to possible multiple definitions, I've added `ifdef` guards around it.

Note that the error was previously not detected because the DSWG unit tests do not include any synthesis. This PR adds synthesis to one of the DSWG testcases to detect future occurances of the issue.