### PR TITLE
Add support for Coyote shell

### DIFF
--- a/docker/Dockerfile.finn
+++ b/docker/Dockerfile.finn
@@ -126,6 +126,8 @@ RUN pip install tclwrapper==0.0.1
 # extra environment variables for FINN compiler
 ENV VIVADO_IP_CACHE "/tmp/vivado_ip_cache"
 
+RUN apt-get install -y cmake
+
 COPY docker/finn_entrypoint.sh /usr/local/bin/
 COPY docker/quicktest.sh /usr/local/bin/
 RUN chmod 755 /usr/local/bin/finn_entrypoint.sh

--- a/src/finn/builder/build_dataflow_config.py
+++ b/src/finn/builder/build_dataflow_config.py
@@ -50,6 +50,7 @@ class ShellFlowType(str, Enum):
 
     VIVADO_ZYNQ = "vivado_zynq"
     VITIS_ALVEO = "vitis_alveo"
+    COYOTE_ALVEO = "coyote_alveo"
 
 
 class DataflowOutputType(str, Enum):
@@ -291,6 +292,7 @@ class DataflowBuildConfig:
 
     #: Which Vitis platform will be used.
     #: Only relevant when `shell_flow_type = ShellFlowType.VITIS_ALVEO`
+    # or `shell_flow_type = ShellFlowType.COYOTE_ALVEO`
     #: e.g. "xilinx_u250_xdma_201830_2"
     #: If not specified but "board" is specified, will use the FINN
     #: default (if any) for that Alveo board
@@ -298,11 +300,13 @@ class DataflowBuildConfig:
 
     #: Path to JSON config file assigning each layer to an SLR.
     #: Only relevant when `shell_flow_type = ShellFlowType.VITIS_ALVEO`
+    # or `shell_flow_type = ShellFlowType.COYOTE_ALVEO`
     #: Will be applied with :py:mod:`qonnx.transformation.general.ApplyConfig`
     vitis_floorplan_file: Optional[str] = None
 
     #: Vitis optimization strategy
     #: Only relevant when `shell_flow_type = ShellFlowType.VITIS_ALVEO`
+    # or `shell_flow_type = ShellFlowType.COYOTE_ALVEO`
     vitis_opt_strategy: Optional[VitisOptStrategyCfg] = VitisOptStrategyCfg.DEFAULT
 
     #: Whether intermediate ONNX files will be saved during the build process.
@@ -361,7 +365,10 @@ class DataflowBuildConfig:
     def _resolve_driver_platform(self):
         if self.shell_flow_type == ShellFlowType.VIVADO_ZYNQ:
             return "zynq-iodma"
-        elif self.shell_flow_type == ShellFlowType.VITIS_ALVEO:
+        elif (
+            self.shell_flow_type == ShellFlowType.VITIS_ALVEO
+            or self.shell_flow_type == ShellFlowType.COYOTE_ALVEO
+        ):
             return "alveo"
         else:
             raise Exception("Couldn't resolve driver platform for " + str(self.shell_flow_type))
@@ -371,7 +378,10 @@ class DataflowBuildConfig:
             # lookup from part map if not specified
             if self.shell_flow_type == ShellFlowType.VIVADO_ZYNQ:
                 return pynq_part_map[self.board]
-            elif self.shell_flow_type == ShellFlowType.VITIS_ALVEO:
+            elif (
+                self.shell_flow_type == ShellFlowType.VITIS_ALVEO
+                or self.shell_flow_type == ShellFlowType.COYOTE_ALVEO
+            ):
                 return alveo_part_map[self.board]
             else:
                 raise Exception("Couldn't resolve fpga_part for " + self.board)

--- a/src/finn/builder/build_dataflow_steps.py
+++ b/src/finn/builder/build_dataflow_steps.py
@@ -807,7 +807,7 @@ def step_synthesize_bitfile(model: ModelWrapper, cfg: DataflowBuildConfig):
                     signature=cfg.signature,
                 )
             )
-            copy_tree(model.get_metadata_prop("coyote_dir"), cfg.output_dir + "/coyote_proj")
+            copy_tree(model.get_metadata_prop("bitstream"), bitfile_dir)
         else:
             raise Exception("Unrecognized shell_flow_type: " + str(cfg.shell_flow_type))
         print("Bitfile written into " + bitfile_dir)

--- a/src/finn/transformation/fpgadataflow/coyote_build.py
+++ b/src/finn/transformation/fpgadataflow/coyote_build.py
@@ -27,14 +27,16 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
+import json
 import os
 import subprocess
-from dataclasses import dataclass
+from abc import ABC, abstractmethod
+from enum import Enum
 from pathlib import Path
 from qonnx.core.modelwrapper import ModelWrapper
 from qonnx.transformation.base import Transformation
 from qonnx.transformation.general import GiveUniqueNodeNames
-from typing import List, Optional
+from typing import List, Optional, Tuple
 from typing_extensions import TypeAlias
 
 from finn.transformation.fpgadataflow.create_stitched_ip import CreateStitchedIP
@@ -51,41 +53,118 @@ from finn.util.basic import alveo_part_map, make_build_dir
 # Interfaces
 
 
-class Interface:
+class Interface(ABC):
     Signal: TypeAlias = str
     name: Signal
-    _sub_signals: "list[Signal]"
-
-    def test(self):
-        if isinstance(self, AXI4Stream):
-            return "stream"
-        elif isinstance(self, AXI4Lite):
-            return "lite"
-
-
-@dataclass
-class AXI4Stream(Interface):
+    _sub_signals: List[Tuple[Signal, int]]
     width: int
-    tlast: bool
-    master: bool
+    owner: Optional["Instantiation"]
 
