### PR TITLE
[Infra] support passing arguments to build_custom flow

### DIFF
--- a/run-docker.sh
+++ b/run-docker.sh
@@ -142,7 +142,7 @@ elif [ "$1" = "build_custom" ]; then
   DOCKER_INTERACTIVE="-it"
   #FINN_HOST_BUILD_DIR=$BUILD_DATAFLOW_DIR/build
   gecho "Running build_custom: $BUILD_CUSTOM_DIR/$FLOW_NAME.py"
-  DOCKER_CMD="python -mpdb -cc -cq $FLOW_NAME.py"
+  DOCKER_CMD="python -mpdb -cc -cq $FLOW_NAME.py ${@:4}"
 elif [ -z "$1" ]; then
    gecho "Running container only"
    DOCKER_CMD="bash"


### PR DESCRIPTION
This enables passing arguments to custom build scripts. e.g. with a build script called `test_args.py` containing:

```python
import argparse

parser = argparse.ArgumentParser()
parser.add_argument('filename')           # positional argument
parser.add_argument('-c', '--count')      # option that takes a value
parser.add_argument('-v', '--verbose',
                    action='store_true')  # on/off flag
args = parser.parse_args()
print(f"{args.filename=} | {args.count=} | {args.verbose=}")
```

Can now pass in arguments via run-docker:

```bash
./run-docker.sh build_custom .. test_args abc -c 12 -v
...
args.filename='abc' | args.count='12' | args.verbose=True
The program finished and will be restarted
```