### PR TITLE
Remove outdated stream depth pragma from decoupled mode

### DIFF
--- a/src/finn/custom_op/fpgadataflow/matrixvectoractivation.py
+++ b/src/finn/custom_op/fpgadataflow/matrixvectoractivation.py
@@ -1274,9 +1274,6 @@ class MatrixVectorActivation(HLSCustomOp):
             self.code_gen_dict["$PRAGMAS$"].append(
                 "#pragma HLS INTERFACE axis port=weights_" + self.hls_sname()
             )
-            self.code_gen_dict["$PRAGMAS$"].append(
-                "#pragma HLS stream depth=8 variable=weights_" + self.hls_sname()
-            )
 
         else:
             raise Exception(

--- a/src/finn/custom_op/fpgadataflow/vectorvectoractivation.py
+++ b/src/finn/custom_op/fpgadataflow/vectorvectoractivation.py
@@ -979,9 +979,6 @@ class VectorVectorActivation(HLSCustomOp):
             self.code_gen_dict["$PRAGMAS$"].append(
                 "#pragma HLS INTERFACE axis port=weights_" + self.hls_sname()
             )
-            self.code_gen_dict["$PRAGMAS$"].append(
-                "#pragma HLS stream depth=8 variable=weights_" + self.hls_sname()
-            )
         else:
             raise Exception(
                 """Please set mem_mode to "const", "decoupled", or external,


### PR DESCRIPTION
Remove outdated stream depth pragma from HLS code generation for decoupled mode in MVAU and VVAU