### PR TITLE
[MVU,VVU] fix bug in datatype-bound accumulator sizing

### DIFF
--- a/src/finn/custom_op/fpgadataflow/matrixvectoractivation.py
+++ b/src/finn/custom_op/fpgadataflow/matrixvectoractivation.py
@@ -482,7 +482,7 @@ class MVAU(HWCustomOp):
             upper_worst = wdt.max() * np.ones_like(weights)
             upper_range = calculate_matvec_accumulator_range(upper_worst, idt)
             acc_min = min(min(lower_range), min(upper_range))
-            acc_max = max(max(upper_range), max(upper_range))
+            acc_max = max(max(lower_range), max(upper_range))
 
         # if the thresholds can be used to determine range, then adjust the range
         # according to the known values of the thresholds

--- a/src/finn/custom_op/fpgadataflow/vectorvectoractivation.py
+++ b/src/finn/custom_op/fpgadataflow/vectorvectoractivation.py
@@ -421,7 +421,7 @@ class VVAU(HWCustomOp):
             upper_worst = wdt.max() * np.ones_like(weights)
             upper_range = calculate_matvec_accumulator_range(upper_worst, idt)
             acc_min = min(min(lower_range), min(upper_range))
-            acc_max = max(max(upper_range), max(upper_range))
+            acc_max = max(max(lower_range), max(upper_range))
 
         # if the thresholds can be used to determine range, then adjust the range
         # according to the known values of the thresholds


### PR DESCRIPTION
Small bugfix for accumulator sizing of MVU and VVUs with runtime-writable weights, old `max(max(upper_range), max(upper_range))` was probably a copy paste bug.