### PR TITLE
Fix: Add stream padding to RTL SWG

### DIFF
--- a/finn-rtllib/swg/swg_template_wrapper.v
+++ b/finn-rtllib/swg/swg_template_wrapper.v
@@ -35,10 +35,10 @@ module $TOP_MODULE_NAME$ (
 	input  ap_clk,
 	(* X_INTERFACE_PARAMETER = "POLARITY ACTIVE_LOW" *)
 	input  ap_rst_n,
-	input  [BUF_IN_WIDTH-1:0] in0_V_TDATA,
+	input  [IN_WIDTH_PADDED-1:0] in0_V_TDATA,
 	input  in0_V_TVALID,
 	output in0_V_TREADY,
-	output [BUF_OUT_WIDTH-1:0] out_V_TDATA,
+	output [OUT_WIDTH_PADDED-1:0] out_V_TDATA,
 	output out_V_TVALID,
 	input  out_V_TREADY
 );
@@ -48,6 +48,8 @@ parameter BIT_WIDTH = $BIT_WIDTH$;
 parameter SIMD = $SIMD$;
 parameter MMV_IN = $MMV_IN$;
 parameter MMV_OUT = $MMV_OUT$;
+parameter IN_WIDTH_PADDED = $IN_WIDTH_PADDED$;
+parameter OUT_WIDTH_PADDED = $OUT_WIDTH_PADDED$;
 
 // derived constants
 parameter BUF_IN_WIDTH = BIT_WIDTH * SIMD * MMV_IN;
@@ -61,10 +63,10 @@ $TOP_MODULE_NAME$_impl #(
 ) impl (
 	.ap_clk(ap_clk),
 	.ap_rst_n(ap_rst_n),
-	.in0_V_V_TDATA(in0_V_TDATA),
+	.in0_V_V_TDATA(in0_V_TDATA[BUF_IN_WIDTH-1:0]),
 	.in0_V_V_TVALID(in0_V_TVALID),
 	.in0_V_V_TREADY(in0_V_TREADY),
-	.out_V_V_TDATA(out_V_TDATA),
+	.out_V_V_TDATA(out_V_TDATA[BUF_OUT_WIDTH-1:0]),
 	.out_V_V_TVALID(out_V_TVALID),
 	.out_V_V_TREADY(out_V_TREADY)
 );

--- a/finn-rtllib/swg/swg_template_wrapper_dynamic.v
+++ b/finn-rtllib/swg/swg_template_wrapper_dynamic.v
@@ -35,6 +35,8 @@ module $TOP_MODULE_NAME$ #(
     parameter SIMD = $SIMD$,
     parameter MMV_IN = $MMV_IN$,
     parameter MMV_OUT = $MMV_OUT$,
+    parameter IN_WIDTH_PADDED = $IN_WIDTH_PADDED$,
+    parameter OUT_WIDTH_PADDED = $OUT_WIDTH_PADDED$,
 
     parameter CNTR_BITWIDTH = $CNTR_BITWIDTH$,
     parameter INCR_BITWIDTH = $INCR_BITWIDTH$,
@@ -52,10 +54,10 @@ module $TOP_MODULE_NAME$ #(
     input  ap_clk,
     (* X_INTERFACE_PARAMETER = "POLARITY ACTIVE_LOW" *)
     input  ap_rst_n,
-    input  [BUF_IN_WIDTH-1:0] in0_V_TDATA,
+    input  [IN_WIDTH_PADDED-1:0] in0_V_TDATA,
     input  in0_V_TVALID,
     output in0_V_TREADY,
-    output [BUF_OUT_WIDTH-1:0] out_V_TDATA,
+    output [OUT_WIDTH_PADDED-1:0] out_V_TDATA,
     output out_V_TVALID,
     input  out_V_TREADY,
 
@@ -153,10 +155,10 @@ $TOP_MODULE_NAME$_impl #(
 ) impl (
     .ap_clk(ap_clk),
     .ap_rst_n(ap_rst_n),
-    .in0_V_V_TDATA(in0_V_TDATA),
+    .in0_V_V_TDATA(in0_V_TDATA[BUF_IN_WIDTH-1:0]),
     .in0_V_V_TVALID(in0_V_TVALID),
     .in0_V_V_TREADY(in0_V_TREADY),
-    .out_V_V_TDATA(out_V_TDATA),
+    .out_V_V_TDATA(out_V_TDATA[BUF_OUT_WIDTH-1:0]),
     .out_V_V_TVALID(out_V_TVALID),
     .out_V_V_TREADY(out_V_TREADY),
 

--- a/src/finn/custom_op/fpgadataflow/convolutioninputgenerator_rtl.py
+++ b/src/finn/custom_op/fpgadataflow/convolutioninputgenerator_rtl.py
@@ -33,6 +33,7 @@ import shutil
 from qonnx.core.datatype import DataType
 from qonnx.custom_op.general import im2col
 from qonnx.custom_op.general.im2col import compute_conv_output_dim
+from qonnx.util.basic import roundup_to_integer_multiple
 
 from finn.custom_op.fpgadataflow.hlscustomop import HLSCustomOp
 from finn.util.basic import get_rtlsim_trace_depth, make_build_dir
@@ -991,6 +992,12 @@ class ConvolutionInputGenerator_rtl(HLSCustomOp):
         # (e.g. by GiveUniqueNodeNames(prefix) during MakeZynqProject)
         self.set_nodeattr("gen_top_module", self.get_verilog_top_module_name())
         code_gen_dict["$BIT_WIDTH$"] = [str(self.get_input_datatype().bitwidth())]
+        code_gen_dict["$IN_WIDTH_PADDED$"] = [
+            str(roundup_to_integer_multiple(self.get_instream_width(), 8))
+        ]
+        code_gen_dict["$OUT_WIDTH_PADDED$"] = [
+            str(roundup_to_integer_multiple(self.get_outstream_width(), 8))
+        ]
         ram_style = self.get_nodeattr("ram_style")
         code_gen_dict["$RAM_STYLE$"] = ['"{}"'.format(ram_style)]
 

--- a/tests/fpgadataflow/test_fpgadataflow_convinputgenerator_rtl.py
+++ b/tests/fpgadataflow/test_fpgadataflow_convinputgenerator_rtl.py
@@ -134,7 +134,7 @@ def prepare_inputs(input_tensor):
 
 
 # input datatype
-@pytest.mark.parametrize("idt", [DataType["UINT4"]])
+@pytest.mark.parametrize("idt", [DataType["INT2"], DataType["UINT4"]])
 # kernel size
 @pytest.mark.parametrize("k", [[3, 3], [1, 5]])
 # input dimension


### PR DESCRIPTION
Padding to multiples of 8 seems to be required not only to satisfy the AXI Stream spec, but also for correct Verilator simulation (in case SIMD=1 and signed input with bit width that is not a multiple of 8).