### PR TITLE
[Docker] Pin anyio<4.13 to fix pytest 6.2.5 crash

### DIFF
--- a/docker/Dockerfile.finn
+++ b/docker/Dockerfile.finn
@@ -99,6 +99,8 @@ RUN pip install torch==2.8.0 torchvision==0.23.0 torchaudio==2.8.0 --extra-index
 RUN pip install pygments==2.14.0
 RUN pip install ipykernel==6.21.2
 RUN pip install jupyter==1.0.0 --ignore-installed
+# anyio >= 4.13.0 for jupyter incompatible with pytest 6.2.5 (missing _pytest.scope module, added in pytest 7.0.0)
+RUN pip install 'anyio<4.13'
 RUN pip install markupsafe==2.0.1
 RUN pip install matplotlib==3.7.0  --ignore-installed
 RUN pip install pytest-dependency==0.5.1


### PR DESCRIPTION
A dependency of jupyter (anyio) released version 4.13.0 yesterday (24/Mar/2026). This introduces an issue when running a newly built docker image. When anyio 4.13.0 does `from _pytest.scope import Scope` the file doesn't exist in pytest 6.2.5, so Python raises `ModuleNotFoundError`. It was added in pytest 7.0.0 as a standalone module.

### Fix

Pin anyio<4.13 after the jupyter install. Versions 4.0-4.12 are all compatible with pytest 6.2.5.

### Verification

Built the docker with three anyio versions and verified that the newest release was the culprit.

| anyio   | pytest 6.2.5 |
|---------|-------------|
| 4.13.0  | Fail |
| 4.12.1  | Success |
| 4.12.0  | Success |

### To reproduce

Run this test with before and after the patch.

```bash
docker build -f docker/Dockerfile.finn \
    --build-arg SKIP_XRT=1 \
    --build-arg USERNAME=testuser \
    --build-arg USER_UID=1000 \
    --build-arg GROUP_ID=1000 \
    --build-arg GROUPNAME=testgroup \
    --tag=finn-test \
    .

# test that pytest works (fails with 4.13.0)
docker run --rm --entrypoint bash --user root finn-test \
  -c 'pytest --version'
```