### PR TITLE
Support 64-bit buffer addresses

### DIFF
--- a/src/finn/qnn-data/templates/driver/driver_base.py
+++ b/src/finn/qnn-data/templates/driver/driver_base.py
@@ -358,12 +358,16 @@ class FINNExampleOverlay(Overlay):
                 iwdma.write(0x00, 1)
             for o in range(self.num_outputs):
                 self.odma[o].write(0x10, self.obuf_packed_device[o].device_address & 0xFFFFFFFF)
-                self.odma[o].write(0x14, (self.obuf_packed_device[o].device_address >> 32) & 0xFFFFFFFF)
+                self.odma[o].write(
+                    0x14, (self.obuf_packed_device[o].device_address >> 32) & 0xFFFFFFFF
+                )
                 self.odma[o].write(0x1C, batch_size)
                 self.odma[o].write(0x00, 1)
             for i in range(self.num_inputs):
                 self.idma[i].write(0x10, self.ibuf_packed_device[i].device_address & 0xFFFFFFFF)
-                self.idma[i].write(0x14, (self.ibuf_packed_device[i].device_address >> 32) & 0xFFFFFFFF)
+                self.idma[i].write(
+                    0x14, (self.ibuf_packed_device[i].device_address >> 32) & 0xFFFFFFFF
+                )
                 self.idma[i].write(0x1C, batch_size)
                 self.idma[i].write(0x00, 1)
         elif self.platform == "alveo":

--- a/src/finn/qnn-data/templates/driver/driver_base.py
+++ b/src/finn/qnn-data/templates/driver/driver_base.py
@@ -352,15 +352,18 @@ class FINNExampleOverlay(Overlay):
                 assert self.odma[o].read(0x00) & 0x4 != 0, "Output DMA %d is not idle" % (o)
             # manually launch IODMAs since signatures are missing
             for iwdma, iwbuf, iwdma_name in self.external_weights:
-                iwdma.write(0x10, iwbuf.device_address)
+                iwdma.write(0x10, iwbuf.device_address & 0xFFFFFFFF)
+                iwdma.write(0x14, (iwbuf.device_address >> 32) & 0xFFFFFFFF)
                 iwdma.write(0x1C, batch_size)
                 iwdma.write(0x00, 1)
             for o in range(self.num_outputs):
-                self.odma[o].write(0x10, self.obuf_packed_device[o].device_address)
+                self.odma[o].write(0x10, self.obuf_packed_device[o].device_address & 0xFFFFFFFF)
+                self.odma[o].write(0x14, (self.obuf_packed_device[o].device_address >> 32) & 0xFFFFFFFF)
                 self.odma[o].write(0x1C, batch_size)
                 self.odma[o].write(0x00, 1)
             for i in range(self.num_inputs):
-                self.idma[i].write(0x10, self.ibuf_packed_device[i].device_address)
+                self.idma[i].write(0x10, self.ibuf_packed_device[i].device_address & 0xFFFFFFFF)
+                self.idma[i].write(0x14, (self.ibuf_packed_device[i].device_address >> 32) & 0xFFFFFFFF)
                 self.idma[i].write(0x1C, batch_size)
                 self.idma[i].write(0x00, 1)
         elif self.platform == "alveo":


### PR DESCRIPTION
Added 64-bit address support when setting up the DMAs in the driver template file to enable compatibility with pynq v3.1 and xrt 2.17. 

Tested running multiple finn-examples with pynq v3.1 on the AUP-ZU3 board and running the tfc-w1a1-mnist example with pynq 3.0.1 on the ZCU104 board.