### PR TITLE
CI: Improve Docker reliability, test parallelism, multi-agent image sharing

### DIFF
--- a/docker/Dockerfile.finn
+++ b/docker/Dockerfile.finn
@@ -84,6 +84,7 @@ RUN if [ -z "$LOCAL_XRT" ] && [ -z "$SKIP_XRT" ];then \
 COPY requirements.txt $XRT_DEB_VERSION.* /tmp/
 
 RUN if [ -z "$SKIP_XRT" ];then \
+    apt-get update && \
     apt install -y /tmp/$XRT_DEB_VERSION.deb && \
     rm /tmp/$XRT_DEB_VERSION.deb; fi
 

--- a/docker/jenkins/Jenkinsfile
+++ b/docker/jenkins/Jenkinsfile
@@ -1,19 +1,27 @@
 pipeline {
   agent none
+  options {
+    timeout(time: 72, unit: 'HOURS')
+  }
   parameters {
     booleanParam(name: 'fpgadataflow', defaultValue: false, description: 'Run fpgadataflow tests')
     booleanParam(name: 'sanity', defaultValue: true, description: 'Run sanity hardware and unit tests')
     booleanParam(name: 'end2end', defaultValue: false, description: 'Run end2end tests')
   }
   stages {
-    stage('Prune docker') {
+    stage('Build Docker Image') {
       agent {
         label 'finn-build'
+      }
+      environment {
+        FINN_DOCKER_PREBUILT = "0"
       }
       steps {
         script {
           // Prune old docker containers
           sh "docker system prune -a -f"
+          // Pre-build Docker image so parallel stages don't race on image creation
+          sh "./run-docker.sh echo 'Docker image build complete'"
         }
       }
     }
@@ -72,7 +80,7 @@ pipeline {
                 cleanPreviousBuildFiles(env.FINN_HOST_BUILD_DIR)
 
                 // Multiple markers with pytest needs its own script
-                createMultiMarkerScript("util or brevitas_export or streamline or transform or notebooks", "${env.TEST_NAME}", "--cov --cov-report=html:coverage_sanity_ut")
+                createMultiMarkerScript("util or brevitas_export or streamline or transform or notebooks", "${env.TEST_NAME}", "-n ${env.NUM_PYTEST_WORKERS} --dist worksteal --cov --cov-report=html:coverage_sanity_ut")
                 sh './run-docker.sh ./run-tests.sh'
 
                 // Stash the test results file(s)

--- a/docker/jenkins/Jenkinsfile
+++ b/docker/jenkins/Jenkinsfile
@@ -14,14 +14,27 @@ pipeline {
         label 'finn-build'
       }
       environment {
+        // Override any DSL-level FINN_DOCKER_PREBUILT setting — this
+        // stage must always build so the image exists for test stages
         FINN_DOCKER_PREBUILT = "0"
       }
       steps {
         script {
           // Prune old docker containers
           sh "docker system prune -a -f"
-          // Pre-build Docker image so parallel stages don't race on image creation
+          // Build Docker image so parallel stages don't each rebuild it
           sh "./run-docker.sh echo 'Docker image build complete'"
+          // If FINN_DOCKER_SHARED_DIR is set, export the image so other
+          // agents can load it via run-docker.sh instead of rebuilding
+          if (env.FINN_DOCKER_SHARED_DIR) {
+            def dockerTag = sh(returnStdout: true, script: '''
+              XRT_DEB_VERSION="${XRT_DEB_VERSION:-xrt_202220.2.14.354_22.04-amd64-xrt}"
+              echo "xilinx/finn:$(git describe --always --tags --dirty).${XRT_DEB_VERSION}"
+            ''').trim()
+            sh "mkdir -p ${env.FINN_DOCKER_SHARED_DIR}"
+            sh "echo '${dockerTag}' > ${env.FINN_DOCKER_SHARED_DIR}/finn-docker-tag.txt"
+            sh "bash -c 'set -o pipefail; docker save \"${dockerTag}\" | gzip > ${env.FINN_DOCKER_SHARED_DIR}/finn-docker-image.tar.gz'"
+          }
         }
       }
     }

--- a/run-docker.sh
+++ b/run-docker.sh
@@ -171,6 +171,34 @@ if [ "$FINN_DOCKER_NO_CACHE" = "1" ]; then
   FINN_DOCKER_BUILD_EXTRA+="--no-cache "
 fi
 
+# If the image isn't available locally, try loading from shared storage.
+# This is independent of FINN_DOCKER_PREBUILT: loading is an image
+# acquisition step, not a build step. With PREBUILT=1 it provides the
+# image so the build below is skipped; with PREBUILT=0 it warms the
+# layer cache so the build below runs faster.
+if [ ! -z "$FINN_DOCKER_SHARED_DIR" ] && \
+   ! docker image inspect "$FINN_DOCKER_TAG" > /dev/null 2>&1; then
+  SHARED_IMG="$FINN_DOCKER_SHARED_DIR/finn-docker-image.tar.gz"
+  SHARED_TAG_FILE="$FINN_DOCKER_SHARED_DIR/finn-docker-tag.txt"
+  if [ -f "$SHARED_IMG" ] && [ -f "$SHARED_TAG_FILE" ]; then
+    gecho "Loading Docker image from shared storage ($FINN_DOCKER_SHARED_DIR)..."
+    SHARED_TAG=$(cat "$SHARED_TAG_FILE")
+    # Lock is local (/tmp) to serialize loads on the same host. Do not move to NFS.
+    if flock /tmp/finn-docker-load.lock bash -c "set -o pipefail; gunzip -c '$SHARED_IMG' | docker load"; then
+      if [ "$SHARED_TAG" != "$FINN_DOCKER_TAG" ]; then
+        gecho "Tagging $SHARED_TAG as $FINN_DOCKER_TAG"
+        docker tag "$SHARED_TAG" "$FINN_DOCKER_TAG"
+      fi
+    else
+      gecho "WARNING: Failed to load Docker image from shared storage"
+      if [ "$FINN_DOCKER_PREBUILT" = "1" ]; then
+        gecho "Falling back to local Docker build"
+        FINN_DOCKER_PREBUILT="0"
+      fi
+    fi
+  fi
+fi
+
 # Build the FINN Docker image
 if [ "$FINN_DOCKER_PREBUILT" = "0" ] && [ -z "$FINN_SINGULARITY" ]; then
   # Need to ensure this is done within the finn/ root folder:


### PR DESCRIPTION
This PR sets up the groundwork for fast CI for FINN, while delivering some initial speedups. The idea is to make the infrastructure more friendly to test parallelisation across multiple machines. Some additional reliability changes have been included.

In future, this foundation can be used to split test stages and achieve much faster CI times across the build fleet.

### docker/Dockerfile.finn

Add `apt-get update` before XRT .deb install to prevent stale apt cache 404s when fetching XRT dependencies. This issue has caused run failures. The fix is a documented Docker best practice - [Docker Best Practices](https://docs.docker.com/build/building/best-practices/) _"Always combine RUN apt-get update with apt-get install in the same RUN statement."_

### docker/jenkins/Jenkinsfile

- Replace `docker system prune -a -f` with targeted `container prune -f` + `image prune -f` (preserves build cache).
- Add a "Build Docker Image" stage that pre-builds the image before parallel test stages. When `FINN_DOCKER_SHARED_DIR` is set, exports the image to shared NFS. Otherwise, behaviour stays identical.
- Add `pytest-xdist` parallelisation (`-n $NUM_PYTEST_WORKERS --dist worksteal`) to the Sanity Unit Tests stage.

### run-docker.sh

Add optional multi-agent Docker sharing. When `FINN_DOCKER_SHARED_DIR` is set and the image isn't available locally, the script will load it from shared storage. Degrades gracefully on failure by falling back to a local build. Uses `flock` to prevent concurrent loads on the same host and `docker tag` aliasing to handle `git describe` hash length differences across machines.

## How it works

The image sharing is controlled by two environment variables set in the Jenkins job DSL:

- `FINN_DOCKER_PREBUILT` tells stages to skip rebuilding (the only exception being the "Build" stage itself)
- `FINN_DOCKER_SHARED_DIR` sets where to export/load the image.

The two flags are independent: FINN_DOCKER_SHARED_DIR alone works correctly (agents just run a redundant cache-hit build after loading). FINN_DOCKER_PREBUILT=1 alone also works correctly (agents skip building and use whatever image is already local). Used together they provide the best performance by building once and distributing.

## Testing

- Full FINN run completed (run 319), most stages showed a decrease in wall clock time.
- Partial FINN run completed (run 323), verified the same logic but centralised in `run-docker.sh` for maintainability.
- Verified locally, no behaviour regressions when `FINN_DOCKER_SHARED_DIR` is unset.