-    def __post_init__(self):
-        # TODO: Check what is on AXI converter + FINN side
-        self.sub_signals = ["tvalid", "tdata", "tlast"]
+    def __init__(self, name: str, width: int):
+        self.name = name
+        self.width = width
+        self._sub_signals = []
+        self.connected = False
+
+    @abstractmethod
+    def connect(self, design: "Design", interface: "Interface", is_external=False):
+        pass
 
 
-@dataclass
-class AXI4Lite(Interface):
-    def __post_init__(self):
-        self.sub_signals = ["d", "e", "f"]
+class Delimiter(Enum):
+    UNDERSCORE = 1
+    POINT = 2
 
 
-@dataclass
+class AXIInterface(Interface):
+    def __init__(self, name: str, width: int, delimiter: Delimiter):
+        super().__init__(name=name, width=width)
+        self.delimiter = delimiter
+
+    def connect(self, design: "Design", interface: "AXIInterface", is_external=False):
+        assert not interface.connected
+        assert not self.connected
+        if len(self._sub_signals) != len(interface._sub_signals):
+            assert isinstance(self, "AXI4Stream") and isinstance(
+                interface, "AXI4Stream"
+            ), "This should not happen"
+
+        # NOTE: This holds if the the potential additional signals are at the end of the list
+        # NOTE: This is currently the case for AXI4Stream
+        max_range = min(len(self._sub_signals), len(interface._sub_signals))
+        for i in range(max_range):
+            (sub_signal, width) = self._sub_signals[i]
+            our_interface = "%s%s%s" % (self.name, self.delimiter, sub_signal)
+            other_interface = "%s%s%s" % (interface.name, interface.delimiter, sub_signal)
+            assert self.owner is not None
+            if is_external:
+                assert interface.owner is None
+                self.owner.connections[our_interface] = other_interface
+                self.connected = True
+            else:
+                assert interface.owner is not None
+                wire = SimpleWire(
+                    name="%s_wire_%s" % (our_interface, other_interface),
+                    width=width,
+                )
+                wire.connected = True
+                design.wires.append(wire)
+                self.owner.connections[our_interface] = wire.name
+                self.connected = True
+                interface.owner.connections[other_interface] = wire.name
+                interface.connected = True
+
+
+class AXI4Stream(AXIInterface):
+    def __init__(self, name: str, width: int, tlast: bool, delimiter: Delimiter):
+        super().__init__(name, width, delimiter)
+        self.tlast = tlast
+        self._sub_signals = [("tdata", width), ("tvalid", 1), ("tready", 1)]
+        if tlast:
+            # TODO: Check if these can be larger than one depending on the number of bytes
+            # TLAST is always one bit and TKEEP is WIDTH(in bits)/8
+            self._sub_signals.append(("tlast", 1))
+            self._sub_signals.append(("tkeep", width >> 3))
+
+
+class AXI4Lite(AXIInterface):
+    def __init__(self, name: str, width: int, delimiter: Delimiter):
+        super().__init__(name, width, delimiter)
+        # Infer address width from data width
+        # bresp, rresp always two bits
+        # One wstrb bit per byte on the data bus data width (in bits) / 2^3 (=8 bits)
+        self._sub_signals = [
+            ("awaddr", width.bit_length() - 1),
+            ("awvalid", 1),
+            ("awready", 1),
+            ("wdata", width),
+            ("wstrb", width >> 3),
+            ("wvalid", 1),
+            ("wready", 1),
+            ("bresp", 2),
+            ("bvalid", 1),
+            ("bready", 1),
+            ("araddr", width.bit_length() - 1),
+            ("arvalid", 1),
+            ("arready", 1),
+            ("rdata", width),
+            ("rresp", 2),
+        ]
+
+
 class SimpleWire(Interface):
-    width: int
+    def __init__(self, name: str, width: int, generated=False):
+        super().__init__(name, width)
 
-    def __post_init__(self):
-        self.sub_signals = [self.name]
+    def connect(self, design: "Design", interface: "SimpleWire", is_external=False):
+        assert not self.connected
+
+        # NOTE: A wire is either generated and thus already connected, or belongs to the external
+        # interface
+        assert is_external
+        assert self.owner is not None
+
+        self.owner.connections[self.name] = interface.name
 
 
 class IP:
