### PR TITLE
Driving AXI bus padding to zero.

### DIFF
--- a/finn-rtllib/thresholding/hdl/thresholding_axi.sv
+++ b/finn-rtllib/thresholding/hdl/thresholding_axi.sv
@@ -191,7 +191,10 @@ module thresholding_axi #(
 		.cfg_rack, .cfg_q,
 
 		.irdy(s_axis_tready), .ivld(s_axis_tvalid), .idat,
-		.ordy(m_axis_tready), .ovld(m_axis_tvalid), .odat(m_axis_tdata)
+		.ordy(m_axis_tready), .ovld(m_axis_tvalid), .odat(m_axis_tdata[PE*O_BITS-1:0])
 	);
+	if($bits(m_axis_tdata) > PE*O_BITS) begin : genPadOut
+		assign	m_axis_tdata[$left(m_axis_tdata):PE*O_BITS] = '0;
+	end : genPadOut
 
 endmodule : thresholding_axi

--- a/finn-rtllib/thresholding/sim/thresholding_axi_tb.sv
+++ b/finn-rtllib/thresholding/sim/thresholding_axi_tb.sv
@@ -232,7 +232,7 @@ module thresholding_axi_tb #(
 			end
 		join_any
 		done <= 1;
-		repeat(N+6)  @(posedge clk);
+		repeat(2*N+8)  @(posedge clk);
 
 		assert(QW.size() == 0) else begin
 			$error("Missing %0d outputs.", QW.size());


### PR DESCRIPTION
As with the other AXI wrappers of RTL components, drive the full-byte AXI-Stream extension to zero.