### PR TITLE
Enable optional xrt installation from local deb

### DIFF
--- a/docker/Dockerfile.finn
+++ b/docker/Dockerfile.finn
@@ -83,7 +83,7 @@ RUN cd verilator && \
 RUN if [ -z "$LOCAL_XRT" ] && [ -z "$SKIP_XRT" ];then \
     wget -U 'Mozilla/5.0 (X11; Linux i686) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1312.27 Safari/537.17' "https://www.xilinx.com/bin/public/openDownload?filename=$XRT_DEB_VERSION.deb" -O /tmp/$XRT_DEB_VERSION.deb; fi
 
-COPY $XRT_DEB_VERSION.deb /tmp/$XRT_DEB_VERSION.deb
+COPY requirements.txt $XRT_DEB_VERSION.* /tmp/
 
 RUN if [ -z "$SKIP_XRT" ];then \
     apt install -y /tmp/$XRT_DEB_VERSION.deb && \
@@ -91,9 +91,8 @@ RUN if [ -z "$SKIP_XRT" ];then \
 
 # versioned Python package requirements for FINN compiler
 # these are given in requirements.txt
-COPY requirements.txt .
-RUN pip install -r requirements.txt
-RUN rm requirements.txt
+RUN pip install -r /tmp/requirements.txt
+RUN rm /tmp/requirements.txt
 
 # install PyTorch
 RUN pip install torch==1.13.1 torchvision==0.14.1 torchaudio==0.13.1 --extra-index-url https://download.pytorch.org/whl/cu116

--- a/docker/Dockerfile.finn
+++ b/docker/Dockerfile.finn
@@ -80,7 +80,7 @@ RUN cd verilator && \
     make install
 
 # install XRT
-RUN if [ -z "$LOCAL_XRT" ];then \
+RUN if [ -z "$LOCAL_XRT" ] && [ -z "$SKIP_XRT" ];then \
     wget -U 'Mozilla/5.0 (X11; Linux i686) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1312.27 Safari/537.17' "https://www.xilinx.com/bin/public/openDownload?filename=$XRT_DEB_VERSION.deb" -O /tmp/$XRT_DEB_VERSION.deb; fi
 
 COPY $XRT_DEB_VERSION.deb /tmp/$XRT_DEB_VERSION.deb

--- a/docker/Dockerfile.finn
+++ b/docker/Dockerfile.finn
@@ -32,6 +32,7 @@ LABEL maintainer="Jakoba Petri-Koenig <jakoba.petri-koenig@amd.com>, Yaman Umuro
 
 ARG XRT_DEB_VERSION="xrt_202220.2.14.354_22.04-amd64-xrt"
 ARG SKIP_XRT
+ARG LOCAL_XRT
 
 WORKDIR /workspace
 
@@ -79,8 +80,12 @@ RUN cd verilator && \
     make install
 
 # install XRT
+RUN if [ -z "$LOCAL_XRT" ];then \
+    wget -U 'Mozilla/5.0 (X11; Linux i686) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1312.27 Safari/537.17' "https://www.xilinx.com/bin/public/openDownload?filename=$XRT_DEB_VERSION.deb" -O /tmp/$XRT_DEB_VERSION.deb; fi
+
+COPY $XRT_DEB_VERSION.deb /tmp/$XRT_DEB_VERSION.deb
+
 RUN if [ -z "$SKIP_XRT" ];then \
-    wget -U 'Mozilla/5.0 (X11; Linux i686) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1312.27 Safari/537.17' "https://www.amd.com/bin/public/amdOpenDownload?filename=$XRT_DEB_VERSION.deb" -O /tmp/$XRT_DEB_VERSION.deb --debug && \
     apt install -y /tmp/$XRT_DEB_VERSION.deb && \
     rm /tmp/$XRT_DEB_VERSION.deb; fi
 

--- a/run-docker.sh
+++ b/run-docker.sh
@@ -101,6 +101,7 @@ SCRIPTPATH=$(dirname "$SCRIPT")
 : ${DOCKER_BUILDKIT="1"}
 : ${FINN_SINGULARITY=""}
 : ${FINN_SKIP_XRT_DOWNLOAD=""}
+: ${FINN_XRT_PATH=""}
 
 DOCKER_INTERACTIVE=""
 
@@ -182,14 +183,27 @@ if [ "$FINN_SKIP_DEP_REPOS" = "0" ]; then
   ./fetch-repos.sh
 fi
 
+# If xrt path given, copy .deb file to this repo
+# Be aware that we assume a certain name of the xrt deb version
+if [ -d "$FINN_XRT_PATH" ];then
+  cp $FINN_XRT_PATH/$XRT_DEB_VERSION.deb .
+  export LOCAL_XRT=1
+fi
+
 # Build the FINN Docker image
 if [ "$FINN_DOCKER_PREBUILT" = "0" ] && [ -z "$FINN_SINGULARITY" ]; then
   # Need to ensure this is done within the finn/ root folder:
   OLD_PWD=$(pwd)
   cd $SCRIPTPATH
-  docker build -f docker/Dockerfile.finn --build-arg XRT_DEB_VERSION=$XRT_DEB_VERSION --build-arg SKIP_XRT=$FINN_SKIP_XRT_DOWNLOAD --tag=$FINN_DOCKER_TAG $FINN_DOCKER_BUILD_EXTRA .
+  docker build -f docker/Dockerfile.finn --build-arg XRT_DEB_VERSION=$XRT_DEB_VERSION --build-arg SKIP_XRT=$FINN_SKIP_XRT_DOWNLOAD --build-arg LOCAL_XRT=$LOCAL_XRT --tag=$FINN_DOCKER_TAG $FINN_DOCKER_BUILD_EXTRA .
   cd $OLD_PWD
 fi
+
+# Remove local xrt.deb file from repo
+if [ ! -z "$LOCAL_XRT" ];then
+  rm $XRT_DEB_VERSION.deb
+fi
+
 # Launch container with current directory mounted
 # important to pass the --init flag here for correct Vivado operation, see:
 # https://stackoverflow.com/questions/55733058/vivado-synthesis-hangs-in-docker-container-spawned-by-jenkins


### PR DESCRIPTION
This PR expands the capability of the docker scripts to install xrt from local .deb file.

To use a local file, set the env var FINN_XRT_PATH to the path in which the .deb file lies. Be aware, that we currently assume a specific xrt deb version: `xrt_202220.2.14.354_22.04-amd64-xrt`, see here: https://github.com/Xilinx/finn/blob/dev/run-docker.sh#L89