### PR TITLE
Singularity container support for run script

### DIFF
--- a/.github/workflows/singularity-quicktest.yml
+++ b/.github/workflows/singularity-quicktest.yml
@@ -1,0 +1,47 @@
+name: SingularityQuicktest
+
+on:
+  pull_request:
+    branches: [ apptainer_testing ]
+  push:
+    branches: [ apptainer_testing ]
+
+jobs:
+  build_quicktest_singularity:
+    name: Build and quicktest Singularity container
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Reclaim storage
+        run: |
+          docker image prune -a -f
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Docker
+        uses: docker/setup-buildx-action@v2
+        with:
+          driver: docker
+      - name: Set up Singularity
+        run: |
+          sudo add-apt-repository -y ppa:apptainer/ppa
+          sudo apt update
+          sudo apt install -y apptainer
+          alias singularity="apptainer"
+      - name: Build Docker image
+        uses: docker/build-push-action@v4
+        with:
+          file: docker/Dockerfile.finn
+          context: .
+          load: true
+          no-cache: true
+          tags: finn_docker_export:latest
+      - name: Build Singularity image
+        run: |
+          mkdir $GITHUB_WORKSPACE/singularity_tmp
+          export APPTAINER_TMPDIR=$GITHUB_WORKSPACE/singularity_tmp
+          singularity build --disable-cache finn_singularity_image.sif docker-daemon://finn_docker_export:latest
+      - name: Run quicktest
+        run: |
+          export FINN_SINGULARITY=finn_singularity_image.sif
+          ./run-docker.sh quicktest

--- a/.github/workflows/singularity-quicktest.yml
+++ b/.github/workflows/singularity-quicktest.yml
@@ -2,9 +2,9 @@ name: SingularityQuicktest
 
 on:
   pull_request:
-    branches: [ apptainer_testing ]
+    branches: [ dev ]
   push:
-    branches: [ apptainer_testing ]
+    branches: [ dev ]
 
 jobs:
   build_quicktest_singularity:

--- a/docker/Dockerfile.finn
+++ b/docker/Dockerfile.finn
@@ -60,7 +60,9 @@ RUN apt-get update && \
     lsb-core \
     python3 \
     python-is-python3 \
-    python3-pip
+    python3-pip \
+    python3-setuptools-scm \
+    python3-venv
 RUN echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config
 RUN locale-gen "en_US.UTF-8"
 

