### PR TITLE
LD_LIBRARY_PATH autoload

### DIFF
--- a/docker/finn_entrypoint.sh
+++ b/docker/finn_entrypoint.sh
@@ -119,6 +119,7 @@ else
       recho "Failed to build finn_xsi"
     fi
   fi
+  export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/lib/x86_64-linux-gnu/:${XILINX_VIVADO}/lib/lnx64.o
 fi
 
 if [ -f "$HLS_PATH/settings64.sh" ];then
@@ -153,6 +154,8 @@ else
   echo "If you need to enable a beta device, ensure .Xilinx/HLS_init.tcl and/or .Xilinx/Vivado/Vivado_init.tcl are set correctly and mounted"
   echo "See https://docs.xilinx.com/r/en-US/ug835-vivado-tcl-commands/Tcl-Initialization-Scripts"
 fi
+
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$VITIS_PATH/lnx64/tools/fpo_v7_1"
 
 export PATH=$PATH:$HOME/.local/bin
 


### PR DESCRIPTION
 ## Summary

Add automatic `LD_LIBRARY_PATH` configuration for Vivado and Vitis libraries in the Python package, replacing logic from the Docker orchestration and entrypoint scripts. This way, library paths configured automatically when finn is imported, regardless of execution environment

  ## Changes

  - **src/finn/__init__.py**: Added `_setup_ld_library_path()` function that automatically configures 
  `LD_LIBRARY_PATH` when the finn package is imported, adding paths for:
    - Vivado libraries (`${XILINX_VIVADO}/lib/lnx64.o`)
    - System libraries (`/lib/x86_64-linux-gnu/`)
    - Vitis FPO libraries (`${VITIS_PATH}/lnx64/tools/fpo_v7_1`)