### PR TITLE
Broadcast single threshold values along PE dimension

### DIFF
--- a/src/finn/custom_op/fpgadataflow/rtl/thresholding_rtl.py
+++ b/src/finn/custom_op/fpgadataflow/rtl/thresholding_rtl.py
@@ -188,6 +188,12 @@ class Thresholding_rtl(Thresholding, RTLBackend):
         o_bitwidth = DataType[output_data_type].bitwidth()
         num_channels = self.get_nodeattr("NumChannels")  # number of channels
 
+        # If a single threshold value is found, broadcast it to all channels
+        n_thres_steps = self.get_nodeattr("numSteps")
+        expected_shape = (num_channels, n_thres_steps)
+        if t_packed.shape != expected_shape:
+             t_packed = np.broadcast_to(t_packed, expected_shape)
+
         channel_fold = int(num_channels / pe)
 
         for stage in range(o_bitwidth):
@@ -506,6 +512,12 @@ class Thresholding_rtl(Thresholding, RTLBackend):
         pe = self.get_nodeattr("PE")
         ch = self.get_nodeattr("NumChannels")
         n_thres_steps = self.get_nodeattr("numSteps")
+
+        # If a single threshold value is found, broadcast it to all channels
+        n_thres_steps = self.get_nodeattr("numSteps")
+        expected_shape = (ch, n_thres_steps)
+        if weights.shape != expected_shape:
+             weights = np.broadcast_to(weights, expected_shape)
 
         width_padded = roundup_to_integer_multiple(weights.shape[1], 4)
         weight_padded = np.zeros((weights.shape[0], width_padded))

--- a/src/finn/custom_op/fpgadataflow/rtl/thresholding_rtl.py
+++ b/src/finn/custom_op/fpgadataflow/rtl/thresholding_rtl.py
@@ -188,11 +188,11 @@ class Thresholding_rtl(Thresholding, RTLBackend):
         o_bitwidth = DataType[output_data_type].bitwidth()
         num_channels = self.get_nodeattr("NumChannels")  # number of channels
 
-        # If a single threshold value is found, broadcast it to all channels
+        # If a single threshold value is found, broadcast the value
         n_thres_steps = self.get_nodeattr("numSteps")
         expected_shape = (num_channels, n_thres_steps)
-        if t_packed.shape != expected_shape:
-             t_packed = np.broadcast_to(t_packed, expected_shape)
+        if t_packed.shape == (1, 1):
+            t_packed = np.broadcast_to(t_packed, expected_shape)
 
         channel_fold = int(num_channels / pe)
 
@@ -513,11 +513,11 @@ class Thresholding_rtl(Thresholding, RTLBackend):
         ch = self.get_nodeattr("NumChannels")
         n_thres_steps = self.get_nodeattr("numSteps")
 
-        # If a single threshold value is found, broadcast it to all channels
+        # If a single threshold value is found, broadcast the value
         n_thres_steps = self.get_nodeattr("numSteps")
         expected_shape = (ch, n_thres_steps)
-        if weights.shape != expected_shape:
-             weights = np.broadcast_to(weights, expected_shape)
+        if weights.shape == (1, 1):
+            weights = np.broadcast_to(weights, expected_shape)
 
         width_padded = roundup_to_integer_multiple(weights.shape[1], 4)
         weight_padded = np.zeros((weights.shape[0], width_padded))

--- a/src/finn/transformation/qonnx/qonnx_activation_handlers.py
+++ b/src/finn/transformation/qonnx/qonnx_activation_handlers.py
@@ -515,7 +515,8 @@ class QuantIdentityHandler(QuantActBaseHandler):
         if bit_width == 1.0:
             thresholds = np.empty([1, 1], dtype=np_default_dtype)
             thresholds[0] = 0
-            return thresholds
+            num_thresholds = 1
+
         else:
             if narrow:
                 num_distinct_values = 2**bit_width - 1
@@ -537,13 +538,13 @@ class QuantIdentityHandler(QuantActBaseHandler):
                 for t in range(num_thresholds):
                     thresholds[c][t] = min_threshold[c] + step[c] * t
 
-            # ToDo: The index 1 needs to be changed to -1 for the channels last format
-            num_output_channels = self._model.get_tensor_shape(self._q_node.output[0])[1]
-            final_shape = (num_output_channels, num_thresholds)
-            if thresholds.shape != final_shape:
-                thresholds = np.broadcast_to(thresholds, final_shape)
+        # ToDo: The index 1 needs to be changed to -1 for the channels last format
+        num_output_channels = self._model.get_tensor_shape(self._q_node.output[0])[1]
+        final_shape = (num_output_channels, num_thresholds)
+        if thresholds.shape != final_shape:
+            thresholds = np.broadcast_to(thresholds, final_shape)
 
-            return thresholds
+        return thresholds
 
     def _calculate_act_scale(self):
         # Gather parameters

--- a/src/finn/transformation/qonnx/qonnx_activation_handlers.py
+++ b/src/finn/transformation/qonnx/qonnx_activation_handlers.py
@@ -515,8 +515,7 @@ class QuantIdentityHandler(QuantActBaseHandler):
         if bit_width == 1.0:
             thresholds = np.empty([1, 1], dtype=np_default_dtype)
             thresholds[0] = 0
-            num_thresholds = 1
-
+            return thresholds
         else:
             if narrow:
                 num_distinct_values = 2**bit_width - 1
@@ -538,13 +537,13 @@ class QuantIdentityHandler(QuantActBaseHandler):
                 for t in range(num_thresholds):
                     thresholds[c][t] = min_threshold[c] + step[c] * t
 
-        # ToDo: The index 1 needs to be changed to -1 for the channels last format
-        num_output_channels = self._model.get_tensor_shape(self._q_node.output[0])[1]
-        final_shape = (num_output_channels, num_thresholds)
-        if thresholds.shape != final_shape:
-            thresholds = np.broadcast_to(thresholds, final_shape)
+            # ToDo: The index 1 needs to be changed to -1 for the channels last format
+            num_output_channels = self._model.get_tensor_shape(self._q_node.output[0])[1]
+            final_shape = (num_output_channels, num_thresholds)
+            if thresholds.shape != final_shape:
+                thresholds = np.broadcast_to(thresholds, final_shape)
 
-        return thresholds
+            return thresholds
 
     def _calculate_act_scale(self):
         # Gather parameters


### PR DESCRIPTION
Added workaround to enable per tensor quantization based on channel dimensions, providing consistency with per channel quantization.

Depending on the quantization strategy, a single per tensor scale could be present, however the Thresholding RTL module expects a per channel scale. This patch provides a workaround by broadcasting the scale to imitate the per channel quantization strategy.