### PR TITLE
Prevent Vivado from losing RAM_STYLE attribute during synthesis.

### DIFF
--- a/finn-rtllib/thresholding/hdl/thresholding.sv
+++ b/finn-rtllib/thresholding/hdl/thresholding.sv
@@ -222,7 +222,7 @@ module thresholding #(
 					// If BRAM trigger defined, force distributed memory below if Vivado may be tempted to use BRAM nonetheless.
 					DEPTH_TRIGGER_BRAM && (DEPTH >= 64)? "distributed" : "auto";
 
-				(* RAM_STYLE = RAM_STYLE *)
+				(* DONT_TOUCH = "true", RAM_STYLE = RAM_STYLE *)
 				val_t  Threshs[DEPTH];
 				if(THRESHOLDS_PATH != "") begin
 					initial  $readmemh($sformatf("%sthreshs_%0d_%0d.dat", THRESHOLDS_PATH, pe, stage), Threshs);


### PR DESCRIPTION
With this PR, we're preventing Vivado from losing the RAM_STYLE attribute for the RTL Thresholding component. 