@@ -94,6 +173,7 @@ class IP:
     def __init__(
         self,
         vlnv: str,
+        module_name: str,
         interfaces: List[Interface],
         ip_repo_path: Optional[str] = None,
         config: Optional[IPConfig] = None,
@@ -104,6 +184,7 @@ class IP:
         self.config = config
         self.run_needed = run_needed
         self.interfaces = {}
+        self.module_name = module_name
         for interface in interfaces:
             self.interfaces[interface.name] = interface
 
@@ -112,34 +193,38 @@ class IP:
         return "%s:%s:%s:%s" % (vendor, library, name, version)
 
 
-class Instantiations:
+class Instantiation:
     def __init__(self, instantiation_name: str, ip: IP):
         self.instantiation_name = instantiation_name
         self.ip = ip
         self.connections = {}
+        for interface in ip.interfaces.values():
+            interface.owner = self
 
 
-@dataclass
 class ExternalInterface:
-    interfaces: List[Interface]
+    def __init__(self, interfaces: List[Interface]):
+        self.interfaces = {}
+        for interface in interfaces:
+            self.interfaces[interface.name] = interface
 
 
 class Design:
     def __init__(
         self,
-        instantiations: List[Instantiations],
+        instantiations: List[Instantiation],
         external_interface: ExternalInterface,
-        wires: List[SimpleWire],
     ):
         self.instantiations = instantiations
         self.external_interface = external_interface
-        self.wires = wires
+        self.wires = []
         self.ips = set()
         self.ip_repo_paths = set()
         # Sets of unique IPs and unique repo paths
         for instantiation in instantiations:
             self.ips.add(instantiation.ip)
-            self.ip_repo_paths.add(instantiation.ip.ip_repo_path)
+            if instantiation.ip.ip_repo_path is not None:
+                self.ip_repo_paths.add(instantiation.ip.ip_repo_path)
 
 
 class CreateStitchedIPForCoyote(Transformation):
@@ -160,7 +245,7 @@ class CreateStitchedIPForCoyote(Transformation):
         # We want dynamic True so we leave default arguments
         # Also, we only want it at the output since the Coyote interface already provides tlast to
         # the input width converter
-        if model.get_metadata_prop("accl_mode"):
+        if not json.loads(model.get_metadata_prop("accl_mode")):
             model = model.transform(InsertTLastMarker())
         model = model.transform(GiveUniqueNodeNames())
         model = model.transform(PrepareIP(self.fpga_part, self.period_ns))
@@ -180,13 +265,14 @@ class CreateStitchedIPForCoyote(Transformation):
 
 
 class GenerateCoyoteProject(Transformation):
-    def __init__(self, fpga_part):
+    def __init__(self, fpga_part, design: Design):
         super().__init__()
         self.fpga_part = fpga_part
         self.coyote_proj_dir = Path(make_build_dir(prefix="coyote_proj_"))
         self.coyote_repo_dir = self.coyote_proj_dir / "Coyote"
         self.coyote_hw_dir = self.coyote_repo_dir / "hw"
         self.coyote_hw_build_dir = self.coyote_hw_dir / "build"
+        self.design = design
 
     def generate_config(self, config: IP.IPConfig):
         config_tcl = []
@@ -200,46 +286,44 @@ class GenerateCoyoteProject(Transformation):
 
     def create_ip(
         self,
-        module_name: str,
-        vlnv: str,
-        config: Optional[IP.IPConfig] = None,
-        run_needed: bool = False,
+        ip: IP,
     ):
         tcl = []
-        tcl.append("create_ip -vlnv %s -module_name %s" % (vlnv, module_name))
-        if config is not None:
+        tcl.append("create_ip -vlnv %s -module_name %s" % (ip.vlnv, ip.module_name))
+        if ip.config is not None:
             tcl.append(
                 "set_property -dict [list %s] [get_ips %s]"
-                % (self.generate_config(config), module_name)
+                % (self.generate_config(ip.config), ip.module_name)
             )
 
         tcl.append(
             "generate_target {instantiation_template} [get_files"
             " %s/lynx/lynx.srcs/sources_1/ip/%s/%s.xci]"
-            % (self.coyote_hw_build_dir, module_name, module_name)
+            % (self.coyote_hw_build_dir, ip.module_name, ip.module_name)
         )
 
         tcl.append("update_compile_order -fileset sources_1")
         tcl.append(
             "generate_target all [get_files  %s/lynx/lynx.srcs/sources_1/ip/%s/%s.xci]"
-            % (self.coyote_hw_build_dir, module_name, module_name)
+            % (self.coyote_hw_build_dir, ip.module_name, ip.module_name)
         )
         # NOTE: Only appears for width converter. Is this necessary?
-        tcl.append("catch { config_ip_cache -export [get_ips -all %s] }" % module_name)
+        tcl.append("catch { config_ip_cache -export [get_ips -all %s] }" % ip.module_name)
 
         tcl.append(
             "export_ip_user_files -of_objects [get_files"
             " %s/lynx/lynx.srcs/sources_1/ip/%s/%s.xci]"
-            " -no_script -sync -force -quiet" % (self.coyote_hw_build_dir, module_name, module_name)
+            " -no_script -sync -force -quiet"
+            % (self.coyote_hw_build_dir, ip.module_name, ip.module_name)
         )
 
-        if run_needed:
+        if ip.run_needed:
             tcl.append(
                 "create_ip_run [get_files -of_objects [get_fileset sources_1]"
                 " %s/lynx/lynx.srcs/sources_1/ip/%s/%s.xci]"
-                % (self.coyote_hw_build_dir, module_name, module_name)
+                % (self.coyote_hw_build_dir, ip.module_name, ip.module_name)
             )
-            tcl.append("launch_runs %s_synth_1 -jobs 4" % module_name)
+            tcl.append("launch_runs %s_synth_1 -jobs 4" % ip.module_name)
         # NOTE: Seems involved. Is this required?
         tcl.append(
             "export_simulation -of_objects [get_files %s/lynx/lynx.srcs/sources_1/ip/%s/%s.xci]"
@@ -253,8 +337,8 @@ class GenerateCoyoteProject(Transformation):
             " -quiet"
             % (
                 self.coyote_hw_build_dir,
-                module_name,
-                module_name,
+                ip.module_name,
+                ip.module_name,
                 self.coyote_hw_build_dir,
                 self.coyote_hw_build_dir,
                 self.coyote_hw_build_dir,
@@ -267,19 +351,6 @@ class GenerateCoyoteProject(Transformation):
         )
 
         return tcl
-
-    def create_width_converter(self, module_name: str, config: Optional[IP.IPConfig]):
-        return self.create_ip(
-            module_name=module_name,
-            vlnv=GenerateCoyoteProject.build_vlnv(
-                vendor="xilinx.com", library="ip", name="axis_dwidth_converter", version="1.1"
-            ),
-            config=config,
-            run_needed=True,
-        )
-
-    def create_finn_kernel(self, vlnv: str):
-        return self.create_ip(module_name="finn_design_0", vlnv=vlnv)
 
     def apply(self, model):
         # Clone Coyote git repo
@@ -314,17 +385,18 @@ class GenerateCoyoteProject(Transformation):
         tcl.append("open_project lynx/lynx.xpr")
         tcl.append("update_compile_order -fileset sources_1")
 
-        # Add FINN kernel IP to Coyote
-        tcl.append(
-            "set_property  ip_repo_paths  {%s/ip} [current_project]"
-            % model.get_metadata_prop("vivado_stitch_proj")
-        )
+        for ip_repo_path in self.design.ip_repo_paths:
+            # Add IP paths to Coyote
+            tcl.append("set_property  ip_repo_paths  {%s} [current_project]" % ip_repo_path)
         tcl.append("update_ip_catalog")
 
-        # Generate IPs and their products
-        vlnv = model.get_metadata_prop("vivado_stitch_vlnv")
-        tcl.extend(self.create_finn_kernel(vlnv))
+        for ip in self.design.ips:
+            tcl.extend(self.create_ip(ip))
 
+        # Generate IPs and their products
+        # vlnv = model.get_metadata_prop("vivado_stitch_vlnv")
+        # tcl.extend(self.create_finn_kernel(vlnv))
+        """
         if model.get_metadata_prop("accl_mode"):
             # TODO: Add ACCL ip repo
             # TODO: Instantiate ACCL IP
@@ -350,7 +422,7 @@ class GenerateCoyoteProject(Transformation):
                     },
                 )
             )
-
+        """
         tcl_string = "\n".join(tcl) + "\n"
         with open(self.coyote_hw_build_dir / "automate.tcl", "w") as f:
             f.write(tcl_string)
@@ -358,8 +430,6 @@ class GenerateCoyoteProject(Transformation):
         vivado_cmd = ["vivado", "-mode", "batch", "-source", "automate.tcl"]
         process_vivado = subprocess.Popen(vivado_cmd, stdout=subprocess.PIPE)
         process_vivado.communicate()
-
-        # TODO: Write HDL to instantiate IPs
 
         os.chdir(finn_cwd)
 
@@ -396,7 +466,13 @@ class CoyoteBuild(Transformation):
         # Also, we only want it at the output since the Coyote interface already provides tlast to
         # the input width converter
 
-        # model.set_metadata_prop("accl_mode", CoyoteBuild.__is_accl_mode(model))
+        model.set_metadata_prop("accl_mode", json.dumps(CoyoteBuild.__is_accl_mode(model)))
+        is_accl_mode = json.loads(model.get_metadata_prop("accl_mode"))
+
+        model = ModelWrapper(
+            "/home/antoine/Documents/coyote_finn/cybersecurity/outputs_u250_automate/"
+            "intermediate_models/step_create_stitched_ip.onnx"
+        )
 
         # model = model.transform(
         #     CreateStitchedIPForCoyote(
@@ -405,11 +481,120 @@ class CoyoteBuild(Transformation):
         #         signature=self.signature,
         #     )
         # )
+
+        intf_names = json.loads(model.get_metadata_prop("vivado_stitch_ifnames"))  # type: ignore
+
+        # Only one main output and one main input
+        # NOTE: This will probably stay like this
+        assert len(intf_names["s_axis"]) == 1, "Only support one toplevel input"
+        assert len(intf_names["m_axis"]) == 1, "Only support one toplevel output"
+
+        # TODO: Support multiple AXI lites using interconnect
+        assert len(intf_names["axilite"]) == 1, "Only support one AXI lite for now"
+
+        # TODO: Create helpers to build IP
+        finn_kernel_ip = IP(
+            vlnv=model.get_metadata_prop("vivado_stitch_vlnv"),  # type: ignore
+            module_name="finn_kernel_0",
+            interfaces=[
+                SimpleWire(intf_names["clk"][0], 1),
+                SimpleWire(intf_names["rst"][0], 1),
+                # NOTE: Input of FINN does not have TLast
+                AXI4Stream(
+                    intf_names["s_axis"][0][0],
+                    intf_names["s_axis"][0][1],
+                    False,
+                    Delimiter.UNDERSCORE,
+                ),
+                AXI4Stream(
+                    intf_names["m_axis"][0][0],
+                    intf_names["m_axis"][0][1],
+                    not is_accl_mode,
+                    Delimiter.UNDERSCORE,
+                ),
+                AXI4Lite(
+                    intf_names["axilite"][0],
+                    # TODO: Figure out if this can be dynamic
+                    32,
+                    Delimiter.UNDERSCORE,
+                ),
+            ],
+            ip_repo_path=model.get_metadata_prop("vivado_stitch_proj") + "/ip",  # type: ignore
+        )
+
+        axis_dwidth_convert_host_to_finn = IP(
+            vlnv=IP.build_vlnv(
+                vendor="xilinx.com", library="ip", name="axis_dwidth_converter", version="1.1"
+            ),
+            module_name="axis_dwidth_converter_host_to_finn",
+            interfaces=[
+                SimpleWire("aclk", 1),
+                SimpleWire("aresetn", 1),
+                AXI4Stream("s_axis", 512, not is_accl_mode, Delimiter.UNDERSCORE),
+                AXI4Stream("m_axis", 8, not is_accl_mode, Delimiter.UNDERSCORE),
+            ],
+            ip_repo_path=None,
+            config={
+                "HAS_TLAST": "1",
+                "M_TDATA_NUM_BYTES": "1",
+                "S_TDATA_NUM_BYTES": "64",
+            },
+            run_needed=True,
+        )
+
+        axis_dwidth_convert_finn_to_host = IP(
+            vlnv=IP.build_vlnv(
+                vendor="xilinx.com", library="ip", name="axis_dwidth_converter", version="1.1"
+            ),
+            module_name="axis_dwidth_convert_finn_to_host",
+            interfaces=[
+                SimpleWire("aclk", 1),
+                SimpleWire("aresetn", 1),
+                AXI4Stream("s_axis", 8, not is_accl_mode, Delimiter.UNDERSCORE),
+                AXI4Stream("m_axis", 512, not is_accl_mode, Delimiter.UNDERSCORE),
+            ],
+            ip_repo_path=None,
+            config={
+                "HAS_TLAST": "1",
+                "M_TDATA_NUM_BYTES": "64",
+                "S_TDATA_NUM_BYTES": "1",
+            },
+            run_needed=True,
+        )
+
+        coyote_interface = ExternalInterface(
+            interfaces=[
+                AXI4Lite(name="axi_ctrl", width=64, delimiter=Delimiter.POINT),
+                SimpleWire(name="aclk", width=1),
+                SimpleWire(name="aresetn", width=1),
+                AXI4Stream(
+                    name="axis_host_0_sink", width=512, tlast=True, delimiter=Delimiter.POINT
+                ),
+                AXI4Stream(
+                    name="axis_host_0_src", width=512, tlast=True, delimiter=Delimiter.POINT
+                ),
+            ]
+        )
+
+        instantiations = []
+        instantiations.append(
+            Instantiation(instantiation_name="finn_kernel_inst", ip=finn_kernel_ip)
+        )
+        instantiations.append(
+            Instantiation(
+                instantiation_name="axis_dwidth_convert_host_to_finn_inst",
+                ip=axis_dwidth_convert_host_to_finn,
+            )
+        )
+        instantiations.append(
+            Instantiation(
+                instantiation_name="axis_dwidth_convert_finn_to_host_inst",
+                ip=axis_dwidth_convert_finn_to_host,
+            )
+        )
+
+        design = Design(instantiations, coyote_interface)
         # intf_names = json.loads(model.get_metadata_prop("vivado_stitch_ifnames"))
-        # model = model.transform(
-        #     GenerateCoyoteProject(fpga_part=self.fpga_part, intf_names=intf_names)
-        # )
+        model = model.transform(GenerateCoyoteProject(fpga_part=self.fpga_part, design=design))
         # model = model.transform(CoyoteUserLogic())
-        intf_test = Interface()
-        intf_test.test()
         return (model, False)

--- a/src/finn/transformation/fpgadataflow/coyote_build.py
+++ b/src/finn/transformation/fpgadataflow/coyote_build.py
@@ -26,6 +26,9 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import os
+import subprocess
+from pathlib import Path
 from qonnx.transformation.base import Transformation
 from qonnx.transformation.general import GiveUniqueNodeNames
 
@@ -36,11 +39,17 @@ from finn.transformation.fpgadataflow.prepare_ip import PrepareIP
 from finn.transformation.fpgadataflow.replace_verilog_relpaths import (
     ReplaceVerilogRelPaths,
 )
+from finn.util.basic import alveo_part_map, make_build_dir
 
-# from finn.util.basic import make_build_dir
 
+class CreateStitchedIPForCoyote(Transformation):
+    """Create a stitched IP configured for use with Coyote
 
-class CoyoteBuild(Transformation):
+    The stitched IP will be generated with vitis=True (i.e stitched_ip_gen_dcp=True
+    from the config).
+    Also, a TLastMarker is inserted as the last node.
+    """
+
     def __init__(self, fpga_part, period_ns, signature):
         super().__init__()
         self.fpga_part = fpga_part
@@ -64,5 +73,76 @@ class CoyoteBuild(Transformation):
                 signature=self.signature,
             )
         )
