### PR TITLE
[Threshold RTL] padd threshold steps based on activation bitwidth

### DIFF
--- a/src/finn/custom_op/fpgadataflow/rtl/thresholding_rtl.py
+++ b/src/finn/custom_op/fpgadataflow/rtl/thresholding_rtl.py
@@ -529,7 +529,8 @@ class Thresholding_rtl(Thresholding, RTLBackend):
         if weights.shape == (1, 1):
             weights = np.broadcast_to(weights, expected_shape)
 
-        width_padded = roundup_to_integer_multiple(weights.shape[1], 4)
+        odt = self.get_output_datatype().bitwidth()
+        width_padded = roundup_to_integer_multiple(weights.shape[1], 2**odt)
         weight_padded = np.zeros((weights.shape[0], width_padded))
         weight_padded[: weights.shape[0], :n_thres_steps] = weights
         weight_stream = []

--- a/tests/end2end/test_end2end_bnn_pynq.py
+++ b/tests/end2end/test_end2end_bnn_pynq.py
@@ -135,7 +135,6 @@ def fold_tfc(model):
     inp_qnt_node = model.get_nodes_by_op_type("Thresholding_rtl")[0]
     inp_qnt = getCustomOp(inp_qnt_node)
     inp_qnt.set_nodeattr("PE", 49)
-    # TODO: update PYNQ driver to support runtime writeable weights for RTL Thresholding
     inp_qnt.set_nodeattr("runtime_writeable_weights", 1)
     return model
 

--- a/tests/end2end/test_end2end_bnn_pynq.py
+++ b/tests/end2end/test_end2end_bnn_pynq.py
@@ -136,7 +136,7 @@ def fold_tfc(model):
     inp_qnt = getCustomOp(inp_qnt_node)
     inp_qnt.set_nodeattr("PE", 49)
     # TODO: update PYNQ driver to support runtime writeable weights for RTL Thresholding
-    # inp_qnt.set_nodeattr("runtime_writeable_weights", 1)
+    inp_qnt.set_nodeattr("runtime_writeable_weights", 1)
     return model
 
 


### PR DESCRIPTION
The number of thresholding steps is 2^N where N is the activation bitwidth. the created weight file should have 0 paddings if threshold values are less than required.  