### PR TITLE
added helper function for reading from numpy files into hls::vector

### DIFF
--- a/src/finn/qnn-data/cpp/npy2vectorstream.hpp
+++ b/src/finn/qnn-data/cpp/npy2vectorstream.hpp
@@ -1,0 +1,73 @@
+#include <iostream>
+#include "cnpy.h"
+#include "hls_stream.h"
+#include "ap_int.h"
+#include <vector>
+#include <stdio.h>
+#include <hls_vector.h>
+
+#define DEBUG
+#ifdef DEBUG
+#define DEBUG_NPY2VECTORSTREAM(x) std::cout << "[npy2vectorstream] " << x << std::endl;
+#define DEBUG_VECTORSTREAM2NPY(x) std::cout << "[vectorstream2npy] " << x << std::endl;
+#else
+#define DEBUG_NPY2VECTORSTREAM(x) ;
+#define DEBUG_VECTORSTREAM2NPY(x) ;
+#endif
+
+template <typename ElemT, typename NpyT, unsigned N>
+void npy2vectorstream(const char * npy_path, hls::stream<hls::vector<ElemT,N>> & out_stream, bool reverse_inner = true, size_t numReps = 1) {
+  for (size_t rep = 0; rep < numReps; rep++) {
+    cnpy::NpyArray arr = cnpy::npy_load(npy_path);
+    DEBUG_NPY2VECTORSTREAM("word_size " << arr.word_size << " num_vals " << arr.num_vals)
+    if (arr.word_size != sizeof(NpyT)) {
+      throw "Npy array word size and specified NpyT size do not match";
+    }
+    NpyT *loaded_data = arr.data<NpyT>();
+    size_t outer_dim_elems = 1;
+    for (size_t dim = 0; dim < arr.shape.size() - 1; dim++) {
+      outer_dim_elems *= arr.shape[dim];
+    }
+    size_t inner_dim_elems = arr.shape[arr.shape.size() - 1];
+    DEBUG_NPY2VECTORSTREAM("n_outer " << outer_dim_elems << " n_inner " << inner_dim_elems)
+    for (size_t outer_elem = 0; outer_elem < outer_dim_elems; outer_elem++) {
+      hls::vector <ElemT, N> vec;
+      for (size_t ii = 0; ii < inner_dim_elems; ii++) {
+        NpyT elemNpy = loaded_data[outer_elem * inner_dim_elems + ii];
+        ElemT elem = loaded_data[outer_elem * inner_dim_elems + ii];
+        DEBUG_NPY2VECTORSTREAM("npy2 elem = " << elem << ", loaded data = " << loaded_data[outer_elem * inner_dim_elems + ii])
+        vec[ii] = elem;
+      }
+      out_stream << vec;
+    }
+  }
+}
+
+template <typename ElemT, typename NpyT, unsigned N>
+void vectorstream2npy(hls::stream<hls::vector<ElemT,N>> & in_stream, const std::vector<size_t> & shape, const char * npy_path, bool reverse_inner = false, size_t numReps = 1, size_t multi_pixel_out = 1) {
+  for(size_t rep = 0; rep < numReps; rep++) {
+    std::vector<NpyT> data_to_save;
+    size_t outer_dim_elems = 1;
+    for(size_t dim = 0; dim < shape.size()-1; dim++) {
+      outer_dim_elems *= shape[dim];
+    }
+    size_t inner_dim_elems = shape[shape.size()-1] / multi_pixel_out;
+    DEBUG_VECTORSTREAM2NPY("n_outer " << outer_dim_elems << " n_inner " << inner_dim_elems << " n_multi_pixel_out " << multi_pixel_out)
+    for(size_t outer_elem = 0; outer_elem < outer_dim_elems; outer_elem++) {
+      for(size_t ii_multi_pixel_out = 0; ii_multi_pixel_out < multi_pixel_out; ii_multi_pixel_out++) {
+        // loop over multi_pixel_out blocks of inner_dim_elems separately,
+        // so that reverse_inner is not applied across multiple pixels
+        hls::vector<ElemT, N> elems;
+        in_stream >> elems;
+        for(size_t ii = 0; ii < inner_dim_elems; ii++) {
+          size_t i = ii_multi_pixel_out*inner_dim_elems;
+          i += reverse_inner ? inner_dim_elems-ii-1 : ii;
+          NpyT npyt = (NpyT) elems[i];
+          DEBUG_VECTORSTREAM2NPY("elems[i] = " << elems[i] << ", NpyT = " << npyt)
+          data_to_save.push_back(npyt);
+        }
+      }
+    }
+    cnpy::npy_save(npy_path, &data_to_save[0], shape, "w");
+  }
+}

--- a/src/finn/qnn-data/cpp/npy2vectorstream.hpp
+++ b/src/finn/qnn-data/cpp/npy2vectorstream.hpp
@@ -6,7 +6,7 @@
 #include <stdio.h>
 #include <hls_vector.h>
 