+
+        return (model, True)
+
+
+class GenerateCoyoteProject(Transformation):
+    def __init__(self, fpga_part):
+        super().__init__()
+        self.fpga_part = fpga_part
+
+    def apply(self, model):
+        # Clone Coyote git repo
+        coyote_proj_dir = Path(make_build_dir(prefix="coyote_proj_"))
+        coyote_repo_dir = coyote_proj_dir / "Coyote"
+        COYOTE_REPOSITORY = "https://github.com/fpgasystems/Coyote.git"
+
+        git_clone_command = ["git", "clone", f"{COYOTE_REPOSITORY}", f"{coyote_repo_dir}"]
+        process_compile = subprocess.Popen(git_clone_command, stdout=subprocess.PIPE)
+        process_compile.communicate()
+        assert os.path.isdir(coyote_repo_dir)
+
+        # Create build directory
+        coyote_hw_dir = coyote_repo_dir / "hw"
+        coyote_hw_build_dir = coyote_hw_dir / "build"
+        coyote_hw_build_dir.mkdir()
+
+        part_to_board = {v: k for k, v in alveo_part_map.items()}
+        board = part_to_board[self.fpga_part]
+
+        # Change working directory to Coyote hw build dir
+        finn_cwd = os.getcwd()
+        os.chdir(coyote_hw_build_dir)
+
+        # CMake Coyote
+        coyote_board = board.lower()
+        cmake_command = ["/usr/bin/cmake", f"{coyote_hw_dir}", f"-DFDEV_NAME={coyote_board}"]
+        process_compile = subprocess.Popen(cmake_command, stdout=subprocess.PIPE)
+        process_compile.communicate()
+
+        make_shell_command = ["make", "shell"]
+        process_compile = subprocess.Popen(make_shell_command, stdout=subprocess.PIPE)
+        process_compile.communicate()
+
+        # TODO: Generate script to generate IPs
+        # TODO: Write HDL to instantiate IPs
+
+        os.chdir(finn_cwd)
+
+        return (model, False)
+
+
+class CoyoteBuild(Transformation):
+    def __init__(self, fpga_part, period_ns, signature):
+        super().__init__()
+        self.fpga_part = fpga_part
+        self.period_ns = period_ns
+        self.signature = signature
+
+    def apply(self, model):
+        # We want dynamic True so we leave default arguments
+        # Also, we only want it at the output since the Coyote interface already provides tlast to
+        # the input width converter
+        model = model.transform(
+            CreateStitchedIPForCoyote(
+                fpgapart=self.fpga_part,
+                clk_ns=self.period_ns,
+                vitis=True,
+                signature=self.signature,
+            )
+        )
+
+        model = model.transform(GenerateCoyoteProject(fpga_part=self.fpga_part))
 
         return (model, False)

