### PR TITLE
Fixes for branched structures

### DIFF
--- a/src/finn/transformation/fpgadataflow/insert_fifo.py
+++ b/src/finn/transformation/fpgadataflow/insert_fifo.py
@@ -268,7 +268,7 @@ class InsertFIFO(Transformation):
                         fifo_input_tensor = oh.make_tensor_value_info(
                             model.make_new_valueinfo_name(),
                             n0_tensor_dtype,
-                            n0.get_normal_output_shape(),
+                            n0.get_normal_output_shape(out_ind),
                         )
                         graph.value_info.append(fifo_input_tensor)
                         model.set_tensor_datatype(fifo_input_tensor.name, dtype)
@@ -294,7 +294,7 @@ class InsertFIFO(Transformation):
                         graph.node.append(fifo_node)
 
                         # set fifo output tensor as new input tensor of second node
-                        final_node.output[0] = fifo_input_tensor.name
+                        final_node.output[out_ind] = fifo_input_tensor.name
                     else:
                         warnings.warn(
                             """Output FIFO for %s has depth %d and won't


### PR DESCRIPTION
- The MoveOpPastFork() transformation is more flexible because it uses deepcopies of an original node (the get_attrs_fxn parameter is not needed anymore)

- Some transformations (MoveScalarLinearPastInvariants, MakeMaxPoolNHWC, MakeScaleResizeNHWC) are fixed to check whether the node to be moved is a fork node, in which case the MoveOpPastFork would be called

- InferDuplicateStreamsLayer() transform in [src/finn/transformation/fpgadataflow/convert_to_hw_layers.py](https://github.com/Xilinx/finn/compare/dev...mdanilow:finn:feature/split_and_concat?expand=1#diff-a331fda12d6897bb8da38d2237c9a4c24df8eb8e095bde550f400d2a6a2e692f) is fixed and every output of a fork node is checked (the transform used to be applying the transform just for the first output of a node)

- InsertFIFO() transform in [src/finn/transformation/fpgadataflow/insert_fifo.py](https://github.com/Xilinx/finn/compare/dev...mdanilow:finn:feature/split_and_concat?expand=1#diff-910ada17340f80d68fdfa7a20efbf78cc9fd94da4c1baed2e34bc8deed1ca7ac) is fixed for the case of the last node in the graph being a fork node (the transform was breaking the graph in such a case)