### PR TITLE
rename all pynq variables to zynq

### DIFF
--- a/notebooks/end2end_example/bnn-pynq/tfc_end2end_example.ipynb
+++ b/notebooks/end2end_example/bnn-pynq/tfc_end2end_example.ipynb
@@ -631,8 +631,8 @@
    "outputs": [],
    "source": [
     "# print the names of the supported PYNQ boards\n",
-    "from finn.util.basic import pynq_part_map\n",
-    "print(pynq_part_map.keys())"
+    "from finn.util.basic import zynq_part_map\n",
+    "print(zynq_part_map.keys())"
    ]
   },
   {
@@ -643,7 +643,7 @@
    "source": [
     "# change this if you have a different PYNQ board, see list above\n",
     "pynq_board = \"Pynq-Z1\"\n",
-    "fpga_part = pynq_part_map[pynq_board]\n",
+    "fpga_part = zynq_part_map[pynq_board]\n",
     "target_clk_ns = 10"
    ]
   },

--- a/notebooks/end2end_example/cybersecurity/3-build-accelerator-with-finn.ipynb
+++ b/notebooks/end2end_example/cybersecurity/3-build-accelerator-with-finn.ipynb
@@ -78,7 +78,7 @@
     "### Configuring the Board and FPGA Part <a id=\"config_fpga\"></a>\n",
     "\n",
     "* `fpga_part`: Xilinx FPGA part to be used for synthesis, can be left unspecified to be inferred from `board` below, or specified explicitly for e.g. out-of-context synthesis.\n",
-    "* `board`: target Xilinx Zynq or Alveo board for generating accelerators integrated into a shell. See the `pynq_part_map` and `alveo_part_map` dicts in [this file](https://github.com/Xilinx/finn-base/blob/dev/src/finn/util/basic.py#L41) for a list of possible boards.\n",
+    "* `board`: target Xilinx Zynq or Alveo board for generating accelerators integrated into a shell. See the `zynq_part_map` and `alveo_part_map` dicts in [this file](https://github.com/Xilinx/finn-base/blob/dev/src/finn/util/basic.py#L41) for a list of possible boards.\n",
     "* `shell_flow_type`: the target [shell flow type](https://finn-dev.readthedocs.io/en/latest/source_code/finn.builder.html#finn.builder.build_dataflow_config.ShellFlowType), only needed for generating full bitfiles where the FINN design is integrated into a shell (so only needed if `BITFILE` is selected) \n",
     "\n",
     "### Configuring the Performance <a id=\"config_perf\"></a>\n",

--- a/src/finn/builder/build_dataflow_config.py
+++ b/src/finn/builder/build_dataflow_config.py
@@ -34,7 +34,7 @@ from enum import Enum
 from typing import Any, List, Optional
 
 from finn.transformation.fpgadataflow.vitis_build import VitisOptStrategy
-from finn.util.basic import alveo_default_platform, alveo_part_map, pynq_part_map
+from finn.util.basic import alveo_default_platform, alveo_part_map, zynq_part_map
 
 
 class AutoFIFOSizingMethod(str, Enum):
@@ -374,7 +374,7 @@ class DataflowBuildConfig:
         if self.fpga_part is None:
             # lookup from part map if not specified
             if self.shell_flow_type == ShellFlowType.VIVADO_ZYNQ:
-                return pynq_part_map[self.board]
+                return zynq_part_map[self.board]
             elif self.shell_flow_type == ShellFlowType.VITIS_ALVEO:
                 return alveo_part_map[self.board]
             else:

--- a/src/finn/transformation/fpgadataflow/make_zynq_proj.py
+++ b/src/finn/transformation/fpgadataflow/make_zynq_proj.py
@@ -45,7 +45,7 @@ from finn.transformation.fpgadataflow.insert_dwc import InsertDWC
 from finn.transformation.fpgadataflow.insert_fifo import InsertFIFO
 from finn.transformation.fpgadataflow.insert_iodma import InsertIODMA
 from finn.transformation.fpgadataflow.prepare_ip import PrepareIP
-from finn.util.basic import make_build_dir, pynq_native_port_width, pynq_part_map
+from finn.util.basic import make_build_dir, zynq_native_port_width, zynq_part_map
 
 from . import templates
 
@@ -250,7 +250,7 @@ class MakeZYNQProject(Transformation):
                     axilite_idx,
                     aximm_idx,
                     self.platform,
-                    pynq_part_map[self.platform],
+                    zynq_part_map[self.platform],
                     config,
                     self.enable_debug,
                 )
@@ -319,8 +319,8 @@ class ZynqBuild(Transformation):
         partition_model_dir=None,
     ):
         super().__init__()
-        self.fpga_part = pynq_part_map[platform]
-        self.axi_port_width = pynq_native_port_width[platform]
+        self.fpga_part = zynq_part_map[platform]
+        self.axi_port_width = zynq_native_port_width[platform]
         self.period_ns = period_ns
         self.platform = platform
         self.enable_debug = enable_debug

--- a/src/finn/util/basic.py
+++ b/src/finn/util/basic.py
@@ -32,27 +32,27 @@ import sys
 import tempfile
 
 # mapping from PYNQ board names to FPGA part names
