### PR TITLE
Bug fix for FIFO count range mismatch between Python and RTL

### DIFF
--- a/finn-rtllib/fifo/hdl/Q_srl.v
+++ b/finn-rtllib/fifo/hdl/Q_srl.v
@@ -73,8 +73,9 @@ module Q_srl (clock, reset, i_d, i_v, i_r, o_d, o_v, o_r, count, maxcount);
 
    parameter depth = 16;   // - greatest #items in queue  (2 <= depth <= 256)
    parameter width = 16;   // - width of data (i_d, o_d)
+   parameter countwidth = $clog2(depth + 1);
 
-   parameter addrwidth = $clog2(depth);
+   localparam addrwidth = $clog2(depth);
 
    input     clock;
    input     reset;
@@ -89,10 +90,10 @@ module Q_srl (clock, reset, i_d, i_v, i_r, o_d, o_v, o_r, count, maxcount);
    input              o_r;	// - output stream ready
    wire               o_b;	// - output stream back-pressure
 
-   output [addrwidth:0] count;  // - output number of elems in queue
-   output [addrwidth:0] maxcount;  // - maximum observed count since reset
+   output [countwidth-1:0] count;  // - output number of elems in queue
+   output [countwidth-1:0] maxcount;  // - maximum observed count since reset
 
-   reg [addrwidth:0] maxcount_reg;  // - maximum count seen until now
+   reg [countwidth-1:0] maxcount_reg;  // - maximum count seen until now
    reg    [addrwidth-1:0] addr, addr_, a_;		// - SRL16 address
 							//     for data output
    reg 			  shift_en_;			// - SRL16 shift enable

--- a/finn-rtllib/fifo/hdl/fifo_template.v
+++ b/finn-rtllib/fifo/hdl/fifo_template.v
@@ -53,7 +53,8 @@ output  $OUT_RANGE$ out_V_TDATA
 
 Q_srl #(
 .depth($DEPTH$),
-.width($WIDTH$)
+.width($WIDTH$),
+.countwidth($COUNT_WIDTH$)
 )
 impl
 (

--- a/src/finn/custom_op/fpgadataflow/rtl/streamingfifo_rtl.py
+++ b/src/finn/custom_op/fpgadataflow/rtl/streamingfifo_rtl.py
@@ -95,12 +95,13 @@ class StreamingFIFO_rtl(StreamingFIFO, RTLBackend):
         code_gen_dict["$TOP_MODULE_NAME$"] = topname
         # make instream width a multiple of 8 for axi interface
         in_width = self.get_instream_width_padded()
-        count_width = int(self.get_nodeattr("depth") - 1).bit_length()
+        count_width = int(self.get_nodeattr("depth") + 1).bit_length()
         code_gen_dict["$COUNT_RANGE$"] = "[{}:0]".format(count_width - 1)
         code_gen_dict["$IN_RANGE$"] = "[{}:0]".format(in_width - 1)
         code_gen_dict["$OUT_RANGE$"] = "[{}:0]".format(in_width - 1)
         code_gen_dict["$WIDTH$"] = str(in_width)
         code_gen_dict["$DEPTH$"] = str(self.get_nodeattr("depth"))
+        code_gen_dict["$COUNT_WIDTH$"] = count_width
         # apply code generation to templates
         code_gen_dir = self.get_nodeattr("code_gen_dir_ipgen")
         with open(template_path, "r") as f:


### PR DESCRIPTION
This PR introduces a new parameter in the RTL implementation of the StreamingFIFO component which propagates the count width value from the code generation in Python to the verilog component. 
Bug fix for https://github.com/Xilinx/finn/issues/998.