### PR TITLE
[INFRA] Exit run-docker if tool paths are invalid

### DIFF
--- a/run-docker.sh
+++ b/run-docker.sh
@@ -226,15 +226,25 @@ if [ ! -z "$FINN_XILINX_PATH" ];then
   VITIS_PATH="$FINN_XILINX_PATH/Vitis/$FINN_XILINX_VERSION"
   HLS_PATH="$FINN_XILINX_PATH/Vitis_HLS/$FINN_XILINX_VERSION"
   DOCKER_EXEC+="-v $FINN_XILINX_PATH:$FINN_XILINX_PATH "
+  PATH_FLAG=0
   if [ -d "$VIVADO_PATH" ];then
     DOCKER_EXEC+="-e "XILINX_VIVADO=$VIVADO_PATH" "
     DOCKER_EXEC+="-e VIVADO_PATH=$VIVADO_PATH "
+  else
+    recho "VIVADO_PATH: ${VIVADO_PATH} does not exist"
+    PATH_FLAG=1
   fi
   if [ -d "$HLS_PATH" ];then
     DOCKER_EXEC+="-e HLS_PATH=$HLS_PATH "
+  else
+    recho "HLS_PATH: ${HLS_PATH} does not exist"
+    PATH_FLAG=1
   fi
   if [ -d "$VITIS_PATH" ];then
     DOCKER_EXEC+="-e VITIS_PATH=$VITIS_PATH "
+  else
+    recho "VITIS_PATH: ${VITIS_PATH} does not exist"
+    PATH_FLAG=1
   fi
   if [ -d "$PLATFORM_REPO_PATHS" ];then
     DOCKER_EXEC+="-v $PLATFORM_REPO_PATHS:$PLATFORM_REPO_PATHS "
@@ -244,6 +254,12 @@ if [ ! -z "$FINN_XILINX_PATH" ];then
     DOCKER_EXEC+="-e ALVEO_PASSWORD=$ALVEO_PASSWORD "
     DOCKER_EXEC+="-e ALVEO_BOARD=$ALVEO_BOARD "
     DOCKER_EXEC+="-e ALVEO_TARGET_DIR=$ALVEO_TARGET_DIR "
+  else
+    recho "PLATFORM_REPO_PATHS: ${PLATFORM_REPO_PATHS} does not exist"
+    PATH_FLAG=1
+  fi
+  if [ $PATH_FLAG != 0 ];then
+    exit -1
   fi
 fi
 DOCKER_EXEC+="$FINN_DOCKER_EXTRA "


### PR DESCRIPTION
If a tool path is invalid (doesn't exist) then run-docker doesn't pass it onto docker. This can lead to errors much later in the build process. Exiting early brings the issue to the users attention immediately.

If a path doesn't exist, a warning will indicate exactly which variables are incorrect before the script exits. Here is an example of all paths badly formed:
```
VIVADO_PATH: /proj/xbuilds/SWIP/2022.2_1014_8888/installs/lin645/Vivado/2022.2 does not exist
HLS_PATH: /proj/xbuilds/SWIP/2022.2_1014_8888/installs/lin645/Vitis_HLS/2022.2 does not exist
VITIS_PATH: /proj/xbuilds/SWIP/2022.2_1014_8888/installs/lin645/Vitis/2022.2 does not exist
PLATFORM_REPO_PATHS: /opt/xilinx/platforms does not exist
```