-#define DEBUG
+//#define DEBUG
 #ifdef DEBUG
 #define DEBUG_NPY2VECTORSTREAM(x) std::cout << "[npy2vectorstream] " << x << std::endl;
 #define DEBUG_VECTORSTREAM2NPY(x) std::cout << "[vectorstream2npy] " << x << std::endl;

--- a/tests/util/test_hls_vector.py
+++ b/tests/util/test_hls_vector.py
@@ -1,0 +1,117 @@
+# Copyright (c) 2020, Xilinx
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of FINN nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+import pytest
+
+import numpy as np
+import os
+import shutil
+import subprocess
+from qonnx.core.datatype import DataType
+from qonnx.util.basic import gen_finn_dt_tensor
+
+from finn.util.basic import make_build_dir
+
+
+@pytest.mark.util
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        DataType["BINARY"],
+        DataType["UINT8"],
+        DataType["INT32"],
+        DataType["FIXED<9,6>"],
+        DataType["FLOAT32"],
+    ],
+)
+@pytest.mark.parametrize("test_shape", [(1, 2, 4), (1, 1, 64), (2, 64)])
+@pytest.mark.vivado
+def test_npy2vectorstream(test_shape, dtype):
+    ndarray = gen_finn_dt_tensor(dtype, test_shape)
+    test_dir = make_build_dir(prefix="test_npy2vectorstream_")
+    shape = ndarray.shape
+    elem_hls_type = dtype.get_hls_datatype_str()
+    vLen = shape[(len(shape)) - 1]
+    npy_in = test_dir + "/in.npy"
+    npy_out = test_dir + "/out.npy"
+    # restrict the np datatypes we can handle
+    npyt_to_ct = {
+        "float32": "float",
+        "float64": "double",
+        "int8": "int8_t",
+        "int32": "int32_t",
+        "int64": "int64_t",
+        "uint8": "uint8_t",
+        "uint32": "uint32_t",
+        "uint64": "uint64_t",
+    }
+    npy_type = npyt_to_ct[str(ndarray.dtype)]
+    shape_cpp_str = str(shape).replace("(", "{").replace(")", "}")
+    test_app_string = []
+    test_app_string += ["#include <cstddef>"]
+    test_app_string += ["#define AP_INT_MAX_W 8191"]
+    test_app_string += ['#include "ap_int.h"']
+    test_app_string += ['#include "stdint.h"']
+    test_app_string += ['#include "hls_stream.h"']
+    test_app_string += ['#include "hls_vector.h"']
+    test_app_string += ['#include "cnpy.h"']
+    test_app_string += ['#include "npy2vectorstream.hpp"']
+    test_app_string += ["int main(int argc, char *argv[]) {"]
+    test_app_string += ["hls::stream<hls::vector<%s, %d>> teststream;" % (elem_hls_type, vLen)]
+    test_app_string += [
+        'npy2vectorstream<%s, %s, %d>("%s", teststream);' % (elem_hls_type, npy_type, vLen, npy_in)
+    ]
+    test_app_string += [
+        'vectorstream2npy<%s, %s, %d>(teststream, %s, "%s");'
+        % (elem_hls_type, npy_type, vLen, shape_cpp_str, npy_out)
+    ]
+    test_app_string += ["return 0;"]
+    test_app_string += ["}"]
+    with open(test_dir + "/test.cpp", "w") as f:
+        f.write("\n".join(test_app_string))
+    cmd_compile = """
+g++ -o test_npy2vectorstream test.cpp $FINN_ROOT/deps/cnpy/cnpy.cpp \
+-I$FINN_ROOT/deps/cnpy/ -I{}/include -I$FINN_ROOT/src/finn/qnn-data/cpp \
+--std=c++14 -lz """.format(
+        os.environ["HLS_PATH"]
+    )
+    with open(test_dir + "/compile.sh", "w") as f:
+        f.write(cmd_compile)
+    compile = subprocess.Popen(["sh", "compile.sh"], stdout=subprocess.PIPE, cwd=test_dir)
+    (stdout, stderr) = compile.communicate()
+    # make copy before saving the array
+    ndarray = ndarray.copy()
+    np.save(npy_in, ndarray)
+    execute = subprocess.Popen("./test_npy2vectorstream", stdout=subprocess.PIPE, cwd=test_dir)
+    (stdout, stderr) = execute.communicate()
+    produced = np.load(npy_out)
+    success = (produced == ndarray).all()
+    # only delete generated code if test has passed
+    # useful for debug otherwise
+    if success:
+        shutil.rmtree(test_dir)
+    assert success


### PR DESCRIPTION
This PR adds a helper function to support reading from numpy files directly into `hls::vector`, see issue [1046](https://github.com/Xilinx/finn/issues/1046).