### PR TITLE
better logging

### DIFF
--- a/src/finn/util/logger.py
+++ b/src/finn/util/logger.py
@@ -1,0 +1,121 @@
+# Description: This module provides a logger class and decorators for logging function calls and performance.
+#              outputs are written to both console and a file named 'finn.log'.
+#              the log level can be set using the verbosity argument in the configure_logging method.
+#              verbosity can be set to 0, 1, 2, or 3 for logging levels WARNING, INFO, DEBUG, and NOTSET respectively.
+# usage example:
+#       from logger import finn_logger, log_func, log_func_perf
+#       finn_logger.configure_logging(verbosity)
+#       logger = finn_logger.get_logger(__name__)
+#       @log_func(__name__)
+#       @log_func_perf(__name__)
+#       def my_function():
+#           logger.info("Hello, world!")
+#           logger.warning("This is a warning!")
+#           logger.error("This is an error!")
+#           logger.debug("This is a debug message!")
+#           return 42
+
+import logging
+import logging.config
+import functools
+import time
+
+LOGGING_CONFIG = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'formatters': {
+        'standard': {
+            'format': '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+        },
+        'detailed': {
+            'format': '%(asctime)s - %(name)s - %(levelname)s - %(message)s [in %(pathname)s:%(lineno)d]'
+        },
+    },
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+            'formatter': 'standard',
+            'level': 'NOTSET',
+        },
+        'file': {
+            'class': 'logging.FileHandler',
+            'filename': 'finn.log',
+            'formatter': 'detailed',
+            'level': 'NOTSET',
+        },
+    },
+    'loggers': {
+        '': {  # root logger
+            'handlers': ['console', 'file'],
+            'level': 'NOTSET',
+            'propagate': True
+        }
+    }
+}
+
+class FinnLogger:
+    def __init__(self, config):
+        self.config = config
+
+    def get_logging_level(self, verbosity):
+        if verbosity == 0:
+            return logging.WARNING
+        elif verbosity == 1:
+            return logging.INFO
+        elif verbosity == 2:
+            return logging.DEBUG
+        else:
+            return logging.NOTSET
+
+    def configure_logging(self, verbosity):
+        logging_level = self.get_logging_level(verbosity)
+        self.config['handlers']['console']['level'] = logging_level
+        self.config['handlers']['file']['level'] = logging_level
+        logging.config.dictConfig(self.config)
+
+    def get_logger(self, name):
+        return logging.getLogger(name)
+
+
+finn_logger = FinnLogger(LOGGING_CONFIG)
+
+# Decorator for logging function calls
+def log_func(logger_name):
+    def decorator_log_func(func):
+        logger = finn_logger.get_logger(logger_name)
+
+        @functools.wraps(func)
+        def wrapper_log_func(*args, **kwargs):
+            logger.info(f"Entering {func.__name__} with args: {args} and kwargs: {kwargs}")
+            try:
+                result = func(*args, **kwargs)
+                logger.info(f"Exiting {func.__name__} with result: {result}")
+                return result
+            except Exception as e:
+                logger.error(f"Exception in {func.__name__}: {e}")
+                raise
+        return wrapper_log_func
+    return decorator_log_func
+
+# Decorator for logging function performance
+def log_func_perf(logger_name):
+    def decorator_log_func_perf(func):
+        logger = finn_logger.get_logger(logger_name)
+
+        @functools.wraps(func)
+        def wrapper_log_func_perf(*args, **kwargs):
+            start_time = time.time()
+            logger.info(f"Starting {func.__name__}")
+            try:
+                result = func(*args, **kwargs)
+                end_time = time.time()
+                elapsed_time = end_time - start_time
+                logger.info(f"Finished {func.__name__} in {elapsed_time:.4f} seconds")
+                return result
+            except Exception as e:
+                end_time = time.time()
+                elapsed_time = end_time - start_time
+                logger.error(f"Exception in {func.__name__} after {elapsed_time:.4f} seconds: {e}")
+                raise
+        return wrapper_log_func_perf
+    return decorator_log_func_perf

