### PR TITLE
[Deps] Add "pyyaml==6.0.1" dependency to Dockefile

### DIFF
--- a/docker/Dockerfile.finn
+++ b/docker/Dockerfile.finn
@@ -102,6 +102,7 @@ RUN pip install pandas==1.5.3
 RUN pip install scikit-learn==1.2.1
 RUN pip install tqdm==4.64.1
 RUN pip install -e git+https://github.com/fbcotter/dataset_loading.git@0.0.4#egg=dataset_loading
+RUN pip install pyyaml==6.0.1
 
 # extra dependencies from other FINN deps
 # installed in Docker image to make entrypoint script go faster


### PR DESCRIPTION
More of a personal preference, but I assume I am not alone. I like to specify my model or "experiment" configurations as well as the metrics collected in YAML format instead of JSON, see here for an example: https://github.com/iksnagreb/attention-dummy/blob/benchmark/params.yaml

I think it does not hurt to add a YAML parser into the finn container, at least it should not interfere with anything else and I do not expect frequent changes to this dependency either. 

