### PR TITLE
[FINNLoop] Save full context of each iteration

### DIFF
--- a/src/finn/builder/build_dataflow_steps.py
+++ b/src/finn/builder/build_dataflow_steps.py
@@ -800,7 +800,7 @@ def step_minimize_bit_width(model: ModelWrapper, cfg: DataflowBuildConfig):
             verify_out_dir = cfg.output_dir + "/verification_output"
             os.makedirs(verify_out_dir, exist_ok=True)
             for loop_node in model.get_nodes_by_op_type("FINNLoop"):
-                loop_inst = getHWCustomOp(loop_node)
+                loop_inst = getCustomOp(loop_node)
                 ctx_path = os.path.join(
                     verify_out_dir, f"iteration_context_{loop_node.name}_folded_hls_cppsim.npz"
                 )
@@ -809,7 +809,7 @@ def step_minimize_bit_width(model: ModelWrapper, cfg: DataflowBuildConfig):
         # Clear iteration_context_path after verification
         if cfg.verify_save_full_context:
             for loop_node in model.get_nodes_by_op_type("FINNLoop"):
-                loop_inst = getHWCustomOp(loop_node)
+                loop_inst = getCustomOp(loop_node)
                 loop_inst.set_nodeattr("iteration_context_path", "")
 
     return model

--- a/src/finn/builder/build_dataflow_steps.py
+++ b/src/finn/builder/build_dataflow_steps.py
@@ -795,7 +795,22 @@ def step_minimize_bit_width(model: ModelWrapper, cfg: DataflowBuildConfig):
         model = model.transform(PrepareCppSim(), apply_to_subgraphs=True)
         model = model.transform(CompileCppSim(), apply_to_subgraphs=True)
         model = model.transform(SetExecMode("cppsim"), apply_to_subgraphs=True)
+        # Set iteration context path on FINNLoop nodes if verify_save_full_context is enabled
+        if cfg.verify_save_full_context:
+            verify_out_dir = cfg.output_dir + "/verification_output"
+            os.makedirs(verify_out_dir, exist_ok=True)
+            for loop_node in model.get_nodes_by_op_type("FINNLoop"):
+                loop_inst = getHWCustomOp(loop_node)
+                ctx_path = os.path.join(
+                    verify_out_dir, f"iteration_context_{loop_node.name}_folded_hls_cppsim.npz"
+                )
+                loop_inst.set_nodeattr("iteration_context_path", ctx_path)
         verify_step(model, cfg, "folded_hls_cppsim", need_parent=True)
+        # Clear iteration_context_path after verification
+        if cfg.verify_save_full_context:
+            for loop_node in model.get_nodes_by_op_type("FINNLoop"):
+                loop_inst = getHWCustomOp(loop_node)
+                loop_inst.set_nodeattr("iteration_context_path", "")
 
     return model
 

--- a/src/finn/custom_op/fpgadataflow/rtl/finn_loop.py
+++ b/src/finn/custom_op/fpgadataflow/rtl/finn_loop.py
@@ -88,6 +88,9 @@ class FINNLoop(HWCustomOp, RTLBackend):
             "inputDataType": ("s", True, ""),
             # FINN output datatype
             "outputDataType": ("s", True, ""),
+            # Path to save per-iteration execution context (cppsim only).
+            # If non-empty, each iteration's full context is saved to this path.
+            "iteration_context_path": ("s", False, ""),
         }
         my_attrs.update(HWCustomOp.get_nodeattr_types(self))
         my_attrs.update(RTLBackend.get_nodeattr_types(self))
@@ -330,6 +333,11 @@ class FINNLoop(HWCustomOp, RTLBackend):
             loop_body = self.get_nodeattr("body")
             # for each iteration run execution
             iteration = self.get_nodeattr("iteration")
+            iteration_context_path = self.get_nodeattr("iteration_context_path")
+            save_iteration_context = (
+                iteration_context_path is not None and iteration_context_path != ""
+            )
+            all_iteration_contexts = {}
             for i_iter in range(iteration):
                 # set the right parameters
                 input_dict = {}
@@ -341,7 +349,17 @@ class FINNLoop(HWCustomOp, RTLBackend):
                         input_dict[loop_body.graph.input[i].name] = params[i_iter]
                 outp_dict = oxe.execute_onnx(loop_body, input_dict, return_full_exec_context=True)
                 inp_values = outp_dict[loop_body.graph.output[0].name]