--- a/src/finn/transformation/fpgadataflow/coyote_build.py
+++ b/src/finn/transformation/fpgadataflow/coyote_build.py
@@ -31,6 +31,7 @@ import subprocess
 from pathlib import Path
 from qonnx.transformation.base import Transformation
 from qonnx.transformation.general import GiveUniqueNodeNames
+from typing import Dict, Optional
 
 from finn.transformation.fpgadataflow.create_stitched_ip import CreateStitchedIP
 from finn.transformation.fpgadataflow.hlssynth_ip import HLSSynthIP
@@ -60,11 +61,14 @@ class CreateStitchedIPForCoyote(Transformation):
         # We want dynamic True so we leave default arguments
         # Also, we only want it at the output since the Coyote interface already provides tlast to
         # the input width converter
+        print("Inserting tlast marker")
         model = model.transform(InsertTLastMarker())
         model = model.transform(GiveUniqueNodeNames())
         model = model.transform(PrepareIP(self.fpga_part, self.period_ns))
         model = model.transform(HLSSynthIP())
         model = model.transform(ReplaceVerilogRelPaths())
+        # NOTE: Use CreateStitchedIP default IP name = "finn_design"
+        print("Calling create stitched ip")
         model = model.transform(
             CreateStitchedIP(
                 fpgapart=self.fpga_part,
@@ -74,40 +78,145 @@ class CreateStitchedIPForCoyote(Transformation):
             )
         )
 
-        return (model, True)
+        return (model, False)
 
 
 class GenerateCoyoteProject(Transformation):
     def __init__(self, fpga_part):
         super().__init__()
         self.fpga_part = fpga_part
+        self.coyote_proj_dir = Path(make_build_dir(prefix="coyote_proj_"))
+        self.coyote_repo_dir = self.coyote_proj_dir / "Coyote"
+        self.coyote_hw_dir = self.coyote_repo_dir / "hw"
+        self.coyote_hw_build_dir = self.coyote_hw_dir / "build"
+
+    def generate_config(self, config: Dict[str, str]):
+        config_tcl = []
+        for key, value in config.items():
+            config_tcl.append("CONFIG.%s {%s}" % (key, value))
+        return " ".join(config_tcl)
+
+    def create_ip(
+        self,
+        module_name: str,
+        vlnv: Optional[str] = None,
+        config: Optional[Dict[str, str]] = None,
+        run_needed=False,
+        name: Optional[str] = None,
+        vendor: Optional[str] = None,
+        version: Optional[str] = None,
+        library: Optional[str] = None,
+    ):
+        assert vlnv is not None or (
+            name is not None and vendor is not None and library is not None and version is not None
+        )
+
+        tcl = []
+        if vlnv is not None:
+            tcl.append("create_ip -vlnv %s -module_name %s" % (vlnv, module_name))
+        else:
+            tcl.append(
+                "create_ip -name %s -vendor %s -library %s -version %s -module_name %s"
+                % (name, vendor, library, version, module_name)
+            )
+        if config is not None:
+            tcl.append(
+                "set_property -dict [list %s] [get_ips %s]"
+                % (self.generate_config(config), module_name)
+            )
+
+        tcl.append(
+            "generate_target {instantiation_template} [get_files"
+            " %s/lynx/lynx.srcs/sources_1/ip/%s/%s.xci]"
+            % (self.coyote_hw_build_dir, module_name, module_name)
+        )
+
+        tcl.append("update_compile_order -fileset sources_1")
+        tcl.append(
+            "generate_target all [get_files  %s/lynx/lynx.srcs/sources_1/ip/%s/%s.xci]"
+            % (self.coyote_hw_build_dir, module_name, module_name)
+        )
+        # NOTE: Only appears for width converter. Is this necessary?
+        tcl.append("catch { config_ip_cache -export [get_ips -all %s] }" % module_name)
+
+        tcl.append(
+            "export_ip_user_files -of_objects [get_files"
+            " %s/lynx/lynx.srcs/sources_1/ip/%s/%s.xci]"
+            " -no_script -sync -force -quiet" % (self.coyote_hw_build_dir, module_name, module_name)
+        )
+
+        if run_needed:
+            tcl.append(
+                "create_ip_run [get_files -of_objects [get_fileset sources_1]"
+                " %s/lynx/lynx.srcs/sources_1/ip/%s/%s.xci]"
+                % (self.coyote_hw_build_dir, module_name, module_name)
+            )
+            tcl.append("launch_runs %s_synth_1 -jobs 4" % module_name)
+        # NOTE: Seems involved. Is this required?
+        tcl.append(
+            "export_simulation -of_objects [get_files %s/lynx/lynx.srcs/sources_1/ip/%s/%s.xci]"
+            " -directory %s/lynx/lynx.ip_user_files/sim_scripts -ip_user_files_dir"
+            " %s/lynx/lynx.ip_user_files -ipstatic_source_dir %s/lynx/lynx.ip_user_files/ipstatic"
+            " -lib_map_path [list {modelsim=%s/lynx/lynx.cache/compile_simlib/modelsim}"
+            " {questa=%s/lynx/lynx.cache/compile_simlib/questa}"
+            " {xcelium=%s/lynx/lynx.cache/compile_simlib/xcelium}"
+            " {vcs=%s/lynx/lynx.cache/compile_simlib/vcs}"
+            " {riviera=%s/lynx/lynx.cache/compile_simlib/riviera}] -use_ip_compiled_libs -force"
+            " -quiet"
+            % (
+                self.coyote_hw_build_dir,
+                module_name,
+                module_name,
+                self.coyote_hw_build_dir,
+                self.coyote_hw_build_dir,
+                self.coyote_hw_build_dir,
+                self.coyote_hw_build_dir,
+                self.coyote_hw_build_dir,
+                self.coyote_hw_build_dir,
+                self.coyote_hw_build_dir,
+                self.coyote_hw_build_dir,
+            )
+        )
+
+        return tcl
+
+    def create_width_converter(self, module_name: str, config: Optional[Dict[str, str]]):
+        return self.create_ip(
+            module_name=module_name,
+            vlnv=None,
+            config=config,
+            run_needed=True,
+            name="axis_dwidth_converter",
+            vendor="xilinx.com",
+            version="1.1",
+            library="ip",
+        )
+
+    def create_finn_kernel(self, vlnv: str):
+        return self.create_ip(module_name="finn_design_0", vlnv=vlnv)
 
     def apply(self, model):
         # Clone Coyote git repo
-        coyote_proj_dir = Path(make_build_dir(prefix="coyote_proj_"))
-        coyote_repo_dir = coyote_proj_dir / "Coyote"
         COYOTE_REPOSITORY = "https://github.com/fpgasystems/Coyote.git"
 
-        git_clone_command = ["git", "clone", f"{COYOTE_REPOSITORY}", f"{coyote_repo_dir}"]
+        git_clone_command = ["git", "clone", f"{COYOTE_REPOSITORY}", f"{self.coyote_repo_dir}"]
         process_compile = subprocess.Popen(git_clone_command, stdout=subprocess.PIPE)
         process_compile.communicate()
