### PR TITLE
Install setupstools explicitly in Dockerfile

### DIFF
--- a/docker/Dockerfile.finn
+++ b/docker/Dockerfile.finn
@@ -132,6 +132,9 @@ RUN pip install tokenize-rt==4.2.1
 # pyverilator
 RUN pip install tclwrapper==0.0.1
 
+# assure that we have the right setuptools version
+RUN pip install setuptools==68.2.2
+
 # extra environment variables for FINN compiler
 ENV VIVADO_IP_CACHE "/tmp/vivado_ip_cache"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,6 @@ psutil==5.9.4
 pyscaffold==4.4
 scipy==1.10.1
 setupext-janitor>=1.1.2
-setuptools==68.2.2
 sigtools==4.0.1
 toposort==1.7.0
 vcdvcd==1.0.5


### PR DESCRIPTION
The setuptools version was overwritten by the jupyter installation, so it got moved directly to the Dockerfile as last pip install command.