### PR TITLE
Faster packing 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ htmlcov/*
 junit.xml
 coverage.xml
 .pytest_cache/
+tests/util/fastpack_*.txt
 
 # Build and docs folder/files
 build/*

--- a/src/finn/util/data_packing.py
+++ b/src/finn/util/data_packing.py
@@ -103,7 +103,7 @@ def array2hexstring(array, dtype, pad_to_nbits, prefix="0x", reverse=False, use_
     # TODO: Expand this to cover more cases
     if use_fastpack and dtype == DataType["BINARY"] and prefix == "0x":
         output_string = ct.create_string_buffer(ceil(pad_to_nbits / 4) + 4)
-        success = fastpack.array_to_hexstring_binary(array, array.size, pad_to_nbits, output_string)
+        success = fastpack.array_to_hexstring_binary(np.asarray(array, order='C'), array.size, pad_to_nbits, output_string)
         assert success, f"Could not convert array {array} with datatype {dtype} to hexstring!"
         return output_string.value.decode("utf-8")
 

--- a/src/finn/util/data_packing.py
+++ b/src/finn/util/data_packing.py
@@ -61,7 +61,7 @@ fastpack.array_to_hexstring_binary.restype = ct.c_bool
 
 
 
-def array2hexstring(array, dtype, pad_to_nbits, prefix="0x", reverse=False):
+def array2hexstring(array, dtype, pad_to_nbits, prefix="0x", reverse=False, use_fastpack=True):
     """
     Pack given one-dimensional NumPy array with FINN DataType dtype into a hex
     string.
@@ -71,7 +71,9 @@ def array2hexstring(array, dtype, pad_to_nbits, prefix="0x", reverse=False):
     fixed width. The minimum value for pad_to_nbits is 4, since a single hex
     digit is four bits. reverse can be used to reverse the array prior to
     packing.
-
+    When use_fastpack is set to true, if available the function is outsourced 
+    to a faster C implementation for some cases.
+    
     Examples:
 
     array2hexstring([1, 1, 1, 0], DataType["BINARY"], 4) = "0xe"
@@ -101,7 +103,7 @@ def array2hexstring(array, dtype, pad_to_nbits, prefix="0x", reverse=False):
 
     # Check if the fast way can be taken
     # TODO: Expand this to cover more cases
-    if dtype == DataType["BINARY"] and prefix == "0x":
+    if use_fastpack and dtype == DataType["BINARY"] and prefix == "0x":
         output_string = ct.create_string_buffer(ceil(pad_to_nbits / 4) + 4)
         success = fastpack.array_to_hexstring_binary(array, array.size, pad_to_nbits, output_string)
         assert success, f"Could not convert array {array} with datatype {dtype} to hexstring!"
@@ -161,10 +163,11 @@ def npbytearray2hexstring(npbytearray, prefix="0x"):
 
 
 def pack_innermost_dim_as_hex_string(
-    ndarray, dtype, pad_to_nbits, reverse_inner=False, prefix="0x"
+    ndarray, dtype, pad_to_nbits, reverse_inner=False, prefix="0x", use_fastpack=True
 ):
     """Pack the innermost dimension of the given numpy ndarray into hex
-    strings using array2hexstring.
+    strings using array2hexstring. If use_fastpack is enabled this tries to speed
+    up the conversion
 
     Examples:
 

--- a/src/finn/util/data_packing.py
+++ b/src/finn/util/data_packing.py
@@ -102,13 +102,13 @@ def array2hexstring(array, dtype, pad_to_nbits, prefix="0x", reverse=False, use_
 
     # Check if the fast way can be taken
     # TODO: Expand this to cover more cases
-    if use_fastpack and dtype == DataType["BINARY"] and prefix == "0x":
+    if use_fastpack and dtype == DataType["BINARY"]:
         output_string = ct.create_string_buffer(ceil(pad_to_nbits / 4) + 4)
         success = fastpack.array_to_hexstring_binary(
             np.asarray(array, order="C"), array.size, pad_to_nbits, output_string
         )
         assert success, f"Could not convert array {array} with datatype {dtype} to hexstring!"
-        return output_string.value.decode("utf-8")
+        return prefix + output_string.value.decode("utf-8")
 
     lineval = BitArray(length=0)
     bw = dtype.bitwidth()

--- a/src/finn/util/fast_pack.c
+++ b/src/finn/util/fast_pack.c
@@ -30,47 +30,34 @@ bool array_to_hexstring_binary(float* values, unsigned int elements, unsigned in
     strcpy(out, "0x");
     unsigned int prefix_digits = (padded_bits - min_bits) / 4;
     for (int i = 0; i < prefix_digits; i++) {
-        strcat(out, "0");
+        out[2 + i] = '0';
     }
-    out[2 + prefix_digits + min_bits / 4 + 1] = '\0';
+    out[2 + prefix_digits] = '0';
+    out[2 + prefix_digits + min_bits / 4] = '\0';
 
-    // Converting 4 at a time
-    uint8_t temp;
-    char buffer[100];
+    unsigned int temp = 0;
+    char letter;
     unsigned int digits = 0;
-    for (int i = elements - (min_bits - 4); i < elements; i += 4) {
-        // Clear temp
-        temp = 0;
+    unsigned int bit_in = 0;
+    for (int index = elements - 1; index > 0; index--) {
+        // Add new bit
+        temp |= (((unsigned int) values[index]) << bit_in);
 
-        // Fill lower 4 bits
-        for (int j = 0; j < 4; j++) {
-            temp <<= 1;
-            temp |= (unsigned int) values[i + j];
-        }
-
-        // Save hex digit
-        if (temp <= 9) {
-            buffer[0] = '0' + temp;
+        // Convert to hex either when 4 bits are there or we arrived at the end
+        if (bit_in == 3 || index == 0) {
+            if (temp <= 9) {
+                letter = '0' + temp;
+            } else {
+                letter = 'a' + temp - 10;
+            }
+            unsigned int assignindex = 2 + prefix_digits + min_bits / 4 - digits - 1;
+            out[assignindex] = letter;
+            digits++;
+            temp = 0;
+            bit_in = 0;
         } else {
-            buffer[0] = 'a' + temp - 10;
+            bit_in++;
         }
-        out[2 + prefix_digits + (min_bits / 4) - digits - 1] = buffer[0]; 
-        digits++;
-    }
-        
-    // Fill in the last odd bits
-    temp = 0;
-    for (int j = 0; j < elements - (min_bits - 4); j++) {
-        temp <<= 1;
-        temp |= (unsigned int) values[min_bits - 4 + j];
-    }
-
-    // Save hex digit
-    if (temp <= 9) {
-        buffer[0] = '0' + temp;
-    } else {
-        buffer[0] = 'a' + temp - 10;
-    }
-    out[2 + prefix_digits] = buffer[0]; 
+    } 
     return true;
 }

--- a/src/finn/util/fast_pack.c
+++ b/src/finn/util/fast_pack.c
@@ -36,27 +36,26 @@ bool array_to_hexstring_binary(float* values, unsigned int elements, unsigned in
     out[2 + prefix_digits + min_bits / 4] = '\0';
 
     unsigned int temp = 0;
-    char letter;
     unsigned int digits = 0;
-    unsigned int bit_in = 0;
+    unsigned int bit_shift_left = 0;
+    char letter;
     for (int index = elements - 1; index >= 0; index--) {
         // Add new bit
-        temp |= (((unsigned int) values[index]) << bit_in);
+        temp |= (((unsigned int) values[index]) << bit_shift_left);
 
         // Convert to hex either when 4 bits are there or we arrived at the end
-        if (bit_in == 3 || index == 0) {
+        if (bit_shift_left == 3 || index == 0) {
             if (temp <= 9) {
                 letter = '0' + temp;
             } else {
                 letter = 'a' + temp - 10;
             }
-            unsigned int assignindex = 2 + prefix_digits + min_bits / 4 - digits - 1;
-            out[assignindex] = letter;
+            out[2 + prefix_digits + min_bits / 4 - digits - 1] = letter;
             digits++;
             temp = 0;
-            bit_in = 0;
+            bit_shift_left = 0;
         } else {
-            bit_in++;
+            bit_shift_left++;
         }
     } 
     return true;

--- a/src/finn/util/fast_pack.c
+++ b/src/finn/util/fast_pack.c
@@ -4,7 +4,6 @@
 #include <string.h>
 #include <stdint.h>
 
-
 /***
  * Takes a numpy array of floats in BINARY datatype from finn and the number of elements in that array, as well as the number of padded bits required.
  * It also takes an out-string buffer to write the results to. This buffer is created by python via ctypes.create_string_buffer() and must be large enough to

--- a/src/finn/util/fast_pack.c
+++ b/src/finn/util/fast_pack.c
@@ -1,0 +1,76 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <string.h>
+#include <stdint.h>
+
+
+/***
+ * Takes a numpy array of floats in BINARY datatype from finn and the number of elements in that array, as well as the number of padded bits required.
+ * It also takes an out-string buffer to write the results to. This buffer is created by python via ctypes.create_string_buffer() and must be large enough to
+ * hold the required number of padded bits.
+ * 
+ * The function returns false on an error and true in case of success
+ */
+bool array_to_hexstring_binary(float* values, unsigned int elements, unsigned int padded_bits, char* out) {
+    // Calculate min number of bits required
+    unsigned int min_bits;
+    if (elements % 4 != 0) {
+        min_bits = elements + (4 - (elements % 4));
+    } else {
+        min_bits = elements;
+    }
+
+    // Padded bits must be atleast length of min_bits and divisible by 4 for hex repr
+    if (min_bits > padded_bits || padded_bits % 4 != 0) {
+        return false;
+    }
+
+    // Pad output string
+    strcpy(out, "0x");
+    unsigned int prefix_digits = (padded_bits - min_bits) / 4;
+    for (int i = 0; i < prefix_digits; i++) {
+        strcat(out, "0");
+    }
+    out[2 + prefix_digits + min_bits / 4 + 1] = '\0';
+
+    // Converting 4 at a time
+    uint8_t temp;
+    char buffer[100];
+    unsigned int digits = 0;
+    for (int i = elements - (min_bits - 4); i < elements; i += 4) {
+        // Clear temp
+        temp = 0;
+
+        // Fill lower 4 bits
+        for (int j = 0; j < 4; j++) {
+            temp <<= 1;
+            temp |= (unsigned int) values[i + j];
+        }
+
+        // Save hex digit
+        if (temp <= 9) {
+            buffer[0] = '0' + temp;
+        } else {
+            buffer[0] = 'a' + temp - 10;
+        }
+        out[2 + prefix_digits + (min_bits / 4) - digits - 1] = buffer[0]; 
+        digits++;
+    }
+        
+    // Fill in the last odd bits
+    temp = 0;
+    for (int j = 0; j < elements - (min_bits - 4); j++) {
+        temp <<= 1;
+        temp |= (unsigned int) values[min_bits - 4 + j];
+    }
+
+    // Save hex digit
+    if (temp <= 9) {
+        buffer[0] = '0' + temp;
+    } else {
+        buffer[0] = 'a' + temp - 10;
+    }
+    out[2 + prefix_digits] = buffer[0]; 
+    return true;
+}

