### PR TITLE
Increase rtl and fifo-depth sim timeouts (fixes #1457)

### DIFF
--- a/src/finn/builder/build_dataflow_steps.py
+++ b/src/finn/builder/build_dataflow_steps.py
@@ -665,7 +665,7 @@ def step_create_stitched_ip(model: ModelWrapper, cfg: DataflowBuildConfig):
         estimate_network_performance = verify_model.analysis(dataflow_performance)
         prev_liveness = get_liveness_threshold_cycles()
         os.environ["LIVENESS_THRESHOLD"] = str(
-            int(estimate_network_performance["critical_path_cycles"] * 1.1)
+            int(estimate_network_performance["critical_path_cycles"] * 1.1 + 50)
         )
         if cfg.verify_save_rtlsim_waveforms:
             verify_out_dir = cfg.output_dir + "/verification_output"
@@ -702,7 +702,7 @@ def step_measure_rtlsim_performance(model: ModelWrapper, cfg: DataflowBuildConfi
         model = model.transform(AnnotateCycles())
         perf = model.analysis(dataflow_performance)
         latency = perf["critical_path_cycles"]
-        max_iters = latency * 1.1 + 20
+        max_iters = latency * 1.1 + 50
         rtlsim_perf_dict = xsi_fifosim(model, rtlsim_bs, max_iters=max_iters)
         # keep keys consistent between the Python and C++-styles
         cycles = rtlsim_perf_dict["cycles"]

--- a/src/finn/transformation/fpgadataflow/set_fifo_depths.py
+++ b/src/finn/transformation/fpgadataflow/set_fifo_depths.py
@@ -372,7 +372,7 @@ class InsertAndSetFIFODepths(Transformation):
             n_inferences = 2
 
         # use the critical_path_cycles estimate to set the timeout limit for FIFO sim
-        max_iters = latency * 1.1 + 20
+        max_iters = latency * 1.1 + 50
 
         # set up rate limit for input throttling
         if self.fifosim_input_throttle:


### PR DESCRIPTION
Slightly increased the rtl and fifo-depth simulation timeouts to fix issue #1457 to not run into simulation timeouts when building the upscaled bnn-pynq finn-examples for the AUP-ZU3 board.