### PR TITLE
[RTL SWG] Support SIMD < C in window-parallel mode

### DIFF
--- a/docs/finn/internals.rst
+++ b/docs/finn/internals.rst
@@ -311,6 +311,13 @@ Depending on the amount of parallelism requested, one of two implementation styl
      - 1
      - default
      - depthwise-agnostic
+   * - < C
+     - 1
+     - 1
+     - 1
+     - K
+     - parallel
+     - depthwise only
    * - C
      - 1
      - 1
@@ -343,4 +350,4 @@ The RTL SWG is supported by the basic automatic folding algorithm in FINN (:py:m
 
 **MVAU:** Although it is recommended to unfold SIMD first, SIMD and PE can be set independently. Full (and balanced) parallelism is achieved by using the SWG in parallel window mode and setting MVAU SIMD and PE to their maximum values (SIMD = MW = C_in * K, PE = MH = C_out).
 
-**VVAU:** While the VVAU HLS component supports SIMD unfolding independently from PE, the RTL SWG requires full unfolding across the channel dimension (SIMD of the SWG = PE of the VVAU) before enabling window-parallelism. Unlike the MVAU, the VVAU can't accept datawidth-converted input from a fully-parallel SWG in this case due to the depthwise data layout. As a result, the VVAU should be unfolded by PE first (up to PE = C), followed by SIMD (up to SIMD = K).
+**VVAU:** The VVAU component supports SIMD unfolding (up to SIMD = K) independently from PE unfolding (up to PE = C), but can't accept a datawidth-converted input from a fully-parallel SWG in case PE is not fully unfolded due to the depthwise data layout. Therefore, it is required to set SIMD of the SWG = PE of the VVAU when window-parallelism is enabled. In this scenario, VVAU SIMD < K is supported via an automatically inserted DWC.

--- a/finn-rtllib/swg/swg_common.sv
+++ b/finn-rtllib/swg/swg_common.sv
@@ -195,8 +195,7 @@ for (genvar e=0; e<DEPTH; e++)
 
 always @ (posedge clk) begin
     if (shift_enable) begin
-        for (int i=DEPTH-1; i>0; i--)
-            Data[i] <= Data[i-1];
+        if (DEPTH > 1) Data[DEPTH-1:1] <= Data[DEPTH-2:0];
         Data[0] <= shift_in;
     end
 end

--- a/finn-rtllib/swg/swg_template_parallel.sv
+++ b/finn-rtllib/swg/swg_template_parallel.sv
@@ -136,7 +136,6 @@ module $TOP_MODULE_NAME$_impl #(
     // counters/address registers
     logic signed [$clog2(LAST_READ_ELEM+1)+1-1:0]  Newest_buffered_elem = -1;
     logic        [$clog2(LAST_READ_ELEM+1)+1-1:0]  Current_elem = FIRST_WRITE_ELEM;
-    logic        [$clog2(LAST_READ_ELEM+1)+1-1:0]  First_elem_next_window = 0;
 
     // control registers/signals
     logic  Writing_done  = 0;
@@ -146,13 +145,7 @@ module $TOP_MODULE_NAME$_impl #(
     uwire  write_blocked = write_cmd && !out_V_V_TREADY && !Write_done;
 
     uwire  reading_done = Newest_buffered_elem == LAST_READ_ELEM;
-    uwire  read_cmd     =
-        !reading_done && ( // if there is still an input element left to read
-            Writing_done || ( // if writing is done (e.g. for skipped rows at FM end due to stride)
-                $signed(((Newest_buffered_elem - ($signed(BUF_ELEM_TOTAL) - 1)))) < $signed(First_elem_next_window) &&
-                $signed(((Newest_buffered_elem - ($signed(BUF_ELEM_TOTAL) - 1)))) < $signed(Current_elem)
-            ) // (over-)write to buffer if oldest buffered element will no longer be needed
-        );
+    uwire  read_cmd     = !reading_done && (Writing_done || Newest_buffered_elem <= $signed(Current_elem));
     uwire  read_ok      = read_cmd && in0_V_V_TVALID && !write_blocked;
 
     //            includes waiting on W    if W-only cycle: wait only on W     no R/W to wait for
@@ -186,7 +179,6 @@ module $TOP_MODULE_NAME$_impl #(
         if(!ap_rst_n) begin
             Newest_buffered_elem <= -1;
             Current_elem <= FIRST_WRITE_ELEM;
-            First_elem_next_window <= 0;
             Writing_done <= 0;
         end
         else begin
@@ -199,14 +191,11 @@ module $TOP_MODULE_NAME$_impl #(
                     // todo: allow for read overlapping between feature maps (i.e., reading first elements from next FM while still writing last window of current FM)
                     Newest_buffered_elem <= -1;
                     Current_elem <= FIRST_WRITE_ELEM;
-                    First_elem_next_window <= 0;
                     Writing_done <= 0;
                 end
             end
 
             if (write_ok) begin
-                First_elem_next_window <= First_elem_next_window + tail_incr;
-
                 // check if this is the last write cycle (Writing_done will be true afterwards)
                 if (Current_elem == LAST_WRITE_ELEM) begin
                     Writing_done <= 1;
@@ -215,7 +204,6 @@ module $TOP_MODULE_NAME$_impl #(
                         // start processing of next FM if reading is done already, or completes in the same cycle
                         Newest_buffered_elem <= -1;
                         Current_elem <= FIRST_WRITE_ELEM;
-                        First_elem_next_window <= 0;
                         Writing_done <= 0;
                     end
                 end

--- a/tests/fpgadataflow/test_fpgadataflow_convinputgenerator_rtl.py
+++ b/tests/fpgadataflow/test_fpgadataflow_convinputgenerator_rtl.py
@@ -196,8 +196,8 @@ def test_fpgadataflow_slidingwindow_rtl(
         pytest.skip("Not all combinations for stride > k edge case supported in default mode")
     if k_h == 1 and k_w == 1 and simd != ifm_ch:
         pytest.skip("1x1 Kernel only supported in parallel mode (SIMD=C)")
-    if parallel_window and simd != ifm_ch:
-        pytest.skip("Parallel window requires SIMD=C")
+    if parallel_window and simd != ifm_ch and not dw:
+        pytest.skip("Parallel window requires SIMD=C for non-depthwise case")
 
     ofm_dim_h = compute_conv_output_dim(ifm_dim_h, k_h, stride_h, 0, dilation_h)
     ofm_dim_w = compute_conv_output_dim(ifm_dim_w, k_w, stride_w, 0, dilation_w)

--- a/tests/fpgadataflow/test_fpgadataflow_convinputgenerator_rtl.py
+++ b/tests/fpgadataflow/test_fpgadataflow_convinputgenerator_rtl.py
@@ -192,11 +192,9 @@ def test_fpgadataflow_slidingwindow_rtl(
         pytest.skip("Illegal convolution configuration: kernel or stride > FM dimension")
     if (k_h == 1 and dilation_h != 1) or (k_w == 1 and dilation_w != 1):
         pytest.skip("Illegal convolution configuration: dilation for unitary kernel dim")
-    if (stride_h > k_h) or (stride_w > k_w) and not parallel_window:
+    if ((stride_h > k_h) or (stride_w > k_w)) and not (parallel_window or (k_h == 1 and k_w == 1)):
         pytest.skip("Not all combinations for stride > k edge case supported in default mode")
-    if k_h == 1 and k_w == 1 and simd != ifm_ch:
-        pytest.skip("1x1 Kernel only supported in parallel mode (SIMD=C)")
-    if parallel_window and simd != ifm_ch and not dw:
+    if parallel_window and simd != ifm_ch and not (dw or (k_h == 1 and k_w == 1)):
         pytest.skip("Parallel window requires SIMD=C for non-depthwise case")
 
     ofm_dim_h = compute_conv_output_dim(ifm_dim_h, k_h, stride_h, 0, dilation_h)


### PR DESCRIPTION
Previously, full SWG SIMD parallelism (SIMD = # Channels) was required before enabling the window-parallel mode. Due to the depthwise data layout, this prevented VVAU SIMD unfolding (across the kernel dimensions) unless VVAU PE (across the channel dimension) was maxed out.

This adds support for SWG SIMD < C when the SWG is in window-parallel and depthwise mode.
**Note that the SIMD of the SWG must match the PE of the following VVAU.**
VVAU SIMD < K is supported via a normal DWC, which is inserted automatically by the compiler.

This experimental HLS DWC component was previously introduced as a workaround for this problem and should now be obsolete: https://github.com/Xilinx/finn-hlslib/pull/134

SWG SIMD < C is also allowed in the 1x1 kernel case (no matter whether `parallel_window` is set or not), which should fix https://github.com/Xilinx/finn/discussions/895.