### PR TITLE
SetFolding rules for Split and Concat operations.

### DIFF
--- a/src/finn/transformation/fpgadataflow/set_folding.py
+++ b/src/finn/transformation/fpgadataflow/set_folding.py
@@ -124,6 +124,7 @@ class SetFolding(Transformation):
         simd_ops = [
             "DownSampler_hls",
             "FMPadding_hls",
+            "FMPadding_rtl",
             "FMPadding_Pixel_hls",
             "ConvolutionInputGenerator_hls",
             "ConvolutionInputGenerator_rtl",


### PR DESCRIPTION
Defines rules of automatic folding for Split and Concat nodes necessary for yolov8.
Basically SIMD parameter needs to be a common divisor of channels for all inputs of Concat and all outputs of Split.
Depends on PRs https://github.com/Xilinx/finn/pull/1194 and https://github.com/Xilinx/finn/pull/1193.
Rule for "FMPadding_rtl" also added.