### PR TITLE
[Thresholding] Support thresholding with fewer than expected thresholds to match RTL behavior

### DIFF
--- a/src/finn/custom_op/fpgadataflow/rtl/thresholding_rtl.py
+++ b/src/finn/custom_op/fpgadataflow/rtl/thresholding_rtl.py
@@ -422,7 +422,7 @@ class Thresholding_rtl(Thresholding, RTLBackend):
                 num_channels = pe
             width_padded = roundup_to_integer_multiple(thresholds.shape[1], 2**o_bitwidth)
             thresh_padded = np.zeros((thresholds.shape[0], width_padded))
-            thresh_padded[: thresholds.shape[0], :n_thres_steps] = thresholds
+            thresh_padded[: thresholds.shape[0], :expected_thresholds] = thresholds
             thresh_stream = []
             bw_hexdigit = roundup_to_integer_multiple(wdt.bitwidth(), 32)
             padding = np.zeros(width_padded, dtype=np.int32)


### PR DESCRIPTION
- Updated the `Thresholding_rtl` class to remove addition of boundary thresholds when number of thresholding is steps is less than `(2**out_bits - 1)`.
- Modified computation of RTL module variables to reflect this.
- Added zero-padding in generated .dat files.
- Removed bias update.

The proposed changes remove the necessity of increasing the bit-width of the thresholds (for unsigned narrow output quantization).