### PR TITLE
Add no_stdout_redirect flag to prevent terminal library conflicts

### DIFF
--- a/src/finn/builder/build_dataflow.py
+++ b/src/finn/builder/build_dataflow.py
@@ -148,7 +148,7 @@ def build_dataflow_cfg(model_filename, cfg: DataflowBuildConfig):
             step_name = transform_step.__name__
             print("Running step: %s [%d/%d]" % (step_name, step_num, len(build_dataflow_steps)))
             # redirect output to logfile
-            if not cfg.verbose:
+            if not cfg.verbose and not cfg.no_stdout_redirect:
                 sys.stdout = stdout_logger
                 sys.stderr = stderr_logger
                 # also log current step name to logfile

--- a/src/finn/builder/build_dataflow_config.py
+++ b/src/finn/builder/build_dataflow_config.py
@@ -332,6 +332,11 @@ class DataflowBuildConfig:
     #: Otherwise, these will be suppressed and only appear in the build log.
     verbose: Optional[bool] = False
 
+    #: When True, stdout/stderr will not be redirected even when verbose=False.
+    #: Useful for applications using terminal-aware libraries (e.g., Rich, tqdm)
+    #: that require direct terminal access and break with stream redirection.
+    no_stdout_redirect: Optional[bool] = False
+
     #: If given, only run the steps in the list. If not, run default steps.
     #: See `default_build_dataflow_steps` for the default list of steps.
     #: When specified:


### PR DESCRIPTION
## Problem

When `verbose=False`, FINN globally redirects `sys.stdout` and `sys.stderr` to logger streams (build_dataflow.py:151-153). This breaks terminal-aware libraries like Rich, tqdm, and blessed that require direct terminal access.

## Solution

Add `no_stdout_redirect` flag to `DataflowBuildConfig` that disables stdout/stderr redirection while keeping `verbose=False`.

**Changes:**
- Add `no_stdout_redirect: Optional[bool] = False` to `DataflowBuildConfig`
- Modify redirect condition: `if not cfg.verbose and not cfg.no_stdout_redirect:`

**Note:** When `no_stdout_redirect=True`, subprocess output is NOT automatically logged to `build_dataflow.log`. Applications using this flag should handle their own logging if persistent logs are needed.

## Benefits

- **Backward compatible**: Defaults to `False`, preserving existing behavior
- **Minimal change**: 3 lines modified
- **Enables modern UI**: Allows FINN integration with terminal libraries
- **Explicit control**: Applications choose their output handling

## Example Usage

```python
config = DataflowBuildConfig(
    output_dir="./build",
    verbose=False,
    no_stdout_redirect=True,  # Preserve terminal compatibility
    ...
)

Applications can capture FINN output using Python's logging or custom handlers
as needed for their use case.
```