### PR TITLE
Fix script to launch Singularity container

### DIFF
--- a/run-docker.sh
+++ b/run-docker.sh
@@ -272,11 +272,12 @@ if [ -z "$FINN_SINGULARITY" ];then
 else
   SINGULARITY_BASE="singularity exec"
   # Replace command options for Singularity
-  SINGULARITY_EXEC="${DOCKER_EXEC//"-e "/"--env "}"
-  SINGULARITY_EXEC="${SINGULARITY_EXEC//"-v "/"-B "}"
-  SINGULARITY_EXEC="${SINGULARITY_EXEC//"-w "/"--pwd "}"
+  SINGULARITY_EXEC="${DOCKER_EXEC//-e /--env }"
+  SINGULARITY_EXEC="${SINGULARITY_EXEC//-v /-B }"
+  SINGULARITY_EXEC="${SINGULARITY_EXEC//-w /--pwd }"
   CMD_TO_RUN="$SINGULARITY_BASE $SINGULARITY_EXEC $FINN_SINGULARITY /usr/local/bin/finn_entrypoint.sh $DOCKER_CMD"
   gecho "FINN_SINGULARITY is set, launching Singularity container instead of Docker"
 fi
 
+echo $CMD_TO_RUN
 $CMD_TO_RUN


### PR DESCRIPTION
Hi there,
The script `run-docker.sh` is currently broken for Singularity. The command generated contains unwanted quotes. See for example:
```
singularity exec "--env "SHELL=/bin/bash "--pwd "/lustre/home/nx08/nx08/s2081362-2/Software/finn "-B "/lustre/home/nx08/nx08/s2081362-2/Software/finn:/lustre/home/nx08/nx08/s2081362-2/Software/finn "-B "/tmp/finn_dev_s2081362-2:/tmp/finn_dev_s2081362-2 "--env "FINN_BUILD_DIR=/tmp/finn_dev_s2081362-2 " ...
```

This patch fixes the script so that FINN can be used in Singularity.