### PR TITLE
Fix: Replace distutil copy_tree with shutil

### DIFF
--- a/notebooks/end2end_example/bnn-pynq/cnv_end2end_example.ipynb
+++ b/notebooks/end2end_example/bnn-pynq/cnv_end2end_example.ipynb
@@ -484,8 +484,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from shutil import copy\n",
-    "from distutils.dir_util import copy_tree\n",
+    "from shutil import copy, copytree\n",
     "\n",
     "# create directory for deployment files\n",
     "deployment_dir = make_build_dir(prefix=\"pynq_deployment_\")\n",
@@ -503,7 +502,7 @@
     "\n",
     "# driver.py and python libraries\n",
     "pynq_driver_dir = model.get_metadata_prop(\"pynq_driver_dir\")\n",
-    "copy_tree(pynq_driver_dir, deployment_dir)"
+    "copytree(pynq_driver_dir, deployment_dir, dirs_exist_ok=True)"
    ]
   },
   {

--- a/notebooks/end2end_example/bnn-pynq/tfc_end2end_example.ipynb
+++ b/notebooks/end2end_example/bnn-pynq/tfc_end2end_example.ipynb
@@ -895,8 +895,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from shutil import copy\n",
-    "from distutils.dir_util import copy_tree\n",
+    "from shutil import copy, copytree\n",
     "\n",
     "# create directory for deployment files\n",
     "deployment_dir = make_build_dir(prefix=\"pynq_deployment_\")\n",
@@ -914,7 +913,7 @@
     "\n",
     "# driver.py and python libraries\n",
     "pynq_driver_dir = model.get_metadata_prop(\"pynq_driver_dir\")\n",
-    "copy_tree(pynq_driver_dir, deployment_dir)"
+    "copytree(pynq_driver_dir, deployment_dir, dirs_exist_ok=True)"
    ]
   },
   {

--- a/src/finn/builder/build_dataflow_steps.py
+++ b/src/finn/builder/build_dataflow_steps.py
@@ -33,7 +33,6 @@ import os
 import shutil
 import warnings
 from copy import deepcopy
-from distutils.dir_util import copy_tree
 from functools import partial
 from qonnx.core.modelwrapper import ModelWrapper
 from qonnx.custom_op.registry import getCustomOp
@@ -656,7 +655,9 @@ def step_create_stitched_ip(model: ModelWrapper, cfg: DataflowBuildConfig):
             )
         )
         # TODO copy all ip sources into output dir? as zip?
-        copy_tree(model.get_metadata_prop("vivado_stitch_proj"), stitched_ip_dir)
+        shutil.copytree(
+            model.get_metadata_prop("vivado_stitch_proj"), stitched_ip_dir, dirs_exist_ok=True
+        )
         print("Vivado stitched IP written into " + stitched_ip_dir)
     if VerificationStepType.STITCHED_IP_RTLSIM in cfg._resolve_verification_steps():
         # prepare ip-stitched rtlsim
@@ -761,7 +762,7 @@ def step_make_pynq_driver(model: ModelWrapper, cfg: DataflowBuildConfig):
     if DataflowOutputType.PYNQ_DRIVER in cfg.generate_outputs:
         driver_dir = cfg.output_dir + "/driver"
         model = model.transform(MakePYNQDriver(cfg._resolve_driver_platform()))
-        copy_tree(model.get_metadata_prop("pynq_driver_dir"), driver_dir)
+        shutil.copytree(model.get_metadata_prop("pynq_driver_dir"), driver_dir, dirs_exist_ok=True)
         print("PYNQ Python driver written into " + driver_dir)
     return model
 
@@ -862,8 +863,8 @@ def step_deployment_package(model: ModelWrapper, cfg: DataflowBuildConfig):
         bitfile_dir = cfg.output_dir + "/bitfile"
         driver_dir = cfg.output_dir + "/driver"
         os.makedirs(deploy_dir, exist_ok=True)
-        copy_tree(bitfile_dir, deploy_dir + "/bitfile")
-        copy_tree(driver_dir, deploy_dir + "/driver")
+        shutil.copytree(bitfile_dir, deploy_dir + "/bitfile", dirs_exist_ok=True)
+        shutil.copytree(driver_dir, deploy_dir + "/driver", dirs_exist_ok=True)
     return model
 
 

--- a/tests/end2end/test_end2end_bnn_pynq.py
+++ b/tests/end2end/test_end2end_bnn_pynq.py
@@ -40,7 +40,6 @@ import torch
 import warnings
 from brevitas.export import export_qonnx
 from dataset_loading import cifar, mnist
-from distutils.dir_util import copy_tree
 from qonnx.core.datatype import DataType
 from qonnx.core.modelwrapper import ModelWrapper
 from qonnx.custom_op.registry import getCustomOp
@@ -59,7 +58,7 @@ from qonnx.transformation.insert_topk import InsertTopK
 from qonnx.transformation.lower_convs_to_matmul import LowerConvsToMatMul
 from qonnx.transformation.merge_onnx_models import MergeONNXModels
 from qonnx.util.cleanup import cleanup as qonnx_cleanup
-from shutil import copy
+from shutil import copy, copytree
 
 import finn.transformation.fpgadataflow.convert_to_hw_layers as to_hw
 import finn.transformation.streamline.absorb as absorb
@@ -357,7 +356,7 @@ def deploy_based_on_board(model, model_title, topology, wbits, abits, board):
 
     # driver.py and python libraries
     pynq_driver_dir = model.get_metadata_prop("pynq_driver_dir")
-    copy_tree(pynq_driver_dir, deployment_dir)
+    copytree(pynq_driver_dir, deployment_dir, dirs_exist_ok=True)
     model.set_metadata_prop("pynq_deploy_dir", deployment_dir)
 
 


### PR DESCRIPTION
Replace distutil copy_tree with shutil copytree for two reasons:

1. It is deprecated
2. I ran into this obscure bug, which does not happen with copytree: https://bugs.python.org/issue22132