--- a/src/finn/util/fast_pack.c
+++ b/src/finn/util/fast_pack.c
@@ -26,13 +26,13 @@ bool array_to_hexstring_binary(float* values, unsigned int elements, unsigned in
     }
 
     // Pad output string
-    strcpy(out, "0x");
+    strcpy(out, "");
     unsigned int prefix_digits = (padded_bits - min_bits) / 4;
     for (int i = 0; i < prefix_digits; i++) {
-        out[2 + i] = '0';
+        out[i] = '0';
     }
-    out[2 + prefix_digits] = '0';
-    out[2 + prefix_digits + min_bits / 4] = '\0';
+    out[prefix_digits] = '0';
+    out[prefix_digits + min_bits / 4] = '\0';
 
     unsigned int temp = 0;
     unsigned int digits = 0;
@@ -49,7 +49,7 @@ bool array_to_hexstring_binary(float* values, unsigned int elements, unsigned in
             } else {
                 letter = 'a' + temp - 10;
             }
-            out[2 + prefix_digits + min_bits / 4 - digits - 1] = letter;
+            out[prefix_digits + min_bits / 4 - digits - 1] = letter;
             digits++;
             temp = 0;
             bit_shift_left = 0;

--- a/src/finn/util/fast_pack.c
+++ b/src/finn/util/fast_pack.c
@@ -39,7 +39,7 @@ bool array_to_hexstring_binary(float* values, unsigned int elements, unsigned in
     char letter;
     unsigned int digits = 0;
     unsigned int bit_in = 0;
-    for (int index = elements - 1; index > 0; index--) {
+    for (int index = elements - 1; index >= 0; index--) {
         // Add new bit
         temp |= (((unsigned int) values[index]) << bit_in);
 

--- a/src/finn/util/fast_pack.c
+++ b/src/finn/util/fast_pack.c
@@ -9,7 +9,7 @@
  * Takes a numpy array of floats in BINARY datatype from finn and the number of elements in that array, as well as the number of padded bits required.
  * It also takes an out-string buffer to write the results to. This buffer is created by python via ctypes.create_string_buffer() and must be large enough to
  * hold the required number of padded bits.
- * 
+ *
  * The function returns false on an error and true in case of success
  */
 bool array_to_hexstring_binary(float* values, unsigned int elements, unsigned int padded_bits, char* out) {
@@ -57,6 +57,6 @@ bool array_to_hexstring_binary(float* values, unsigned int elements, unsigned in
         } else {
             bit_shift_left++;
         }
-    } 
+    }
     return true;
 }

--- a/tests/util/test_data_packing.py
+++ b/tests/util/test_data_packing.py
@@ -26,21 +26,22 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import ctypes
 import pytest
 
 import numpy as np
-import time
 import os
 import shutil
 import subprocess
-from finn.util.data_packing import array2hexstring
+import time
 from qonnx.core.datatype import DataType
 from qonnx.util.basic import gen_finn_dt_tensor
 
 from finn.util.basic import make_build_dir
-from finn.util.data_packing import npy_to_rtlsim_input, numpy_to_hls_code, pack_innermost_dim_as_hex_string
-from finn.util.data_packing import *
+from finn.util.data_packing import (
+    npy_to_rtlsim_input,
+    numpy_to_hls_code,
+    pack_innermost_dim_as_hex_string,
+)
 
 
 @pytest.mark.util
@@ -186,42 +187,64 @@ def test_npy_to_rtlsim_input(dtype):
     assert np.all(output_fast == output_slow_split), "different behavior of packing modes detected"
 
 
-
 @pytest.mark.util
-@pytest.mark.parametrize("tensorshape", [
-    (1, 2, 16384, 64),
-    (1, 1024, 2048)
-])
+@pytest.mark.parametrize("tensorshape", [(1, 2, 16384, 64), (1, 1024, 2048)])
 def test_pack_innermost_dim_to_hexstring_fast(tensorshape: tuple[int]):
     # check that the sped up function call in pack_inermost_dim_to_hex_string() is valid
     tensor_count = 5
     assert tensorshape[-1] % 4 == 0, "Smallest tensorshape dimension must be divisible by 4"
 
     # Create random binary tensor by simply rounding a random tensor
-    tensors = [np.round(np.random.random(tensorshape)).astype(np.float32) for i in range(tensor_count)]
+    tensors = [
+        np.round(np.random.random(tensorshape)).astype(np.float32) for i in range(tensor_count)
+    ]
     results_python = []
     results_c = []
 
     # Test C impl
     start_c = time.time()
     for count in range(tensor_count):
-        c_result = pack_innermost_dim_as_hex_string(tensors[count], DataType["BINARY"], tensorshape[-1] * 2, reverse_inner=False, prefix="0x", use_fastpack=True)
+        c_result = pack_innermost_dim_as_hex_string(
+            tensors[count],
+            DataType["BINARY"],
+            tensorshape[-1] * 2,
+            reverse_inner=False,
+            prefix="0x",
+            use_fastpack=True,
+        )
         results_c.append(c_result)
     end_c = time.time()
 
     # Test python impl
     start_python = time.time()
     for count in range(tensor_count):
-        python_result = pack_innermost_dim_as_hex_string(tensors[count], DataType["BINARY"], tensorshape[-1] * 2, reverse_inner=False, prefix="0x", use_fastpack=False)
+        python_result = pack_innermost_dim_as_hex_string(
+            tensors[count],
+            DataType["BINARY"],
+            tensorshape[-1] * 2,
+            reverse_inner=False,
+            prefix="0x",
+            use_fastpack=False,
+        )
         results_python.append(python_result)
     end_python = time.time()
-    
+
     assert np.array_equal(np.array(results_python), np.array(results_c))
 
     # Write timing results
-    with open(os.path.join(os.path.dirname(__file__), f"fastpack_benchmark" + "_".join(map(lambda x: str(x), list(tensorshape))) + ".txt"), 'w+') as f:
+    with open(
+        os.path.join(
+            os.path.dirname(__file__),
+            "fastpack_benchmark" + "_".join(map(lambda x: str(x), list(tensorshape))) + ".txt",
+        ),
+        "w+",
+    ) as f:
         f.write("Pack_innermost_dim_to_hexstring benchmark test results\n")
         f.write("Shape: " + str(tensorshape) + "\n")
         f.write(f"Ran {tensor_count} times\n")
-        f.write(f"Python: {end_python - start_python}s overall | {(end_python - start_python) / tensor_count}s on avg. per sample\n")
-        f.write(f"C: {end_c - start_c}s overall | {(end_c - start_c) / tensor_count}s on avg. per sample\n")
+        python_time = end_python - start_python
+        c_time = end_c - start_c
+        f.write(
+            f"Python: {python_time}s overall | {python_time / tensor_count}s on avg. per sample\n"
+        )
+        f.write(f"C: {c_time}s overall | {c_time / tensor_count}s on avg. per sample\n")


### PR DESCRIPTION
When building ResNet50 i stumbled upon the issue that due to very large weight tensors, the HLS Codegen step, which internally uses the `array2hexstring` function, was taking a very long time to execute. For tensors of roughly 2 Mio. entries it took in the area of ~30s. When doing it for many layers, this step alone would take ~15min per build, making development in later steps difficult due to low iteration speeds. 

To speed this process up, I firstly focused on the BINARY datatype case and rewrote the function in C, integrating it via Python's `ctypes`. I also added tests that check the results of randomized input tensors to the original Python implementation.

I tested two shapes for the input tensors, one with 64 as the innermost, and one with 2048 as the innermost dimension, both with overall roughly 2 Mio. elements.  For both I executed the function 5 times. 
For the 64 one I got an overall runtime of 237.41s (47.482s per sample) in Python and 2.856s overall runtime (0.571s per sample) for the C function for an estimated speedup of ~83x. For the 2048 one, I got an overall runtime of 232.201s (46.44s per sample) in Python and an overall runtime of 0.115s (0.023s per sample) in C, yielding an estimated speedup of ~2019x, presumably due to lower function call overhead.

In the future I would like to expand this to all `DataType`s and try to speed up the C implementation a bit more as well, but for now I don't think that further speedup is strictly necessary.