-        assert os.path.isdir(coyote_repo_dir)
+        assert os.path.isdir(self.coyote_repo_dir)
 
         # Create build directory
-        coyote_hw_dir = coyote_repo_dir / "hw"
-        coyote_hw_build_dir = coyote_hw_dir / "build"
-        coyote_hw_build_dir.mkdir()
+        self.coyote_hw_build_dir.mkdir(parents=True)
 
         part_to_board = {v: k for k, v in alveo_part_map.items()}
         board = part_to_board[self.fpga_part]
 
         # Change working directory to Coyote hw build dir
         finn_cwd = os.getcwd()
-        os.chdir(coyote_hw_build_dir)
+        os.chdir(self.coyote_hw_build_dir)
 
         # CMake Coyote
         coyote_board = board.lower()
-        cmake_command = ["/usr/bin/cmake", f"{coyote_hw_dir}", f"-DFDEV_NAME={coyote_board}"]
+        cmake_command = ["/usr/bin/cmake", f"{self.coyote_hw_dir}", f"-DFDEV_NAME={coyote_board}"]
         process_compile = subprocess.Popen(cmake_command, stdout=subprocess.PIPE)
         process_compile.communicate()
 
@@ -115,11 +224,64 @@ class GenerateCoyoteProject(Transformation):
         process_compile = subprocess.Popen(make_shell_command, stdout=subprocess.PIPE)
         process_compile.communicate()
 
-        # TODO: Generate script to generate IPs
+        tcl = []
+        tcl.append("open_project lynx/lynx.xpr")
+        tcl.append("update_compile_order -fileset sources_1")
+
+        # Add FINN kernel IP to Coyote
+        tcl.append(
+            "set_property  ip_repo_paths  {%s/ip} [current_project]"
+            % model.get_metadata_prop("vivado_stitch_proj")
+        )
+        tcl.append("update_ip_catalog")
+
+        # Generate IPs and their products
+        vlnv = model.get_metadata_prop("vivado_stitch_vlnv")
+        tcl.extend(self.create_finn_kernel(vlnv))
+        tcl.extend(
+            self.create_width_converter(
+                module_name="axis_dwidth_converter_host_to_finn",
+                config={
+                    "Component_Name": "axis_dwidth_converter_host_to_finn",
+                    "HAS_TLAST": "1",
+                    "M_TDATA_NUM_BYTES": "1",
+                    "S_TDATA_NUM_BYTES": "64",
+                },
+            )
+        )
+        tcl.extend(
+            self.create_width_converter(
+                module_name="axis_dwidth_converter_finn_to_host",
+                config={
+                    "Component_Name": "axis_dwidth_converter_finn_to_host",
+                    "HAS_TLAST": "1",
+                    "M_TDATA_NUM_BYTES": "64",
+                    "S_TDATA_NUM_BYTES": "1",
+                },
+            )
+        )
+
+        tcl_string = "\n".join(tcl) + "\n"
+        with open(self.coyote_hw_build_dir / "automate.tcl", "w") as f:
+            f.write(tcl_string)
+
+        vivado_cmd = ["vivado", "-mode", "batch", "-source", "automate.tcl"]
+        process_vivado = subprocess.Popen(vivado_cmd, stdout=subprocess.PIPE)
+        process_vivado.communicate()
+
         # TODO: Write HDL to instantiate IPs
 
         os.chdir(finn_cwd)
 
+        return (model, False)
+
+
+class CoyoteUserLogic(Transformation):
+    def __init__(self):
+        super().__init__()
+
+    def apply(self, model):
+        # model.set_metadata_prop("vivado_stitch_ifnames", json.dumps(self.intf_names))
         return (model, False)
 
 
@@ -136,13 +298,13 @@ class CoyoteBuild(Transformation):
         # the input width converter
         model = model.transform(
             CreateStitchedIPForCoyote(
-                fpgapart=self.fpga_part,
-                clk_ns=self.period_ns,
-                vitis=True,
+                fpga_part=self.fpga_part,
+                period_ns=self.period_ns,
                 signature=self.signature,
             )
         )
 
         model = model.transform(GenerateCoyoteProject(fpga_part=self.fpga_part))
+        model = model.transform(CoyoteUserLogic())
 
         return (model, False)

--- a/src/finn/transformation/fpgadataflow/coyote_build.py
+++ b/src/finn/transformation/fpgadataflow/coyote_build.py
@@ -684,14 +684,14 @@ class CoyoteBuild(Transformation):
                 module_name="axi_crossbar_0",
                 interfaces=[
                     AXI4Lite(
-                        name="s_axi_crossbar",
+                        name="s_axi",
                         width=32,
                         delimiter=Delimiter.UNDERSCORE,
                         external=False,
                         addr_width=32,
                     ),
                     AXI4Lite(
-                        name="m_axi_crossbar",
+                        name="m_axi",
                         width=32,
                         delimiter=Delimiter.UNDERSCORE,
                         external=False,
@@ -896,12 +896,14 @@ class CoyoteBuild(Transformation):
             design, coyote_interface["axis_host_0_sink"]
         )
 
-        instantiations["axi_crossbar_0_inst"]["m_axi_crossbar"].connect_multiple(
+        instantiations["axi_crossbar_0_inst"]["m_axi"].connect_multiple(
             design,
             [
                 instantiations["finn_kernel_inst"][key] for key in intf_names["axilite"]
             ],  # type: ignore
         )
+
+        instantiations["axi_crossbar_0_inst"]["s_axi"].connect(design, coyote_interface["axi_ctrl"])
 
         model = model.transform(GenerateCoyoteProject(fpga_part=self.fpga_part, design=design))
         model = model.transform(CoyoteUserLogic(design=design))

--- a/src/finn/transformation/fpgadataflow/coyote_build.py
+++ b/src/finn/transformation/fpgadataflow/coyote_build.py
@@ -699,6 +699,8 @@ class CoyoteBuild(Transformation):
                         scale=len(axilites),
                     ),
                 ],
+                config=config,
+                run_needed=True,
             ),
             axilites_with_addr_width,
         )

--- a/src/finn/transformation/fpgadataflow/coyote_build.py
+++ b/src/finn/transformation/fpgadataflow/coyote_build.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2020, Xilinx
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of FINN nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from qonnx.transformation.base import Transformation
+from qonnx.transformation.general import GiveUniqueNodeNames
+
+from finn.transformation.fpgadataflow.create_stitched_ip import CreateStitchedIP
+from finn.transformation.fpgadataflow.hlssynth_ip import HLSSynthIP
+from finn.transformation.fpgadataflow.insert_tlastmarker import InsertTLastMarker
+from finn.transformation.fpgadataflow.prepare_ip import PrepareIP
+from finn.transformation.fpgadataflow.replace_verilog_relpaths import (
+    ReplaceVerilogRelPaths,
+)
+
+# from finn.util.basic import make_build_dir
+
+
+class CoyoteBuild(Transformation):
+    def __init__(self, fpga_part, period_ns, signature):
+        super().__init__()
+        self.fpga_part = fpga_part
+        self.period_ns = period_ns
+        self.signature = signature
+
+    def apply(self, model):
+        # We want dynamic True so we leave default arguments
+        # Also, we only want it at the output since the Coyote interface already provides tlast to
+        # the input width converter
+        model = model.transform(InsertTLastMarker())
+        model = model.transform(GiveUniqueNodeNames())
+        model = model.transform(PrepareIP(self.fpga_part, self.period_ns))
+        model = model.transform(HLSSynthIP())
+        model = model.transform(ReplaceVerilogRelPaths())
+        model = model.transform(
+            CreateStitchedIP(
+                fpgapart=self.fpga_part,
+                clk_ns=self.period_ns,
+                vitis=True,
+                signature=self.signature,
+            )
+        )
+
+        return (model, False)

