### PR TITLE
Remove buildDepencies call in C++ driver generation

### DIFF
--- a/src/finn/transformation/fpgadataflow/make_driver.py
+++ b/src/finn/transformation/fpgadataflow/make_driver.py
@@ -128,7 +128,6 @@ class MakeCPPDriver(Transformation):
         run_command(f"git fetch origin {self.commit_hash} --depth=1", cwd=cpp_driver_dir)
         run_command("git checkout FETCH_HEAD", cwd=cpp_driver_dir)
         run_command("git submodule update --init --recursive", cwd=cpp_driver_dir)
-        run_command("./buildDependencies.sh", cwd=cpp_driver_dir)
 
         # * Writing the header file
         inputDatatype: str = MakeCPPDriver.resolve_dt_name(


### PR DESCRIPTION
With the new release of the C++ driver, it is not necessary anymore to build dependencies with a seperate script. Therefore the call needs to be removed from the driver generation.