### PR TITLE
Enable analysis report of post synthesis resource utilization in json

### DIFF
--- a/src/finn/analysis/fpgadataflow/post_synth_res.py
+++ b/src/finn/analysis/fpgadataflow/post_synth_res.py
@@ -64,7 +64,7 @@ def post_synth_res(model, override_synth_report_filename=None):
         "FF": 6,
         "BRAM_36K": 7,
         "BRAM_18K": 8,
-        "DSP48": 9,
+        "DSP48": 10,
     }
     restype_to_ind_vitis = {
         "LUT": 4,

--- a/src/finn/builder/build_dataflow_steps.py
+++ b/src/finn/builder/build_dataflow_steps.py
@@ -57,6 +57,7 @@ import finn.transformation.streamline.absorb as absorb
 from finn.analysis.fpgadataflow.dataflow_performance import dataflow_performance
 from finn.analysis.fpgadataflow.exp_cycles_per_layer import exp_cycles_per_layer
 from finn.analysis.fpgadataflow.hls_synth_res_estimation import hls_synth_res_estimation
+from finn.analysis.fpgadataflow.post_synth_res import post_synth_res
 from finn.analysis.fpgadataflow.op_and_param_counts import (
     aggregate_dict_keys,
     op_and_param_counts,
@@ -774,6 +775,11 @@ def step_synthesize_bitfile(model: ModelWrapper, cfg: DataflowBuildConfig):
                 model.get_metadata_prop("vivado_synth_rpt"),
                 report_dir + "/post_synth_resources.xml",
             )
+
+            post_synth_resources = model.analysis(post_synth_res)
+            with open(report_dir + "/post_synth_resources.json", "w") as f:
+                json.dump(post_synth_resources, f, indent=2)
+
             vivado_pynq_proj_dir = model.get_metadata_prop("vivado_pynq_proj")
             timing_rpt = (
                 "%s/finn_zynq_link.runs/impl_1/top_wrapper_timing_summary_routed.rpt"
@@ -798,6 +804,10 @@ def step_synthesize_bitfile(model: ModelWrapper, cfg: DataflowBuildConfig):
                 model.get_metadata_prop("vivado_synth_rpt"),
                 report_dir + "/post_synth_resources.xml",
             )
+
+            post_synth_resources = model.analysis(post_synth_res)
+            with open(report_dir + "/post_synth_resources.json", "w") as f:
+                json.dump(post_synth_resources, f, indent=2)
         else:
             raise Exception("Unrecognized shell_flow_type: " + str(cfg.shell_flow_type))
         print("Bitfile written into " + bitfile_dir)


### PR DESCRIPTION
This was already implemented, it was just not called from the `step_synthesize_bitfile`. According to the last synthesis I ran using Vitis/Vivado 2022.2, the DSP48 utilization seems to be reported in row 10 of the XML table, however the hard-coded index was set to 9 before - I have fixed this as well. 