--- a/src/finn/transformation/fpgadataflow/coyote_build.py
+++ b/src/finn/transformation/fpgadataflow/coyote_build.py
@@ -61,14 +61,12 @@ class CreateStitchedIPForCoyote(Transformation):
         # We want dynamic True so we leave default arguments
         # Also, we only want it at the output since the Coyote interface already provides tlast to
         # the input width converter
-        print("Inserting tlast marker")
         model = model.transform(InsertTLastMarker())
         model = model.transform(GiveUniqueNodeNames())
         model = model.transform(PrepareIP(self.fpga_part, self.period_ns))
         model = model.transform(HLSSynthIP())
         model = model.transform(ReplaceVerilogRelPaths())
         # NOTE: Use CreateStitchedIP default IP name = "finn_design"
-        print("Calling create stitched ip")
         model = model.transform(
             CreateStitchedIP(
                 fpgapart=self.fpga_part,
@@ -242,7 +240,6 @@ class GenerateCoyoteProject(Transformation):
             self.create_width_converter(
                 module_name="axis_dwidth_converter_host_to_finn",
                 config={
-                    "Component_Name": "axis_dwidth_converter_host_to_finn",
                     "HAS_TLAST": "1",
                     "M_TDATA_NUM_BYTES": "1",
                     "S_TDATA_NUM_BYTES": "64",
@@ -253,7 +250,6 @@ class GenerateCoyoteProject(Transformation):
             self.create_width_converter(
                 module_name="axis_dwidth_converter_finn_to_host",
                 config={
-                    "Component_Name": "axis_dwidth_converter_finn_to_host",
                     "HAS_TLAST": "1",
                     "M_TDATA_NUM_BYTES": "64",
                     "S_TDATA_NUM_BYTES": "1",

--- a/src/finn/transformation/fpgadataflow/coyote_build.py
+++ b/src/finn/transformation/fpgadataflow/coyote_build.py
@@ -399,9 +399,17 @@ class GenerateCoyoteProject(Transformation):
         tcl.append("open_project lynx/lynx.xpr")
         tcl.append("update_compile_order -fileset sources_1")
 
+        tcl.append("catch {get_property ip_repo_paths [current_project]}")
+
+        ip_repo_paths = []
         for ip_repo_path in self.design.ip_repo_paths:
-            # Add IP paths to Coyote
-            tcl.append("set_property  ip_repo_paths  {%s} [current_project]" % ip_repo_path)
+            ip_repo_paths.append(ip_repo_path)
+
+        # Add IP paths to Coyote
+        tcl.append(
+            "set_property  ip_repo_paths  {${*} %s} [current_project]" % " ".join(ip_repo_paths)
+        )
+
         tcl.append("update_ip_catalog")
 
         for ip in self.design.ips:

--- a/src/finn/transformation/fpgadataflow/templates.py
+++ b/src/finn/transformation/fpgadataflow/templates.py
@@ -257,3 +257,50 @@ open_project $VITIS_PROJ_PATH$/_x/link/vivado/vpl/prj/prj.xpr
 open_run impl_1
 report_utilization -hierarchical -hierarchical_depth 5 -file $VITIS_PROJ_PATH$/synth_report.xml -format xml
 """
+
+# All paths relative to coyote hw build directory
+coyote_finn_instantiation_template = """
+open_project lynx/lynx.xpr
+open_project lynx/lynx.xpr
+update_compile_order -fileset sources_1"""
+# TODO: Append to IP repo paths
+# NOTE: Here absolute paths
+"""
+set_property  ip_repo_paths  {/pub/scratch/adegendt/clean_setup/coyote_finn/Coyote/hw/build/iprepo /pub/scratch/adegendt/clean_setup/coyote_finn/cybersecurity/outputs_tlast/stitched_ip/ip} [current_project]
+create_ip -name finn_design -vendor xilinx_finn -library finn -version 1.0 -module_name finn_design_0
+generate_target {instantiation_template} [get_files /pub/scratch/adegendt/clean_setup/coyote_finn/Coyote/hw/build/lynx/lynx.srcs/sources_1/ip/finn_design_0/finn_design_0.xci]
+update_compile_order -fileset sources_1
+generate_target all [get_files  /pub/scratch/adegendt/clean_setup/coyote_finn/Coyote/hw/build/lynx/lynx.srcs/sources_1/ip/finn_design_0/finn_design_0.xci]
+export_ip_user_files -of_objects [get_files /pub/scratch/adegendt/clean_setup/coyote_finn/Coyote/hw/build/lynx/lynx.srcs/sources_1/ip/finn_design_0/finn_design_0.xci] -no_script -sync -force -quiet
+create_ip_run [get_files -of_objects [get_fileset sources_1] /pub/scratch/adegendt/clean_setup/coyote_finn/Coyote/hw/build/lynx/lynx.srcs/sources_1/ip/finn_design_0/finn_design_0.xci]
+export_simulation -of_objects [get_files /pub/scratch/adegendt/clean_setup/coyote_finn/Coyote/hw/build/lynx/lynx.srcs/sources_1/ip/finn_design_0/finn_design_0.xci] -directory /pub/scratch/adegendt/clean_setup/coyote_finn/Coyote/hw/build/lynx/lynx.ip_user_files/sim_scripts -ip_user_files_dir /pub/scratch/adegendt/clean_setup/coyote_finn/Coyote/hw/build/lynx/lynx.ip_user_files -ipstatic_source_dir /pub/scratch/adegendt/clean_setup/coyote_finn/Coyote/hw/build/lynx/lynx.ip_user_files/ipstatic -lib_map_path [list {modelsim=/pub/scratch/adegendt/clean_setup/coyote_finn/Coyote/hw/build/lynx/lynx.cache/compile_simlib/modelsim} {questa=/pub/scratch/adegendt/clean_setup/coyote_finn/Coyote/hw/build/lynx/lynx.cache/compile_simlib/questa} {xcelium=/pub/scratch/adegendt/clean_setup/coyote_finn/Coyote/hw/build/lynx/lynx.cache/compile_simlib/xcelium} {vcs=/pub/scratch/adegendt/clean_setup/coyote_finn/Coyote/hw/build/lynx/lynx.cache/compile_simlib/vcs} {riviera=/pub/scratch/adegendt/clean_setup/coyote_finn/Coyote/hw/build/lynx/lynx.cache/compile_simlib/riviera}] -use_ip_compiled_libs -force -quiet
+create_ip -name axis_dwidth_converter -vendor xilinx.com -library ip -version 1.1 -module_name axis_dwidth_converter_host_to_finn
+set_property -dict [list \
+  CONFIG.Component_Name {axis_dwidth_converter_host_to_finn} \
+  CONFIG.HAS_TLAST {1} \
+  CONFIG.M_TDATA_NUM_BYTES {1} \
+  CONFIG.S_TDATA_NUM_BYTES {64} \
+] [get_ips axis_dwidth_converter_host_to_finn]
+generate_target {instantiation_template} [get_files /pub/scratch/adegendt/clean_setup/coyote_finn/Coyote/hw/build/lynx/lynx.srcs/sources_1/ip/axis_dwidth_converter_host_to_finn/axis_dwidth_converter_host_to_finn.xci]
+update_compile_order -fileset sources_1
+generate_target all [get_files  /pub/scratch/adegendt/clean_setup/coyote_finn/Coyote/hw/build/lynx/lynx.srcs/sources_1/ip/axis_dwidth_converter_host_to_finn/axis_dwidth_converter_host_to_finn.xci]
+catch { config_ip_cache -export [get_ips -all axis_dwidth_converter_host_to_finn] }
+export_ip_user_files -of_objects [get_files /pub/scratch/adegendt/clean_setup/coyote_finn/Coyote/hw/build/lynx/lynx.srcs/sources_1/ip/axis_dwidth_converter_host_to_finn/axis_dwidth_converter_host_to_finn.xci] -no_script -sync -force -quiet
+create_ip_run [get_files -of_objects [get_fileset sources_1] /pub/scratch/adegendt/clean_setup/coyote_finn/Coyote/hw/build/lynx/lynx.srcs/sources_1/ip/axis_dwidth_converter_host_to_finn/axis_dwidth_converter_host_to_finn.xci]
+launch_runs axis_dwidth_converter_host_to_finn_synth_1 -jobs 40
+export_simulation -of_objects [get_files /pub/scratch/adegendt/clean_setup/coyote_finn/Coyote/hw/build/lynx/lynx.srcs/sources_1/ip/axis_dwidth_converter_host_to_finn/axis_dwidth_converter_host_to_finn.xci] -directory /pub/scratch/adegendt/clean_setup/coyote_finn/Coyote/hw/build/lynx/lynx.ip_user_files/sim_scripts -ip_user_files_dir /pub/scratch/adegendt/clean_setup/coyote_finn/Coyote/hw/build/lynx/lynx.ip_user_files -ipstatic_source_dir /pub/scratch/adegendt/clean_setup/coyote_finn/Coyote/hw/build/lynx/lynx.ip_user_files/ipstatic -lib_map_path [list {modelsim=/pub/scratch/adegendt/clean_setup/coyote_finn/Coyote/hw/build/lynx/lynx.cache/compile_simlib/modelsim} {questa=/pub/scratch/adegendt/clean_setup/coyote_finn/Coyote/hw/build/lynx/lynx.cache/compile_simlib/questa} {xcelium=/pub/scratch/adegendt/clean_setup/coyote_finn/Coyote/hw/build/lynx/lynx.cache/compile_simlib/xcelium} {vcs=/pub/scratch/adegendt/clean_setup/coyote_finn/Coyote/hw/build/lynx/lynx.cache/compile_simlib/vcs} {riviera=/pub/scratch/adegendt/clean_setup/coyote_finn/Coyote/hw/build/lynx/lynx.cache/compile_simlib/riviera}] -use_ip_compiled_libs -force -quiet
+create_ip -name axis_dwidth_converter -vendor xilinx.com -library ip -version 1.1 -module_name axis_dwidth_converter_finn_to_host
+set_property -dict [list \
+  CONFIG.Component_Name {axis_dwidth_converter_finn_to_host} \
+  CONFIG.HAS_TLAST {1} \
+  CONFIG.M_TDATA_NUM_BYTES {64} \
+] [get_ips axis_dwidth_converter_finn_to_host]
+generate_target {instantiation_template} [get_files /pub/scratch/adegendt/clean_setup/coyote_finn/Coyote/hw/build/lynx/lynx.srcs/sources_1/ip/axis_dwidth_converter_finn_to_host/axis_dwidth_converter_finn_to_host.xci]
+update_compile_order -fileset sources_1
+generate_target all [get_files  /pub/scratch/adegendt/clean_setup/coyote_finn/Coyote/hw/build/lynx/lynx.srcs/sources_1/ip/axis_dwidth_converter_finn_to_host/axis_dwidth_converter_finn_to_host.xci]
+catch { config_ip_cache -export [get_ips -all axis_dwidth_converter_finn_to_host] }
+export_ip_user_files -of_objects [get_files /pub/scratch/adegendt/clean_setup/coyote_finn/Coyote/hw/build/lynx/lynx.srcs/sources_1/ip/axis_dwidth_converter_finn_to_host/axis_dwidth_converter_finn_to_host.xci] -no_script -sync -force -quiet
+create_ip_run [get_files -of_objects [get_fileset sources_1] /pub/scratch/adegendt/clean_setup/coyote_finn/Coyote/hw/build/lynx/lynx.srcs/sources_1/ip/axis_dwidth_converter_finn_to_host/axis_dwidth_converter_finn_to_host.xci]
+launch_runs axis_dwidth_converter_finn_to_host_synth_1 -jobs 40
+export_simulation -of_objects [get_files /pub/scratch/adegendt/clean_setup/coyote_finn/Coyote/hw/build/lynx/lynx.srcs/sources_1/ip/axis_dwidth_converter_finn_to_host/axis_dwidth_converter_finn_to_host.xci] -directory /pub/scratch/adegendt/clean_setup/coyote_finn/Coyote/hw/build/lynx/lynx.ip_user_files/sim_scripts -ip_user_files_dir /pub/scratch/adegendt/clean_setup/coyote_finn/Coyote/hw/build/lynx/lynx.ip_user_files -ipstatic_source_dir /pub/scratch/adegendt/clean_setup/coyote_finn/Coyote/hw/build/lynx/lynx.ip_user_files/ipstatic -lib_map_path [list {modelsim=/pub/scratch/adegendt/clean_setup/coyote_finn/Coyote/hw/build/lynx/lynx.cache/compile_simlib/modelsim} {questa=/pub/scratch/adegendt/clean_setup/coyote_finn/Coyote/hw/build/lynx/lynx.cache/compile_simlib/questa} {xcelium=/pub/scratch/adegendt/clean_setup/coyote_finn/Coyote/hw/build/lynx/lynx.cache/compile_simlib/xcelium} {vcs=/pub/scratch/adegendt/clean_setup/coyote_finn/Coyote/hw/build/lynx/lynx.cache/compile_simlib/vcs} {riviera=/pub/scratch/adegendt/clean_setup/coyote_finn/Coyote/hw/build/lynx/lynx.cache/compile_simlib/riviera}] -use_ip_compiled_libs -force -quiet
+"""


### PR DESCRIPTION
Hi,

This PR adds support for generation of Coyote shell bitstreams. For now, it only handles the hardware design part and not the driver part.

There are still some things to do to:

- [ ] Test it with other designs than the cybersecurity examples
- [ ] Add test
- [ ] Add support for more than 16 AXI lite interfaces
- [ ] Potentially determine the interfaces from the generated design (for the Coyote interface + the generated IPs)
- [ ] Support more than one axi control interface
- [ ] Better assertions
- [ ] Add comments