### PR TITLE
Separate Input/Output datatype template parameters

### DIFF
--- a/custom_hls/softmax.hpp
+++ b/custom_hls/softmax.hpp
@@ -268,18 +268,19 @@ void quant_stage(
 template<
 	 unsigned N, // The width of the input dimension 
 	 unsigned SIMD, // Amount of parallelism (how many items consumed/produced at a time 
-	 typename T  
+	 typename TI, // Input type param  
+	 typename TO // Output type param
 	 >
 void smaxquant(
-	hls::stream<hls::vector<T,SIMD>> &src,
-	hls::stream<hls::vector<T,SIMD>> &dst
+	hls::stream<hls::vector<TI,SIMD>> &src,
+	hls::stream<hls::vector<TO,SIMD>> &dst
 ) {
 #pragma HLS DATAFLOW disable_start_propagation
 	hls::stream<hls::vector<float,SIMD>> smax_out;
 #pragma HLS stream variable=smax_out depth=2
 	static_assert(N%SIMD == 0, "SIMD must be a factor of N"); 
 
-	smax<N,SIMD,T>(src, smax_out);
-	quant_stage<N,SIMD,T>(smax_out, dst);
+	smax<N,SIMD,TI>(src, smax_out);
+	quant_stage<N,SIMD,TO>(smax_out, dst);
 
 } // smaxquant()

--- a/src/finn/transformation/fpgadataflow/convert_to_hw_layers.py
+++ b/src/finn/transformation/fpgadataflow/convert_to_hw_layers.py
@@ -1779,6 +1779,7 @@ class InferQuantSoftmax(Transformation):
                     "Softmax and MultiThreshold input shapes do not match"
                 )
                 idt0 = model.get_tensor_datatype(n.input[0])
+                odt0 = model.get_tensor_datatype(n.output[0])
                 # create node with no parallelization first
                 simd = 1
                 # create and insert new node
@@ -1789,7 +1790,8 @@ class InferQuantSoftmax(Transformation):
                     domain="finn.custom_op.fpgadataflow",
                     backend="fpgadataflow",
                     ifm_dim=input_shape,
-                    data_type = idt0.name,
+                    input_data_type = idt0.name,
+                    output_data_type = odt0.name,
                     name="Quant"+n.name,
                     simd=simd
                 )

--- a/tests/fpgadataflow/test_fpgadataflow_softmax.py
+++ b/tests/fpgadataflow/test_fpgadataflow_softmax.py
@@ -191,8 +191,8 @@ def test_convert_to_hw_softmax_layer(exec_mode, simd):
 
 @pytest.mark.parametrize("impl_style", ["hls"])
 @pytest.mark.parametrize("simd", ["simd1", "simd2", "simd3", "simd4"])
-@pytest.mark.parametrize("idt", ["INT8",  "INT16"])
-@pytest.mark.parametrize("odt", ["INT8",  "INT16"])
+@pytest.mark.parametrize("idt", ["INT8", "INT9", "INT16"])
+@pytest.mark.parametrize("odt", ["INT8", "INT16"])
 @pytest.mark.parametrize("ifm_dim", [(1, 128, 384), (1, 12, 12, 128)])
 @pytest.mark.fpgadataflow
 def test_fpga_dataflow_quantsoftmax(impl_style, simd, idt, odt, ifm_dim):

--- a/tests/fpgadataflow/test_fpgadataflow_softmax.py
+++ b/tests/fpgadataflow/test_fpgadataflow_softmax.py
@@ -95,7 +95,7 @@ def create_model(io_shape=(1, 12, 128, 128), idt=DataType["INT8"]):
     model.set_tensor_datatype(model.graph.input[0].name, idt)
     return model, dut.get_quant_scale()
 
-def make_single_quantsoftmax_modelwrapper(impl_style="hls", simd=1, idt=DataType["UINT8"], ifm_dim=(128, 128)):
+def make_single_quantsoftmax_modelwrapper(impl_style="hls", simd=1, idt=DataType["UINT8"], odt=DataType["UINT8"], ifm_dim=(128, 128)):
     '''
     Create a single quantized softmax node with variable parameters.
     this is before SpecializeLayers() transformation.
@@ -109,7 +109,8 @@ def make_single_quantsoftmax_modelwrapper(impl_style="hls", simd=1, idt=DataType
         domain="finn.custom_op.fpgadataflow",
         backend="fpgadataflow",
         ifm_dim=list(ifm_dim),
-        data_type = idt.name,
+        input_data_type = idt.name,
+        output_data_type = odt.name,
         simd=simd,
         preferred_impl_style=impl_style,
     )
@@ -191,14 +192,16 @@ def test_convert_to_hw_softmax_layer(exec_mode, simd):
 @pytest.mark.parametrize("impl_style", ["hls"])
 @pytest.mark.parametrize("simd", ["simd1", "simd2", "simd3", "simd4"])
 @pytest.mark.parametrize("idt", ["INT8"])
+@pytest.mark.parametrize("odt", ["INT8"])
 @pytest.mark.parametrize("ifm_dim", [(1, 128, 384), (1, 12, 12, 128)])
 @pytest.mark.fpgadataflow
-def test_fpga_dataflow_quantsoftmax(impl_style, simd, idt, ifm_dim):
+def test_fpga_dataflow_quantsoftmax(impl_style, simd, idt, odt, ifm_dim):
     idt = DataType[idt]
+    odt = DataType[odt]
     simd = int(simd[-1])
     io_shape = ifm_dim
     tollerance = 2
-    model = make_single_quantsoftmax_modelwrapper(impl_style=impl_style, simd=simd, idt=idt, ifm_dim=ifm_dim)
+    model = make_single_quantsoftmax_modelwrapper(impl_style=impl_style, simd=simd, idt=idt, odt=odt, ifm_dim=ifm_dim)
 
     if(ifm_dim[-1] % simd != 0):
         pytest.skip(f"Skipping this test because the inner dimension is not a multiple of {simd}")


### PR DESCRIPTION
This PR updates the softmax integration to include the ability to specify input and output template datatype parameters separately. 

The main changes are:
* Updated to the HLS code to enable the specification of the separate templates for input/output.
* Compiler integration to enable the inference of the output data types and appropriate codegen.
* Test updates to allow the specification of different input/output datatypes.

I have only tested the quantsoftmax node with the following:
```
tests/fpgadataflow/test_fpgadataflow_softmax.py::test_fpga_dataflow_quantsoftmax[ifm_dim0-INT8-INT8-simd4-hls] PASSED
tests/fpgadataflow/test_fpgadataflow_softmax.py::test_fpga_dataflow_quantsoftmax[ifm_dim1-INT8-INT8-simd4-hls] PASSED

```