### PR TITLE
Fix permission error on repeated runs with C++ driver

### DIFF
--- a/src/finn/builder/build_dataflow_steps.py
+++ b/src/finn/builder/build_dataflow_steps.py
@@ -751,7 +751,12 @@ def step_make_driver(model: ModelWrapper, cfg: DataflowBuildConfig):
                 version=cfg.cpp_driver_version,
             )
         )
-        shutil.copytree(model.get_metadata_prop("cpp_driver_dir"), driver_dir, dirs_exist_ok=True)
+        shutil.copytree(
+            model.get_metadata_prop("cpp_driver_dir"),
+            driver_dir,
+            dirs_exist_ok=True,
+            copy_function=shutil.copyfile,
+        )
         print("C++ driver written into " + driver_dir)
     else:
         warnings.warn(

--- a/src/finn/builder/build_dataflow_steps.py
+++ b/src/finn/builder/build_dataflow_steps.py
@@ -863,7 +863,12 @@ def step_deployment_package(model: ModelWrapper, cfg: DataflowBuildConfig):
         driver_dir = cfg.output_dir + "/driver"
         os.makedirs(deploy_dir, exist_ok=True)
         shutil.copytree(bitfile_dir, deploy_dir + "/bitfile", dirs_exist_ok=True)
-        shutil.copytree(driver_dir, deploy_dir + "/driver", dirs_exist_ok=True)
+        shutil.copytree(
+            driver_dir,
+            deploy_dir + "/driver",
+            dirs_exist_ok=True,
+            copy_function=shutil.copyfile,
+        )
     return model
 
 


### PR DESCRIPTION
Running the driver generation step, while a previous driver already exists at the destination location of the `copytree()` call in `step_make_driver` for the C++ driver, leads to permission denied errors (on some file systems such as Lustre FS).

This is the case because git sets the permission of some internal files to 444. When copying these files with `shutil.copytree`, these permissions are retained. When rerunning the driver generation, the step fails, because overwriting files with 444 permission is not possible even with `dirs_exist_ok=True` set for `shutil.copytree`.

(This bug may not affect all file systems, as some file systems do not retain permissions on file copy. This bug does affect Lustre FS.)

The fix switches `shutil.copytree` for the C++ driver generation to `shutil.copyfile`, which specifically overwrites existing files, i.e. it creates the copied files with read-write permissions and does not copy the original permissions.