+                # Save iteration context if enabled
+                if save_iteration_context:
+                    for tensor_name, tensor_val in outp_dict.items():
+                        # Skip empty tensor name (dummy entry for default values)
+                        if tensor_name:
+                            key = f"iter_{i_iter}_{tensor_name}"
+                            all_iteration_contexts[key] = tensor_val
             result = outp_dict[loop_body.graph.output[0].name]
+            # Save all iteration contexts to file
+            if save_iteration_context:
+                np.savez(iteration_context_path, **all_iteration_contexts)
         context[node.output[0]] = np.asarray(result, dtype=np.float32)
 
     def generate_hdl(self, model, fpgapart, clk):

--- a/tests/fpgadataflow/test_fpgadataflow_finnloop.py
+++ b/tests/fpgadataflow/test_fpgadataflow_finnloop.py
@@ -543,6 +543,7 @@ def test_finnloop_end2end_mlo(
         verify_steps=verif_steps,
         verify_input_npy=tmp_output_dir + "/input.npy",
         verify_expected_output_npy=tmp_output_dir + "/expected_output.npy",
+        verify_save_full_context=True,  # Enable per-iteration context saving
         generate_outputs=[
             build_cfg.DataflowOutputType.ESTIMATE_REPORTS,
             build_cfg.DataflowOutputType.STITCHED_IP,
@@ -564,15 +565,39 @@ def test_finnloop_end2end_mlo(
     assert os.path.isfile(tmp_output_dir + "/stitched_ip/ip/component.xml")
 
     verif_dir = tmp_output_dir + "/verification_output"
+    # With verify_save_full_context=True, cppsim and node_by_node_rtlsim save as .npz
+    # stitched_ip_rtlsim with MLO uses rtlsim_pre_hook so it saves as .npy
     assert os.path.isfile(
-        verif_dir + "/verify_folded_hls_cppsim_0_SUCCESS.npy"
-    ), f"Check npy files in {verif_dir}"
+        verif_dir + "/verify_folded_hls_cppsim_0_SUCCESS.npz"
+    ), f"Check npz files in {verif_dir}"
     assert os.path.isfile(
-        verif_dir + "/verify_node_by_node_rtlsim_0_SUCCESS.npy"
-    ), f"Check npy files in {verif_dir}"
+        verif_dir + "/verify_node_by_node_rtlsim_0_SUCCESS.npz"
+    ), f"Check npz files in {verif_dir}"
     assert os.path.isfile(
         verif_dir + "/verify_stitched_ip_rtlsim_0_SUCCESS.npy"
     ), f"Check npy files in {verif_dir}"
+
+    # Verify that the per-iteration context file was created for FINNLoop
+    iteration_context_files = [
+        f for f in os.listdir(verif_dir) if f.startswith("iteration_context_")
+    ]
+    assert len(iteration_context_files) > 0, f"No iteration context files found in {verif_dir}"
+
+    # Load and verify the iteration context file has expected structure
+    ctx_file = os.path.join(verif_dir, iteration_context_files[0])
+    ctx_data = np.load(ctx_file)
+    iter_keys = [k for k in ctx_data.files if k.startswith("iter_")]
+    assert len(iter_keys) > 0, "No iteration keys found in context file"
+
+    # Verify we have contexts for all iterations
+    iter_indices = set()
+    for key in iter_keys:
+        parts = key.split("_", 2)
+        if len(parts) >= 2:
+            iter_indices.add(int(parts[1]))
+    assert (
+        len(iter_indices) == iteration
+    ), f"Expected {iteration} iterations in context, found {len(iter_indices)}"
 
     # also run dcp generation for a subset of the test parameters
     # this extends the test run time quite a lot


### PR DESCRIPTION
This PR adds per-iteration context saving for FINNLoop during **cppsim** verification, enabling debugging of MLO loops by exposing intermediate tensor values for each iteration.

- Added `iteration_context_path` node attribute to FINNLoop
- Modified execute_node to save per-iteration context to .npz when attribute is set
- Builder sets this attribute when `verify_save_full_context=True` for folded cppsim verification
- Extended test_finnloop_end2end_mlo to test the feature

Set `verify_save_full_context=True` in `DataflowBuildConfig`. Iteration contexts are saved to `verification_output/iteration_context_{node_name}_folded_hls_cppsim.npz` with keys like `iter_0_tensor_name`.

Note: This feature only works for cppsim mode. For rtlsim modes, the FINNLoop is a closed IP and intermediate tensors are not accessible.
