### PR TITLE
Fixed processing of integers for minimize_accumulator_width()

### DIFF
--- a/src/finn/custom_op/fpgadataflow/matrixvectoractivation.py
+++ b/src/finn/custom_op/fpgadataflow/matrixvectoractivation.py
@@ -501,6 +501,8 @@ class MVAU(HWCustomOp):
         # if the thresholds can be used to determine range, then adjust the range
         # according to the known values of the thresholds
         if thresholds is not None:
+            # Assume that thresholds values are integers from RoundAndClipThresholds
+            # during streamlining
             threshold_tensor = self.get_hw_compatible_threshold_tensor(thresholds)
             # Use double precision for threshold comparisons to prevent overflow
             min_threshold = np.float64(thresholds.min())
@@ -515,22 +517,18 @@ class MVAU(HWCustomOp):
                 threshold_tensor = self.get_hw_compatible_threshold_tensor(thresholds)
                 min_threshold = np.float64(thresholds.min())
                 max_threshold = np.float64(thresholds.max())
-            acc_min = np.minimum(min_threshold, acc_min_fp)
-            acc_max = np.maximum(max_threshold, acc_max_fp)
-
-        # Use floor/ceil for safe conversion to integer
-        acc_min_int = int(np.floor(acc_min))
-        acc_max_int = int(np.ceil(acc_max))
+            acc_min = min(min_threshold, acc_min_fp)
+            acc_max = max(max_threshold, acc_max_fp)
 
         # if the acc_range is always greater than 0, then acc_max <= 2^P - 1
-        if acc_min_int >= 0:
-            acc_bit_width = np.log2(acc_max_int + 1)
+        if acc_min >= 0:
+            acc_bit_width = np.log2(acc_max + 1)
             acc_bit_width = math.ceil(acc_bit_width)
             adt = DataType[f"UINT{acc_bit_width}"]
         # if the acc_range is signed, then acc_min >= -2^{P-1} and acc_max <=
         # 2^{P - 1} - 1, which means 2^{P - 1} >= max(-acc_min, 1 + acc_max)
         else:
-            _acc_max = max(-acc_min_int, 1 + acc_max_int)
+            _acc_max = max(-acc_min, 1 + acc_max)
             acc_bit_width = np.log2(_acc_max) + 1
             acc_bit_width = math.ceil(acc_bit_width)
             adt = DataType[f"INT{acc_bit_width}"]

--- a/src/finn/custom_op/fpgadataflow/thresholding.py
+++ b/src/finn/custom_op/fpgadataflow/thresholding.py
@@ -125,14 +125,17 @@ class Thresholding(HWCustomOp):
         return DataType[self.get_nodeattr("outputDataType")]
 
     def minimize_accumulator_width(self, model):
-        "Minimize threshold width ('accumulator width' here due to convention)"
+        """Minimize threshold width ('accumulator width' here due to convention).
+        This function should not round or clip the threshold values,
+        that is done in RoundAndClipThresholds. It should just align the threshold dtype
+        with the input dtype if necessary."""
         thresholds = model.get_initializer(self.onnx_node.input[1])
         if self.get_nodeattr("runtime_writeable_weights") or self.get_nodeattr("mlo_max_iter"):
             return DataType[self.get_nodeattr("weightDataType")]
         threshold_tensor = self.get_hw_compatible_threshold_tensor(thresholds)
         # TODO: extend this for fixed point
-        if self.get_input_datatype(0).is_integer():
-            # minimize threshold width only if input is an integer
+        if self.get_input_datatype(0).is_integer() and self.get_input_datatype(1).is_integer():
+            # minimize threshold width only if input and thresholds are integer
             # Use double precision for intermediate calculations to prevent overflow
             min_threshold = np.float64(thresholds.min())
             max_threshold = np.float64(thresholds.max())
@@ -140,20 +143,16 @@ class Thresholding(HWCustomOp):
             max_input = np.float64(self.get_input_datatype(0).max())
 
             # get range required by threshold values
-            tdt_min = np.minimum(min_input, min_threshold)
-            tdt_max = np.maximum(max_input, max_threshold)
+            tdt_min = min(min_input, min_threshold)
+            tdt_max = max(max_input, max_threshold)
 
-            # Use floor/ceil for safe conversion to integer
-            tdt_min_int = int(np.floor(tdt_min))
-            tdt_max_int = int(np.ceil(tdt_max))
-
-            if tdt_min_int < 0:
-                if abs(tdt_min_int) > tdt_max_int:
-                    tdt = DataType.get_smallest_possible(tdt_min_int)
+            if tdt_min < 0:
+                if abs(tdt_min) > tdt_max:
+                    tdt = DataType.get_smallest_possible(tdt_min)
                 else:
-                    tdt = DataType.get_smallest_possible(-tdt_max_int - 1)
+                    tdt = DataType.get_smallest_possible(-tdt_max - 1)
             else:
-                tdt = DataType.get_smallest_possible(tdt_max_int)
+                tdt = DataType.get_smallest_possible(tdt_max)
         else:
             # special case: if input is float, we keep thresholds as is
             tdt = self.get_input_datatype(1)

--- a/tests/fpgadataflow/test_minimize_bit_width.py
+++ b/tests/fpgadataflow/test_minimize_bit_width.py
@@ -325,6 +325,7 @@ def test_minimize_accumulator_width_threshold_boundary_values(tdt: DataType):
     """Test minimize_accumulator_width with boundary threshold values to ensure
     deterministic behavior across systems by avoiding float32 type mixing."""
 
+    idt = DataType["INT15"]
     inp = helper.make_tensor_value_info("inp", TensorProto.FLOAT, [1, 1, 1, 4])
     outp = helper.make_tensor_value_info("outp", TensorProto.FLOAT, [1, 1, 1, 4])
 
@@ -346,7 +347,7 @@ def test_minimize_accumulator_width_threshold_boundary_values(tdt: DataType):
         backend="fpgadataflow",
         NumChannels=4,
         PE=1,
-        inputDataType=tdt.name,
+        inputDataType=idt.name,
         weightDataType=tdt.name,
         outputDataType="UINT2",
         numInputVectors=[1, 1, 1],
@@ -371,7 +372,7 @@ def test_minimize_accumulator_width_threshold_boundary_values(tdt: DataType):
     model = helper.make_model(graph, producer_name="threshold-boundary-test")
     model = ModelWrapper(model)
 
-    model.set_tensor_datatype("inp", tdt)
+    model.set_tensor_datatype("inp", idt)
     model.set_tensor_datatype("outp", DataType["UINT2"])
     model.set_tensor_datatype("thresh", tdt)
 


### PR DESCRIPTION
minimize_accumulator_width() had an issue where threshold and input range values were processed as float32, which led to rounding errors - mixed numpy float32 scalars with python int for math operations. Fix was to convert values to python int before performing arithmetic operations.

Test function was added to check for correct behavior at datatype boundaries for int16, int24, and int32. 

Fixes issue #1517