### PR TITLE
[Container] Apply workaround for running multiple parallel Vivado instances

### DIFF
--- a/run-docker.sh
+++ b/run-docker.sh
@@ -231,6 +231,9 @@ DOCKER_EXEC+="-e NUM_DEFAULT_WORKERS=$NUM_DEFAULT_WORKERS "
 # Workaround for FlexLM issue, see:
 # https://community.flexera.com/t5/InstallAnywhere-Forum/Issues-when-running-Xilinx-tools-or-Other-vendor-tools-in-docker/m-p/245820#M10647
 DOCKER_EXEC+="-e LD_PRELOAD=/lib/x86_64-linux-gnu/libudev.so.1 "
+# Workaround for running multiple Vivado instances simultaneously, see:
+# https://adaptivesupport.amd.com/s/article/63253?language=en_US
+DOCKER_EXEC+="-e XILINX_LOCAL_USER_DATA=no "
 if [ "$FINN_DOCKER_RUN_AS_ROOT" = "0" ] && [ -z "$FINN_SINGULARITY" ];then
   DOCKER_EXEC+="-v /etc/group:/etc/group:ro "
   DOCKER_EXEC+="-v /etc/passwd:/etc/passwd:ro "


### PR DESCRIPTION
See https://adaptivesupport.amd.com/s/article/63253?language=en_US

This issue occurs frequently for users with slow filesystems, such as for us, during the last FINN tutorial, or here: https://github.com/Xilinx/finn/issues/1215

I propose to add the workaround permanently to the Docker Container.