### PR TITLE
Fix the Memstreamer AXI address bits for multiple Sets

### DIFF
--- a/finn-rtllib/memstream/hdl/memstream_axi.sv
+++ b/finn-rtllib/memstream/hdl/memstream_axi.sv
@@ -39,7 +39,7 @@ module memstream_axi #(
 	parameter  RAM_STYLE = "auto",
 	bit  PUMPED_MEMORY = 0,
 
-	localparam int unsigned  AXILITE_ADDR_WIDTH = $clog2(DEPTH * (2**$clog2((WIDTH+31)/32))) + 2,
+	localparam int unsigned  AXILITE_ADDR_WIDTH = $clog2(SETS * DEPTH * (2**$clog2((WIDTH+31)/32))) + 2,
 	localparam int unsigned  SET_BITS = SETS > 2? $clog2(SETS) : 1
 )(
 	// Global Control
@@ -84,7 +84,7 @@ module memstream_axi #(
 	output	logic [((WIDTH+7)/8)*8-1:0]  m_axis_0_tdata
 );
 
-	localparam int unsigned  IP_ADDR_WIDTH0 = $clog2(DEPTH);
+	localparam int unsigned  IP_ADDR_WIDTH0 = $clog2(SETS * DEPTH);
 	localparam int unsigned  IP_ADDR_WIDTH = IP_ADDR_WIDTH0? IP_ADDR_WIDTH0 : 1;
 
 	//-----------------------------------------------------------------------

--- a/finn-rtllib/memstream/hdl/memstream_wrapper_template.v
+++ b/finn-rtllib/memstream/hdl/memstream_wrapper_template.v
@@ -38,7 +38,7 @@ module $MODULE_NAME$_memstream_wrapper #(
 	parameter  RAM_STYLE = "$RAM_STYLE$",
 	parameter  PUMPED_MEMORY = $PUMPED_MEMORY$,
 
-	parameter  AXILITE_ADDR_WIDTH = $clog2(DEPTH * (2**$clog2((WIDTH+31)/32))) + 2,
+	parameter  AXILITE_ADDR_WIDTH = $clog2(SETS * DEPTH * (2**$clog2((WIDTH+31)/32))) + 2,
 	parameter  SET_BITS = SETS > 2? $clog2(SETS) : 1
 )(
 	// Global Control


### PR DESCRIPTION
The address bit widths of the current Memstreamer implementation do not account for multiple Sets. This is addressed in this PR by extending the bit widths. 