--- a/src/finn/util/logger.py
+++ b/src/finn/util/logger.py
@@ -24,30 +24,32 @@ LOGGING_CONFIG = {
     'version': 1,
     'disable_existing_loggers': False,
     'formatters': {
-        'standard': {
-            'format': '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+        'brief': {
+            'format': '[%(levelname)-6s] %(asctime)s - %(message)s',
+            'datefmt': '%d-%m-%Y %H:%M:%S'
         },
-        'detailed': {
-            'format': '%(asctime)s - %(name)s - %(levelname)s - %(message)s [in %(pathname)s:%(lineno)d]'
+        'precise': {
+            'format': '[%(levelname)-6s] %(asctime)s - %(name)s - %(message)s [in %(pathname)s:%(lineno)d]',
+            'datefmt': '%d-%m-%Y %H:%M:%S'
         },
     },
     'handlers': {
         'console': {
             'class': 'logging.StreamHandler',
-            'formatter': 'standard',
-            'level': 'NOTSET',
+            'formatter': 'brief',
+            'level': 'INFO',
         },
         'file': {
             'class': 'logging.FileHandler',
             'filename': 'finn.log',
-            'formatter': 'detailed',
-            'level': 'NOTSET',
+            'formatter': 'precise',
+            'level': 'DEBUG',
         },
     },
     'loggers': {
         '': {  # root logger
             'handlers': ['console', 'file'],
-            'level': 'NOTSET',
+            'level': 'DEBUG',
             'propagate': True
         }
     }
@@ -86,13 +88,13 @@ def log_func(logger_name):
 
         @functools.wraps(func)
         def wrapper_log_func(*args, **kwargs):
-            logger.info(f"Entering {func.__name__} with args: {args} and kwargs: {kwargs}")
+            logger.debug(f"Entering {func.__name__}")
             try:
                 result = func(*args, **kwargs)
-                logger.info(f"Exiting {func.__name__} with result: {result}")
+                logger.debug(f"Exiting {func.__name__}")
                 return result
             except Exception as e:
-                logger.error(f"Exception in {func.__name__}: {e}")
+                logger.error(f"Exception in {func.__name__}: {e}", exc_info=True)
                 raise
         return wrapper_log_func
     return decorator_log_func
@@ -105,17 +107,17 @@ def log_func_perf(logger_name):
         @functools.wraps(func)
         def wrapper_log_func_perf(*args, **kwargs):
             start_time = time.time()
-            logger.info(f"Starting {func.__name__}")
+            logger.debug(f"Starting {func.__name__}")
             try:
                 result = func(*args, **kwargs)
                 end_time = time.time()
                 elapsed_time = end_time - start_time
-                logger.info(f"Finished {func.__name__} in {elapsed_time:.4f} seconds")
+                logger.debug(f"Finished {func.__name__} in {elapsed_time:.4f} seconds")
                 return result
             except Exception as e:
                 end_time = time.time()
                 elapsed_time = end_time - start_time
-                logger.error(f"Exception in {func.__name__} after {elapsed_time:.4f} seconds: {e}")
+                logger.error(f"Exception in {func.__name__} after {elapsed_time:.4f} seconds: {e}", exc_info=True)
                 raise
         return wrapper_log_func_perf
     return decorator_log_func_perf


### PR DESCRIPTION
This is to add a project wide logger.

# Features
1. Use python logging module 
2. Brief console log
3. More detailed file log
4. Accessible configuration 

# Usage
## Internal logging
The logger can be used internally in all finn modules. 
```
       from logger import finn_logger, log_func, log_func_perf
       logger = finn_logger.get_logger(__name__)

       @log_func(__name__)
       @log_func_perf(__name__)
       def my_function():
           logger.info("Hello, world!")
           logger.warning("This is a warning!")
           logger.error("This is an error!")
           logger.debug("This is a debug message!")
           return 42
```

## Control verbosity with argparser 
control verbosity any where, 
```
    from finn.util.logger import finn_logger 
    parser.add_argument('-v', '--verbose', action='count', default=0, help="Increase verbosity level (use -v, -vv, or -vvv)")
    args = parser.parse_args()
    
    # Configure logging based on verbosity
    finn_logger.configure_logging(args.verbose)
    logger = finn_logger.get_logger('main')

    logger.info("Applying FINN steps on " + args.onnx)
```




##  Console output gets brief prints

```
[INFO  ] 15-08-2024 17:54:09 - Building dataflow accelerator from onnx/model.onnx
[INFO  ] 15-08-2024 17:54:09 - Running step: step_tidy_up [1/3]
[INFO  ] 15-08-2024 17:54:10 - Running step: step_qonnx_to_finn [2/3]
```

## Log file gets precise prints

```
[INFO  ] 15-08-2024 18:02:14 - main - Applying FINN steps on onnx/model.onnx [in /group/cdc_ir/members/azizb/workspace/sandbox_finn/finn-flow/sandbox-flow/gen_ip.py:41]
[INFO  ] 15-08-2024 18:02:14 - finn.builder.build_dataflow - Building dataflow accelerator from onnx/model.onnx [in /group/cdc_ir/members/azizb/workspace/brainwave/finn/src/finn/builder/build_dataflow.py:95]
[INFO  ] 15-08-2024 18:02:14 - finn.builder.build_dataflow - Running step: step_tidy_up [1/3] [in /group/cdc_ir/members/azizb/workspace/brainwave/finn/src/finn/builder/build_dataflow.py:115]
[DEBUG ] 15-08-2024 18:02:14 - finn.builder.build_dataflow_steps - Starting step_tidy_up [in /group/cdc_ir/members/azizb/workspace/brainwave/finn/src/finn/util/logger.py:110]
[DEBUG ] 15-08-2024 18:02:14 - finn.builder.build_dataflow_steps - Finished step_tidy_up in 0.0419 seconds [in /group/cdc_ir/members/azizb/workspace/brainwave/finn/src/finn/util/logger.py:115]
[INFO  ] 15-08-2024 18:02:14 - finn.builder.build_dataflow - Running step: step_qonnx_to_finn [2/3] [in /group/cdc_ir/members/azizb/workspace/brainwave/finn/src/finn/builder/build_dataflow.py:115]
[INFO  ] 15-08-2024 18:02:14 - finn.builder.build_dataflow - Running step: step_tidy_up [3/3] [in /group/cdc_ir/members/azizb/workspace/brainwave/finn/src/finn/builder/build_dataflow.py:115]
[DEBUG ] 15-08-2024 18:02:14 - finn.builder.build_dataflow_steps - Starting step_tidy_up [in /group/cdc_ir/members/azizb/workspace/brainwave/finn/src/finn/util/logger.py:110]
[DEBUG ] 15-08-2024 18:02:14 - finn.builder.build_dataflow_steps - Finished step_tidy_up in 0.0363 seconds [in /group/cdc_ir/members/azizb/workspace/brainwave/finn/src/finn/util/logger.py:115]
[INFO  ] 15-08-2024 18:02:14 - finn.builder.build_dataflow - Completed successfully [in /group/cdc_ir/members/azizb/workspace/brainwave/finn/src/finn/builder/build_dataflow.py:142]


```
