### PR TITLE
Accessing adjusted depth and impl style only when FIFO in RTL layer format

### DIFF
--- a/src/finn/custom_op/fpgadataflow/streamingfifo.py
+++ b/src/finn/custom_op/fpgadataflow/streamingfifo.py
@@ -92,7 +92,10 @@ class StreamingFIFO(HWCustomOp):
         return ret
 
     def get_normal_input_shape(self, ind=0):
-        depth = self.get_adjusted_depth()
+        try:
+            depth = self.get_adjusted_depth()
+        except AttributeError:
+            depth = self.get_nodeattr("depth")
         assert depth >= 1, """Depth is too low"""
         if depth > 256 and self.get_nodeattr("impl_style") == "rtl":
             warnings.warn("Depth is high, set between 2 and 256 for efficient SRL implementation")
@@ -133,7 +136,10 @@ class StreamingFIFO(HWCustomOp):
         """Calculates resource estimation for BRAM"""
         impl = self.get_nodeattr("impl_style")
         ram_type = self.get_nodeattr("ram_style")
-        depth = self.get_adjusted_depth()
+        try:
+            depth = self.get_adjusted_depth()
+        except AttributeError:
+            depth = self.get_nodeattr("depth")
         W = self.get_instream_width()
 
         if impl == "rtl" or (impl == "vivado" and ram_type != "block"):
@@ -158,7 +164,10 @@ class StreamingFIFO(HWCustomOp):
 
         impl = self.get_nodeattr("impl_style")
         ram_type = self.get_nodeattr("ram_style")
-        depth = self.get_adjusted_depth()
+        try:
+            depth = self.get_adjusted_depth()
+        except AttributeError:
+            depth = self.get_nodeattr("depth")
         W = self.get_instream_width()
 
         if impl == "rtl" or (impl == "vivado" and ram_type != "ultra"):
@@ -168,7 +177,10 @@ class StreamingFIFO(HWCustomOp):
             return (math.ceil(depth / 4096)) * (math.ceil(W / 72))
 
     def bram_efficiency_estimation(self):
-        depth = self.get_adjusted_depth()
+        try:
+            depth = self.get_adjusted_depth()
+        except AttributeError:
+            depth = self.get_nodeattr("depth")
         W = self.get_instream_width()
         bram16_est = self.bram_estimation()
         if bram16_est == 0:
@@ -181,7 +193,10 @@ class StreamingFIFO(HWCustomOp):
         """Calculates resource estimations for LUTs"""
         impl = self.get_nodeattr("impl_style")
         ram_type = self.get_nodeattr("ram_style")
-        depth = self.get_adjusted_depth()
+        try:
+            depth = self.get_adjusted_depth()
+        except AttributeError:
+            depth = self.get_nodeattr("depth")
         W = self.get_instream_width()
 
         address_luts = 2 * math.ceil(math.log(depth, 2))

--- a/src/finn/custom_op/fpgadataflow/streamingfifo.py
+++ b/src/finn/custom_op/fpgadataflow/streamingfifo.py
@@ -85,7 +85,14 @@ class StreamingFIFO(HWCustomOp):
 
     def get_verilog_top_module_intf_names(self):
         ret = super().get_verilog_top_module_intf_names()
-        is_rtl = self.get_nodeattr("impl_style") == "rtl"
+        try:
+            is_rtl = self.get_nodeattr("impl_style") == "rtl"
+        except AttributeError:
+            raise Exception(
+                self.onnx_node.name
+                + """ is still in hw abstraction format,
+                Please run SpecializeLayers() before proceeding."""
+            )
         is_depth_monitor = self.get_nodeattr("depth_monitor") == 1
         if is_rtl and is_depth_monitor:
             ret["ap_none"] = ["maxcount"]
@@ -97,7 +104,11 @@ class StreamingFIFO(HWCustomOp):
         except AttributeError:
             depth = self.get_nodeattr("depth")
         assert depth >= 1, """Depth is too low"""
-        if depth > 256 and self.get_nodeattr("impl_style") == "rtl":
+        try:
+            impl_style = self.get_nodeattr("impl_style") == "rtl"
+        except AttributeError:
+            impl_style = ""
+        if depth > 256 and impl_style == "rtl":
             warnings.warn("Depth is high, set between 2 and 256 for efficient SRL implementation")
         return self.get_nodeattr("normal_shape")
 
@@ -134,7 +145,15 @@ class StreamingFIFO(HWCustomOp):
 
     def bram_estimation(self):
         """Calculates resource estimation for BRAM"""
-        impl = self.get_nodeattr("impl_style")
+        try:
+            impl = self.get_nodeattr("impl_style") == "rtl"
+        except AttributeError:
+            raise Exception(
+                self.onnx_node.name
+                + """ is still in hw abstraction format,
+                Please run SpecializeLayers() before proceeding."""
+            )
+
         ram_type = self.get_nodeattr("ram_style")
         try:
             depth = self.get_adjusted_depth()
@@ -162,7 +181,14 @@ class StreamingFIFO(HWCustomOp):
     def uram_estimation(self):
         """Calculates resource estimation for URAM"""
 
-        impl = self.get_nodeattr("impl_style")
+        try:
+            impl = self.get_nodeattr("impl_style") == "rtl"
+        except AttributeError:
+            raise Exception(
+                self.onnx_node.name
+                + """ is still in hw abstraction format,
+                Please run SpecializeLayers() before proceeding."""
+            )
         ram_type = self.get_nodeattr("ram_style")
         try:
             depth = self.get_adjusted_depth()
@@ -191,7 +217,14 @@ class StreamingFIFO(HWCustomOp):
 
     def lut_estimation(self):
         """Calculates resource estimations for LUTs"""
-        impl = self.get_nodeattr("impl_style")
+        try:
+            impl = self.get_nodeattr("impl_style") == "rtl"
+        except AttributeError:
+            raise Exception(
+                self.onnx_node.name
+                + """ is still in hw abstraction format,
+                Please run SpecializeLayers() before proceeding."""
+            )
         ram_type = self.get_nodeattr("ram_style")
         try:
             depth = self.get_adjusted_depth()


### PR DESCRIPTION
- Default to `depth` node attribute or raise exception when RTL layer specific parameters are accessed for StreamingFIFO