### PR TITLE
[Driver] Workaround for pynq on alveo bug

### DIFF
--- a/src/finn/qnn-data/templates/driver/driver_base.py
+++ b/src/finn/qnn-data/templates/driver/driver_base.py
@@ -197,8 +197,7 @@ class FINNExampleOverlay(Overlay):
                         # Pynq for Alveo uses tinynumpy under the hood. There is a bug when going
                         # from a tinynumpy.ndarray to numpy.ndarray. To work around this, we first
                         # convert the tinynumpy.ndarray to a list and then copy the list to a
-                        # numpy.ndarray. This shouldn't affect the non-alveo platforms so no need to
-                        # check platform.
+                        # numpy.ndarray.
                         new_w = np.copy(
                             list(layer_mmio.array[: layer_w.shape[0]]), dtype=layer_w.dtype
                         )

--- a/src/finn/qnn-data/templates/driver/driver_base.py
+++ b/src/finn/qnn-data/templates/driver/driver_base.py
@@ -193,7 +193,15 @@ class FINNExampleOverlay(Overlay):
                 layer_w = rt_weight_dict[(sdp_ind, layer_ind)]
                 layer_mmio.write_mm(0, layer_w.tobytes())
                 if verify:
-                    new_w = np.copy(layer_mmio.array[: layer_w.shape[0]])
+                    if self.platform == "alveo":
+                        # Pynq for Alveo uses tinynumpy under the hood. There is a bug when going
+                        # from a tinynumpy.ndarray to numpy.ndarray. To work around this, we first
+                        # convert the tinynumpy.ndarray to a list and then copy the list to a
+                        # numpy.ndarray. This shouldn't affect the non-alveo platforms so no need to
+                        # check platform.
+                        new_w = np.copy(list(layer_mmio.array[: layer_w.shape[0]]), dtype=layer_w.dtype)
+                    else:
+                        new_w = np.copy(layer_mmio.array[: layer_w.shape[0]])
                     assert (layer_w == new_w).all()
         if flush_accel:
             # run accelerator to flush any stale weights from weight streamer FIFOs

--- a/src/finn/qnn-data/templates/driver/driver_base.py
+++ b/src/finn/qnn-data/templates/driver/driver_base.py
@@ -199,7 +199,9 @@ class FINNExampleOverlay(Overlay):
                         # convert the tinynumpy.ndarray to a list and then copy the list to a
                         # numpy.ndarray. This shouldn't affect the non-alveo platforms so no need to
                         # check platform.
-                        new_w = np.copy(list(layer_mmio.array[: layer_w.shape[0]]), dtype=layer_w.dtype)
+                        new_w = np.copy(
+                            list(layer_mmio.array[: layer_w.shape[0]]), dtype=layer_w.dtype
+                        )
                     else:
                         new_w = np.copy(layer_mmio.array[: layer_w.shape[0]])
                     assert (layer_w == new_w).all()


### PR DESCRIPTION
Pynq on alveo uses tinynumpy under the hood which has a bug when converting between tinynumpy.ndarray and numpy.ndarray. Workaround is to first convert to list and then to numpy.ndarray.