### PR TITLE
Hotfix: Pin IPython version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ sphinx_rtd_theme==0.5.0
 toposort==1.5
 vcdvcd==1.0.5
 wget==3.2
+ipython==8.12.2


### PR DESCRIPTION
The newest IPython version (8.13) no longer supports Python 3.8.

Solution: Pin to 8.12.2 until we switch to a newer Python version / base Docker image.