-pynq_part_map = dict()
-pynq_part_map["Ultra96"] = "xczu3eg-sbva484-1-e"
-pynq_part_map["Pynq-Z1"] = "xc7z020clg400-1"
-pynq_part_map["Pynq-Z2"] = "xc7z020clg400-1"
-pynq_part_map["ZCU102"] = "xczu9eg-ffvb1156-2-e"
-pynq_part_map["ZCU104"] = "xczu7ev-ffvc1156-2-e"
-pynq_part_map["ZCU111"] = "xczu28dr-ffvg1517-2-e"
-pynq_part_map["RFSoC2x2"] = "xczu28dr-ffvg1517-2-e"
-pynq_part_map["KV260_SOM"] = "xck26-sfvc784-2LV-c"
+zynq_part_map = dict()
+zynq_part_map["Ultra96"] = "xczu3eg-sbva484-1-e"
+zynq_part_map["Pynq-Z1"] = "xc7z020clg400-1"
+zynq_part_map["Pynq-Z2"] = "xc7z020clg400-1"
+zynq_part_map["ZCU102"] = "xczu9eg-ffvb1156-2-e"
+zynq_part_map["ZCU104"] = "xczu7ev-ffvc1156-2-e"
+zynq_part_map["ZCU111"] = "xczu28dr-ffvg1517-2-e"
+zynq_part_map["RFSoC2x2"] = "xczu28dr-ffvg1517-2-e"
+zynq_part_map["KV260_SOM"] = "xck26-sfvc784-2LV-c"
 
 
 # native AXI HP port width (in bits) for PYNQ boards
-pynq_native_port_width = dict()
-pynq_native_port_width["Pynq-Z1"] = 64
-pynq_native_port_width["Pynq-Z2"] = 64
-pynq_native_port_width["Ultra96"] = 128
-pynq_native_port_width["ZCU102"] = 128
-pynq_native_port_width["ZCU104"] = 128
-pynq_native_port_width["ZCU111"] = 128
-pynq_native_port_width["RFSoC2x2"] = 128
-pynq_native_port_width["KV260_SOM"] = 128
+zynq_native_port_width = dict()
+zynq_native_port_width["Pynq-Z1"] = 64
+zynq_native_port_width["Pynq-Z2"] = 64
+zynq_native_port_width["Ultra96"] = 128
+zynq_native_port_width["ZCU102"] = 128
+zynq_native_port_width["ZCU104"] = 128
+zynq_native_port_width["ZCU111"] = 128
+zynq_native_port_width["RFSoC2x2"] = 128
+zynq_native_port_width["KV260_SOM"] = 128
 
 # Alveo device and platform mappings
 alveo_part_map = dict()

--- a/src/finn/util/test.py
+++ b/src/finn/util/test.py
@@ -44,7 +44,7 @@ from qonnx.custom_op.registry import getCustomOp
 from finn.core.onnx_exec import execute_onnx
 from finn.transformation.fpgadataflow.make_zynq_proj import ZynqBuild
 from finn.transformation.fpgadataflow.vitis_build import VitisBuild, VitisOptStrategy
-from finn.util.basic import alveo_default_platform, alveo_part_map, pynq_part_map
+from finn.util.basic import alveo_default_platform, alveo_part_map, zynq_part_map
 
 # map of (wbits,abits) -> model
 example_map = {
@@ -113,7 +113,7 @@ def get_build_env(kind, target_clk_ns):
     ret = {}
     if kind == "zynq":
         ret["board"] = os.getenv("PYNQ_BOARD", default="Pynq-Z1")
-        ret["part"] = pynq_part_map[ret["board"]]
+        ret["part"] = zynq_part_map[ret["board"]]
         ret["ip"] = os.getenv("PYNQ_IP", "")
         ret["username"] = os.getenv("PYNQ_USERNAME", "xilinx")
         ret["password"] = os.getenv("PYNQ_PASSWORD", "xilinx")

--- a/tests/fpgadataflow/test_fpgadataflow_fmpadding.py
+++ b/tests/fpgadataflow/test_fpgadataflow_fmpadding.py
@@ -46,10 +46,10 @@ from finn.transformation.fpgadataflow.prepare_cppsim import PrepareCppSim
 from finn.transformation.fpgadataflow.prepare_ip import PrepareIP
 from finn.transformation.fpgadataflow.prepare_rtlsim import PrepareRTLSim
 from finn.transformation.fpgadataflow.set_exec_mode import SetExecMode
-from finn.util.basic import pynq_part_map
+from finn.util.basic import zynq_part_map
 
 test_pynq_board = os.getenv("PYNQ_BOARD", default="Pynq-Z1")
-test_fpga_part = pynq_part_map[test_pynq_board]
+test_fpga_part = zynq_part_map[test_pynq_board]
 target_clk_ns = 10
 
 

--- a/tests/fpgadataflow/test_fpgadataflow_ipstitch.py
+++ b/tests/fpgadataflow/test_fpgadataflow_ipstitch.py
@@ -51,12 +51,12 @@ from finn.transformation.fpgadataflow.make_zynq_proj import ZynqBuild
 from finn.transformation.fpgadataflow.prepare_ip import PrepareIP
 from finn.transformation.fpgadataflow.synth_ooc import SynthOutOfContext
 from finn.transformation.fpgadataflow.vitis_build import VitisBuild
-from finn.util.basic import alveo_default_platform, alveo_part_map, pynq_part_map
+from finn.util.basic import alveo_default_platform, alveo_part_map, zynq_part_map
 from finn.util.pyverilator import pyverilate_stitched_ip
 from finn.util.test import load_test_checkpoint_or_skip
 
 test_pynq_board = os.getenv("PYNQ_BOARD", default="Pynq-Z1")
-test_fpga_part = pynq_part_map[test_pynq_board]
+test_fpga_part = zynq_part_map[test_pynq_board]
 
 ip_stitch_model_dir = os.environ["FINN_BUILD_DIR"]
 


### PR DESCRIPTION
As more board support became available in FINN, more Zynq devices were added. As a Pynq is  Zynq device, it makes sense to abstract the variable names as such.