### PR TITLE
[FIFOSim] Update number of inferences

### DIFF
--- a/src/finn/builder/build_dataflow_config.py
+++ b/src/finn/builder/build_dataflow_config.py
@@ -220,7 +220,7 @@ class DataflowBuildConfig:
     verify_save_rtlsim_waveforms: Optional[bool] = False
 
     #: Manually specify the verification tolerance
-    verification_atol: Optional[float] = 1e-1 
+    verification_atol: Optional[float] = 1e-1
 
     #: (Optional) Run synthesis to generate a .dcp for the stitched-IP output product.
     #: This can make it easier to treat it as a standalone artifact without requiring
@@ -287,7 +287,8 @@ class DataflowBuildConfig:
     fifosim_input_throttle: Optional[bool] = True
 
     #: Manually specify the number of inferences for simulation-based FIFO sizing
-    fifosim_n_inferences: Optional[int] = None 
+    #: Default is 2
+    fifosim_n_inferences: Optional[int] = 2
 
     #: Enable saving waveforms from simulation-based FIFO sizing
     #: Only relevant if auto_fifo_strategy = LARGEFIFO_RTLSIM

--- a/src/finn/builder/build_dataflow_steps.py
+++ b/src/finn/builder/build_dataflow_steps.py
@@ -610,7 +610,7 @@ def step_set_fifo_depths(model: ModelWrapper, cfg: DataflowBuildConfig):
                     swg_exception=cfg.default_swg_exception,
                     vivado_ram_style=cfg.large_fifo_mem_style,
                     fifosim_input_throttle=cfg.fifosim_input_throttle,
-                    cfg_n_inferences=cfg.fifosim_n_inferences
+                    cfg_n_inferences=cfg.fifosim_n_inferences,
                 )
             )
             # InsertAndSetFIFODepths internally removes any shallow FIFOs

--- a/src/finn/transformation/fpgadataflow/set_fifo_depths.py
+++ b/src/finn/transformation/fpgadataflow/set_fifo_depths.py
@@ -273,7 +273,7 @@ class InsertAndSetFIFODepths(Transformation):
         swg_exception=False,
         vivado_ram_style="auto",
         fifosim_input_throttle=True,
-        cfg_n_inferences=None,
+        cfg_n_inferences=2,
     ):
         super().__init__()
         self.fpgapart = fpgapart
@@ -359,24 +359,6 @@ class InsertAndSetFIFODepths(Transformation):
         model.set_metadata_prop("exec_mode", "rtlsim")
 
         # do rtlsim in C++ for FIFO sizing
-        # determine # inputs for FIFO sizing according to topology type
-        swg_nodes = [
-            x for x in model.graph.node if x.op_type.startswith("ConvolutionInputGenerator")
-        ]
-        if len(swg_nodes) == 0:
-            # MLP, no layer overlap
-            # assuming half the nodes are now FIFOs, use half the # of
-            # nodes as # inputs to drive the simulation
-            n_inferences = int(len(model.graph.node) / 2)
-        else:
-            # convnet, two inputs are typically enough to fill entire
-            # layer pipeline due to overlaps
-            n_inferences = 2
-
-        # Override the number of inferences if cfg_n_inferences is set
-        if self.cfg_n_inferences is not None:
-            n_inferences = self.cfg_n_inferences
-
         # use the critical_path_cycles estimate to set the timeout limit for FIFO sim
         max_iters = latency * 1.1 + 20
 
@@ -388,7 +370,9 @@ class InsertAndSetFIFODepths(Transformation):
         else:
             throttle_cycles = 0
 
-        sim = xsi_fifosim(model, n_inferences, max_iters=max_iters, throttle_cycles=throttle_cycles)
+        sim = xsi_fifosim(
+            model, self.cfg_n_inferences, max_iters=max_iters, throttle_cycles=throttle_cycles
+        )
 
         for ind, node in enumerate(fifo_nodes):
             maxcount_name = "maxcount_%d" % ind


### PR DESCRIPTION
Update number of inferences for fifo simulation and turn it into builder configuration parameter (default 2). Additionally give user capability to configure the absolute tolerance for a verification result.