### PR TITLE
Increased liveness threshold for verify_step_stitched_ip_rtlsim

### DIFF
--- a/src/finn/builder/build_dataflow_steps.py
+++ b/src/finn/builder/build_dataflow_steps.py
@@ -666,7 +666,7 @@ def step_create_stitched_ip(model: ModelWrapper, cfg: DataflowBuildConfig):
         estimate_network_performance = verify_model.analysis(dataflow_performance)
         prev_liveness = pyverilate_get_liveness_threshold_cycles()
         os.environ["LIVENESS_THRESHOLD"] = str(
-            int(estimate_network_performance["critical_path_cycles"])
+            int(estimate_network_performance["critical_path_cycles"] * 1.1)
         )
         if cfg.verify_save_rtlsim_waveforms:
             report_dir = cfg.output_dir + "/report"


### PR DESCRIPTION
Increases the liveness threshold for the verification step stitched_ip_rtlsim. This will provide a bit more leeway when running rtlsim and prevent the bnn-pynq models from timing out when verification is run during the build.