--- a/docker/finn_entrypoint.sh
+++ b/docker/finn_entrypoint.sh
@@ -56,7 +56,9 @@ recho () {
 
 # qonnx (using workaround for https://github.com/pypa/pip/issues/7953)
 # to be fixed in future Ubuntu versions (https://bugs.launchpad.net/ubuntu/+source/setuptools/+bug/1994016)
-pip install --no-build-isolation --no-warn-script-location -e ${FINN_ROOT}/deps/qonnx
+mv ${FINN_ROOT}/deps/qonnx/pyproject.toml ${FINN_ROOT}/deps/qonnx/pyproject.tmp
+pip install --user -e ${FINN_ROOT}/deps/qonnx
+mv ${FINN_ROOT}/deps/qonnx/pyproject.tmp ${FINN_ROOT}/deps/qonnx/pyproject.toml
 # finn-experimental
 pip install --user -e ${FINN_ROOT}/deps/finn-experimental
 # brevitas

--- a/docs/finn/getting_started.rst
+++ b/docs/finn/getting_started.rst
@@ -116,6 +116,7 @@ These are summarized below:
 * (optional) ``FINN_SKIP_DEP_REPOS`` (default "0") skips the download of FINN dependency repos (uses the ones already downloaded under deps/.
 * (optional) ``NVIDIA_VISIBLE_DEVICES`` (default "") specifies specific Nvidia GPUs to use in Docker container. Possible values are a comma-separated list of GPU UUID(s) or index(es) e.g. ``0,1,2``, ``all``, ``none``, or void/empty/unset.
 * (optional) ``DOCKER_BUILDKIT`` (default "1") enables `Docker BuildKit <https://docs.docker.com/develop/develop-images/build_enhancements/>`_ for faster Docker image rebuilding (recommended).
+* (optional) ``FINN_SINGULARITY`` (default "") points to a pre-built Singularity image to use instead of the Docker image. Singularity support is experimental and intended only for systems where Docker is unavailable. Does not support GPUs.
 
 General FINN Docker tips
 ************************

--- a/run-docker.sh
+++ b/run-docker.sh
@@ -97,6 +97,7 @@ SCRIPTPATH=$(dirname "$SCRIPT")
 : ${OHMYXILINX="${SCRIPTPATH}/deps/oh-my-xilinx"}
 : ${NVIDIA_VISIBLE_DEVICES=""}
 : ${DOCKER_BUILDKIT="1"}
+: ${FINN_SINGULARITY=""}
 
 DOCKER_INTERACTIVE=""
 
@@ -119,8 +120,10 @@ elif [ "$1" = "notebook" ]; then
   DOCKER_CMD="jupyter notebook --allow-root --no-browser --ip=0.0.0.0 --port $JUPYTER_PORT $JUPYTER_PASSWD_ARG notebooks"
   FINN_DOCKER_EXTRA+="-e JUPYTER_PORT=$JUPYTER_PORT "
   FINN_DOCKER_EXTRA+="-e NETRON_PORT=$NETRON_PORT "
-  FINN_DOCKER_EXTRA+="-p $JUPYTER_PORT:$JUPYTER_PORT "
-  FINN_DOCKER_EXTRA+="-p $NETRON_PORT:$NETRON_PORT "
+  if [ -z "$FINN_SINGULARITY" ]; then
+    FINN_DOCKER_EXTRA+="-p $JUPYTER_PORT:$JUPYTER_PORT "
+    FINN_DOCKER_EXTRA+="-p $NETRON_PORT:$NETRON_PORT "
+  fi
 elif [ "$1" = "build_dataflow" ]; then
   BUILD_DATAFLOW_DIR=$(readlink -f "$2")
   FINN_DOCKER_EXTRA+="-v $BUILD_DATAFLOW_DIR:$BUILD_DATAFLOW_DIR "
@@ -146,7 +149,7 @@ else
 fi
 
 
-if [ "$FINN_DOCKER_GPU" != 0 ];then
+if [ "$FINN_DOCKER_GPU" != 0 ] && [ -z "$FINN_SINGULARITY" ];then
   gecho "nvidia-docker detected, enabling GPUs"
   if [ ! -z "$NVIDIA_VISIBLE_DEVICES" ];then
     FINN_DOCKER_EXTRA+="--runtime nvidia -e NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES "
@@ -177,7 +180,7 @@ if [ "$FINN_SKIP_DEP_REPOS" = "0" ]; then
 fi
 
 # Build the FINN Docker image
-if [ "$FINN_DOCKER_PREBUILT" = "0" ]; then
+if [ "$FINN_DOCKER_PREBUILT" = "0" ] && [ -z "$FINN_SINGULARITY" ]; then
   # Need to ensure this is done within the finn/ root folder:
   OLD_PWD=$(pwd)
   cd $SCRIPTPATH
@@ -187,9 +190,8 @@ fi
 # Launch container with current directory mounted
 # important to pass the --init flag here for correct Vivado operation, see:
 # https://stackoverflow.com/questions/55733058/vivado-synthesis-hangs-in-docker-container-spawned-by-jenkins
-DOCKER_EXEC="docker run -t --rm $DOCKER_INTERACTIVE --tty --init "
-DOCKER_EXEC+="--hostname $DOCKER_INST_NAME "
-DOCKER_EXEC+="-e SHELL=/bin/bash "
+DOCKER_BASE="docker run -t --rm $DOCKER_INTERACTIVE --tty --init --hostname $DOCKER_INST_NAME "
+DOCKER_EXEC="-e SHELL=/bin/bash "
 DOCKER_EXEC+="-w $SCRIPTPATH "
 DOCKER_EXEC+="-v $SCRIPTPATH:$SCRIPTPATH "
 DOCKER_EXEC+="-v $FINN_HOST_BUILD_DIR:$FINN_HOST_BUILD_DIR "
@@ -207,7 +209,7 @@ DOCKER_EXEC+="-e NUM_DEFAULT_WORKERS=$NUM_DEFAULT_WORKERS "
 # Workaround for FlexLM issue, see:
 # https://community.flexera.com/t5/InstallAnywhere-Forum/Issues-when-running-Xilinx-tools-or-Other-vendor-tools-in-docker/m-p/245820#M10647
 DOCKER_EXEC+="-e LD_PRELOAD=/lib/x86_64-linux-gnu/libudev.so.1 "
-if [ "$FINN_DOCKER_RUN_AS_ROOT" = "0" ];then
+if [ "$FINN_DOCKER_RUN_AS_ROOT" = "0" ] && [ -z "$FINN_SINGULARITY" ];then
   DOCKER_EXEC+="-v /etc/group:/etc/group:ro "
   DOCKER_EXEC+="-v /etc/passwd:/etc/passwd:ro "
   DOCKER_EXEC+="-v /etc/shadow:/etc/shadow:ro "
@@ -247,6 +249,17 @@ if [ ! -z "$FINN_XILINX_PATH" ];then
   fi
 fi
 DOCKER_EXEC+="$FINN_DOCKER_EXTRA "
-DOCKER_EXEC+="$FINN_DOCKER_TAG $DOCKER_CMD"
 
-$DOCKER_EXEC
+if [ -z "$FINN_SINGULARITY" ];then
+  CMD_TO_RUN="$DOCKER_BASE $DOCKER_EXEC $FINN_DOCKER_TAG $DOCKER_CMD"
+else
+  SINGULARITY_BASE="singularity exec"
+  # Replace command options for Singularity
+  SINGULARITY_EXEC="${DOCKER_EXEC//"-e "/"--env "}"
+  SINGULARITY_EXEC="${SINGULARITY_EXEC//"-v "/"-B "}"
+  SINGULARITY_EXEC="${SINGULARITY_EXEC//"-w "/"--pwd "}"
+  CMD_TO_RUN="$SINGULARITY_BASE $SINGULARITY_EXEC $FINN_SINGULARITY /usr/local/bin/finn_entrypoint.sh $DOCKER_CMD"
+  gecho "FINN_SINGULARITY is set, launching Singularity container instead of Docker"
+fi
+
+$CMD_TO_RUN


### PR DESCRIPTION
Extends run-docker.sh to support execution of FINN inside a Singularity environment instead of Docker. Expects the Singularity image to be pre-built (from the normal Docker image) by the user. We use a GHA in a different repo for this.

I also added some documentation to the "Getting Started" page and a GHA that tests this feature by building a Singularity container from the FINN Docker image and running quicktest inside it.

**Example usage:**

1. Set the new env var to the Singularity image (path or registry URL) you want to use:
`export FINN_SINGULARITY=oras://ghcr.io/eki-project/experiment-manager/finn_apptainer_xilinx:dev`
_(this points to a public nightly build of the official dev branch)_

1. Run `run-docker.sh` normally