### PR TITLE
Double pumped DSPs

### DIFF
--- a/finn-rtllib/mvu/mvu_vvu_axi_wrapper.v
+++ b/finn-rtllib/mvu/mvu_vvu_axi_wrapper.v
@@ -34,7 +34,7 @@
 module $MODULE_NAME_AXI_WRAPPER$ #(
 	parameter	IS_MVU = $IS_MVU$,
 	parameter	COMPUTE_CORE = "$COMPUTE_CORE$",
-	parameter	PUMPED_COMPUTE = 0,
+	parameter	PUMPED_COMPUTE = $PUMPED_COMPUTE$,
 	parameter	MW = $MW$,
 	parameter	MH = $MH$,
 	parameter	PE = $PE$,
@@ -55,9 +55,9 @@ module $MODULE_NAME_AXI_WRAPPER$ #(
 	(* X_INTERFACE_PARAMETER = "ASSOCIATED_BUSIF weights_V:in0_V:out_V, ASSOCIATED_RESET ap_rst_n" *)
 	(* X_INTERFACE_INFO = "xilinx.com:signal:clock:1.0 ap_clk CLK" *)
 	input	ap_clk,
-	// (* X_INTERFACE_PARAMETER = "ASSOCIATED_RESET ap_rst_n" *)
-	// (* X_INTERFACE_INFO = "xilinx.com:signal:clock:1.0 ap_clk2x CLK" *)
-	// input   ap_clk2x,
+	(* X_INTERFACE_PARAMETER = "ASSOCIATED_RESET ap_rst_n" *)
+	(* X_INTERFACE_INFO = "xilinx.com:signal:clock:1.0 ap_clk2x CLK" *)
+	input   ap_clk2x,
 	(* X_INTERFACE_PARAMETER = "POLARITY ACTIVE_LOW" *)
 	input	ap_rst_n,
 
@@ -81,7 +81,7 @@ mvu_vvu_axi #(
 	.SIGNED_ACTIVATIONS(SIGNED_ACTIVATIONS), .SEGMENTLEN(SEGMENTLEN), .FORCE_BEHAVIORAL(FORCE_BEHAVIORAL)
 	) inst (
 	.ap_clk(ap_clk),
-	.ap_clk2x(1'b0), // wired to ground since double-pumped compute not enabled through FINN for now
+	.ap_clk2x(ap_clk2x), // wired to ground since double-pumped compute not enabled through FINN for now
 	.ap_rst_n(ap_rst_n),
 	.s_axis_weights_tdata(weights_V_TDATA),
 	.s_axis_weights_tvalid(weights_V_TVALID),


### PR DESCRIPTION
Work in progress for double-pumped DSPs. Requires more testing and extension from MVU to VVU layer.

**Dependencies:**

- Requires extension to PyVerilator to enable double-clock. This is a WIP item and best to be continued from the following branch: https://github.com/maltanar/pyverilator/tree/refactor/drive_rising_edge