### PR TITLE
Fix HLS MVAU/VVAU threshold datatype minimization

### DIFF
--- a/src/finn/custom_op/fpgadataflow/hls/matrixvectoractivation_hls.py
+++ b/src/finn/custom_op/fpgadataflow/hls/matrixvectoractivation_hls.py
@@ -629,6 +629,61 @@ class MVAU_hls(MVAU, HLSBackend):
                 )
             )
 
+    def minimize_weight_bit_width(self, model):
+        """Minimize weight and threshold datatypes, with HLS-specific adjustments.
+
+        The HLS implementation uses the threshold datatype for comparisons.
+        When the threshold datatype is narrower than the accumulator datatype,
+        accumulator values get truncated, which can cause incorrect results.
+        To prevent this, ensure threshold datatype is at least as wide as
+        accumulator datatype."""
+        # First, call the base class implementation to minimize weight datatype
+        wdt = super().minimize_weight_bit_width(model)
+
+        # Minimize threshold datatype if node has thresholds (noActivation=0)
+        if self.get_nodeattr("noActivation") == 0 and len(self.onnx_node.input) > 2:
+            thresholds = model.get_initializer(self.onnx_node.input[2])
+            acc_dt = self.get_accumulator_datatype()
+
+            # Only minimize if accumulator and thresholds are integer
+            if (
+                acc_dt.is_integer()
+                and model.get_tensor_datatype(self.onnx_node.input[2]).is_integer()
+            ):
+                # Use double precision for intermediate calculations to prevent overflow
+                min_threshold = np.float64(thresholds.min())
+                max_threshold = np.float64(thresholds.max())
+                # Check if accumulator datatype is signed
+                acc_is_signed = acc_dt.signed()
+                if min_threshold < 0:
+                    if abs(min_threshold) > max_threshold:
+                        tdt = DataType.get_smallest_possible(min_threshold)
+                    else:
+                        tdt = DataType.get_smallest_possible(-max_threshold - 1)
+                else:
+                    # If accumulator is signed,
+                    # use signed threshold datatype even if thresholds are positive
+                    if acc_is_signed:
+                        tdt = DataType.get_smallest_possible(-max_threshold - 1)
+                    else:
+                        tdt = DataType.get_smallest_possible(max_threshold)
+
+                # HLS-specific: ensure threshold datatype is at least as wide as
+                # accumulator datatype to prevent truncation during comparison
+                if tdt.bitwidth() < acc_dt.bitwidth():
+                    tdt = acc_dt
+
+                # Verify thresholds can be expressed with the chosen type
+                threshold_tensor = self.get_hw_compatible_threshold_tensor(thresholds)
+                assert np.vectorize(tdt.allowed)(
+                    threshold_tensor
+                ).all(), "Thresholds can't be expressed with type %s" % str(tdt)
+
+                # Update threshold datatype
+                model.set_tensor_datatype(self.onnx_node.input[2], tdt)
+
+        return wdt
+
     def instantiate_ip(self, cmd):
         # instantiate the HLS IP
         vlnv = self.get_nodeattr("ip_vlnv")

--- a/src/finn/custom_op/fpgadataflow/hls/vectorvectoractivation_hls.py
+++ b/src/finn/custom_op/fpgadataflow/hls/vectorvectoractivation_hls.py
@@ -523,6 +523,61 @@ class VVAU_hls(VVAU, HLSBackend):
                 ("#pragma HLS ARRAY_PARTITION variable=threshs.m_thresholds " "complete dim=3")
             )
 
+    def minimize_weight_bit_width(self, model):
+        """Minimize weight and threshold datatypes, with HLS-specific adjustments.
+
+        The HLS implementation uses the threshold datatype for comparisons.
+        When the threshold datatype is narrower than the accumulator datatype,
+        accumulator values get truncated, which can cause incorrect results.
+        To prevent this, ensure threshold datatype is at least as wide as
+        accumulator datatype."""
+        # First, call the base class implementation to minimize weight datatype
+        wdt = super().minimize_weight_bit_width(model)
+
+        # Minimize threshold datatype if node has thresholds (noActivation=0)
+        if self.get_nodeattr("noActivation") == 0 and len(self.onnx_node.input) > 2:
+            thresholds = model.get_initializer(self.onnx_node.input[2])
+            acc_dt = self.get_accumulator_datatype()
+
+            # Only minimize if accumulator and thresholds are integer
+            if (
+                acc_dt.is_integer()
+                and model.get_tensor_datatype(self.onnx_node.input[2]).is_integer()
+            ):
+                # Use double precision for intermediate calculations to prevent overflow
+                min_threshold = np.float64(thresholds.min())
+                max_threshold = np.float64(thresholds.max())
+                # Check if accumulator datatype is signed
+                acc_is_signed = acc_dt.signed()
+                if min_threshold < 0:
+                    if abs(min_threshold) > max_threshold:
+                        tdt = DataType.get_smallest_possible(min_threshold)
+                    else:
+                        tdt = DataType.get_smallest_possible(-max_threshold - 1)
+                else:
+                    # If accumulator is signed,
+                    # use signed threshold datatype even if thresholds are positive
+                    if acc_is_signed:
+                        tdt = DataType.get_smallest_possible(-max_threshold - 1)
+                    else:
+                        tdt = DataType.get_smallest_possible(max_threshold)
+
+                # HLS-specific: ensure threshold datatype is at least as wide as
+                # accumulator datatype to prevent truncation during comparison
+                if tdt.bitwidth() < acc_dt.bitwidth():
+                    tdt = acc_dt
+
+                # Verify thresholds can be expressed with the chosen type
+                threshold_tensor = self.get_hw_compatible_threshold_tensor(thresholds)
+                assert np.vectorize(tdt.allowed)(
+                    threshold_tensor
+                ).all(), "Thresholds can't be expressed with type %s" % str(tdt)
+
+                # Update threshold datatype
+                model.set_tensor_datatype(self.onnx_node.input[2], tdt)
+
+        return wdt
+
     def instantiate_ip(self, cmd):
         # instantiate the HLS IP
         vlnv = self.get_nodeattr("ip_vlnv")

--- a/src/finn/custom_op/fpgadataflow/matrixvectoractivation.py
+++ b/src/finn/custom_op/fpgadataflow/matrixvectoractivation.py
@@ -524,8 +524,7 @@ class MVAU(HWCustomOp):
         return DataType[self.get_nodeattr("accDataType")]
 
     def minimize_weight_bit_width(self, model):
-        """Minimize the bit width based on the values of the weights and thresholds"""
-        # Minimize weight datatype
+        """Minimize the bit width based on the values of the weights."""
         if not (
             self.get_nodeattr("runtime_writeable_weights")
             or self.get_nodeattr("mem_mode") == "external"
@@ -543,35 +542,6 @@ class MVAU(HWCustomOp):
             else:
                 wdt = DataType.get_smallest_possible(w_max)
             self.set_nodeattr("weightDataType", wdt.name)
-
-        # Minimize threshold datatype if node has thresholds (noActivation=0)
-        if self.get_nodeattr("noActivation") == 0 and len(self.onnx_node.input) > 2:
-            thresholds = model.get_initializer(self.onnx_node.input[2])
-            acc_dt = DataType[self.get_nodeattr("accDataType")]
-            # Only minimize if accumulator and thresholds are integer
-            if (
-                acc_dt.is_integer()
-                and model.get_tensor_datatype(self.onnx_node.input[2]).is_integer()
-            ):
-                # Use double precision for intermediate calculations to prevent overflow
-                min_threshold = np.float64(thresholds.min())
-                max_threshold = np.float64(thresholds.max())
-                # Check if accumulator datatype is signed
-                acc_is_signed = acc_dt.signed()
-                if min_threshold < 0:
-                    if abs(min_threshold) > max_threshold:
-                        tdt = DataType.get_smallest_possible(min_threshold)
-                    else:
-                        tdt = DataType.get_smallest_possible(-max_threshold - 1)
-                else:
-                    # If accumulator is signed,
-                    # use signed threshold datatype even if thresholds are positive
-                    if acc_is_signed:
-                        tdt = DataType.get_smallest_possible(-max_threshold - 1)
-                    else:
-                        tdt = DataType.get_smallest_possible(max_threshold)
-                # Update threshold datatype
-                model.set_tensor_datatype(self.onnx_node.input[2], tdt)
 
         return DataType[self.get_nodeattr("weightDataType")]
 

--- a/src/finn/custom_op/fpgadataflow/vectorvectoractivation.py
+++ b/src/finn/custom_op/fpgadataflow/vectorvectoractivation.py
@@ -451,8 +451,7 @@ class VVAU(HWCustomOp):
         return DataType[self.get_nodeattr("accDataType")]
 
     def minimize_weight_bit_width(self, model):
-        """Minimize the bit width based on the values of the weights and thresholds"""
-        # Minimize weight datatype
+        """Minimize the bit width based on the values of the weights."""
         if not (
             self.get_nodeattr("runtime_writeable_weights")
             or self.get_nodeattr("mem_mode") == "external"
@@ -468,35 +467,6 @@ class VVAU(HWCustomOp):
             else:
                 wdt = DataType.get_smallest_possible(w_max)
             self.set_nodeattr("weightDataType", wdt.name)
-
-        # Minimize threshold datatype if node has thresholds (noActivation=0)
-        if self.get_nodeattr("noActivation") == 0 and len(self.onnx_node.input) > 2:
-            thresholds = model.get_initializer(self.onnx_node.input[2])
-            acc_dt = DataType[self.get_nodeattr("accDataType")]
-            # Only minimize if accumulator and thresholds are integer
-            if (
-                acc_dt.is_integer()
-                and model.get_tensor_datatype(self.onnx_node.input[2]).is_integer()
-            ):
-                # Use double precision for intermediate calculations to prevent overflow
-                min_threshold = np.float64(thresholds.min())
-                max_threshold = np.float64(thresholds.max())
-                # Check if accumulator datatype is signed
-                acc_is_signed = acc_dt.signed()
-                if min_threshold < 0:
-                    if abs(min_threshold) > max_threshold:
-                        tdt = DataType.get_smallest_possible(min_threshold)
-                    else:
-                        tdt = DataType.get_smallest_possible(-max_threshold - 1)
-                else:
-                    # If accumulator is signed,
-                    # use signed threshold datatype even if thresholds are positive
-                    if acc_is_signed:
-                        tdt = DataType.get_smallest_possible(-max_threshold - 1)
-                    else:
-                        tdt = DataType.get_smallest_possible(max_threshold)
-                # Update threshold datatype
-                model.set_tensor_datatype(self.onnx_node.input[2], tdt)
 
         return DataType[self.get_nodeattr("weightDataType")]
 

--- a/tests/fpgadataflow/test_fpgadataflow_mvau.py
+++ b/tests/fpgadataflow/test_fpgadataflow_mvau.py
@@ -67,6 +67,7 @@ from finn.transformation.fpgadataflow.set_exec_mode import SetExecMode
 from finn.transformation.fpgadataflow.set_fifo_depths import InsertAndSetFIFODepths
 from finn.transformation.fpgadataflow.specialize_layers import SpecializeLayers
 from finn.transformation.general import ApplyConfig
+from finn.transformation.streamline.round_thresholds import RoundAndClipThresholds
 from finn.util.basic import is_versal
 
 finnxsi = xsi if xsi.is_available() else None
@@ -967,3 +968,88 @@ def test_fpgadataflow_rtl_dynamic_mvau(mh, mw, n_vectors, pe, simd, idt_wdt, par
     assert (
         output_matmul == output_mvau_rtl_stitch
     ).all(), "Output of ONNX model not matching output of stitched-IP RTL model!"
+
+
+@pytest.mark.fpgadataflow
+@pytest.mark.vivado
+def test_fpgadataflow_mvau_hls_threshold_width_cppsim():
+    """
+    Test that threshold datatype is not minimized narrower than accumulator.
+
+    This tests the fix for a bug where HLS MVAU threshold comparisons could
+    produce incorrect results when thresholds were minimized to a narrower
+    datatype than the accumulator. The HLS implementation uses the threshold
+    datatype for comparisons, so if it's narrower than the accumulator,
+    accumulator values get truncated.
+
+    Setup:
+    - INT8 inputs/weights with mw=64 -> accumulator needs ~14 bits
+    - Small thresholds (INT8 range) that would be minimized to narrow type
+    - Extreme input values (min/max) to trigger full accumulator range
+
+    The test follows the builder flow:
+    MinimizeWeightBitWidth -> MinimizeAccumulatorWidth -> RoundAndClipThresholds
+    -> MinimizeWeightBitWidth
+    """
+    mw, mh = 64, 4
+    pe, simd = 2, 8
+    idt = DataType["INT8"]
+    wdt = DataType["INT8"]
+    odt = DataType["INT4"]
+    n_steps = odt.get_num_possible_values() - 1
+
+    # Generate random weights
+    W = gen_finn_dt_tensor(wdt, (mw, mh))
+
+    # Generate SMALL thresholds (INT8 range) - key to triggering the bug
+    # These will be minimized to a narrow type after RoundAndClipThresholds
+    T = gen_finn_dt_tensor(DataType["INT8"], (mh, n_steps)).astype(np.float32)
+    T = np.sort(T, axis=1)
+    tdt = DataType["INT32"]
+
+    model = make_single_fclayer_modelwrapper(W, pe, simd, wdt, idt, odt, T, tdt)
+
+    # Extreme inputs to trigger full accumulator range
+    # Max accumulator = 127 * 64 * max_weight ~ 8128 (needs ~14 bits)
+    # Min accumulator = -128 * 64 * max_weight ~ -8192
+    x_max = np.ones((1, mw), dtype=np.float32) * idt.max()
+    x_min = np.ones((1, mw), dtype=np.float32) * idt.min()
+
+    # Expected outputs using numpy reference
+    y_max_expected = multithreshold(np.matmul(x_max, W), T, 1, odt.min())
+    y_min_expected = multithreshold(np.matmul(x_min, W), T, 1, odt.min())
+
+    # Apply transformations
+    model = model.transform(GiveUniqueNodeNames())
+    for node in model.graph.node:
+        inst = getCustomOp(node)
+        inst.set_nodeattr("preferred_impl_style", "hls")
+        inst.set_nodeattr("mem_mode", "internal_embedded")
+
+    model = model.transform(SpecializeLayers("xczu7ev-ffvc1156-2-e"))
+    model = model.transform(GiveUniqueNodeNames())
+
+    # Full builder flow for bit width minimization
+    model = model.transform(MinimizeWeightBitWidth())
+    model = model.transform(MinimizeAccumulatorWidth())
+    model = model.transform(InferDataTypes())
+    model = model.transform(RoundAndClipThresholds())
+    model = model.transform(InferDataTypes())
+    model = model.transform(MinimizeWeightBitWidth())
+    model = model.transform(InferDataTypes())
+
+    # Run cppsim
+    model = model.transform(SetExecMode("cppsim"))
+    model = model.transform(PrepareCppSim())
+    model = model.transform(CompileCppSim())
+
+    # Verify results with extreme inputs
+    y_max_produced = oxe.execute_onnx(model, {"inp": x_max})["outp"]
+    y_min_produced = oxe.execute_onnx(model, {"inp": x_min})["outp"]
+
+    assert np.allclose(
+        y_max_produced, y_max_expected
+    ), f"Max input test failed: expected {y_max_expected}, got {y_max_produced}"
+    assert np.allclose(
+        y_min_produced, y_min_expected
+    ), f"Min input test failed: expected {y_min_expected}, got {y_min_produced}"


### PR DESCRIPTION
This PR fixes a bug where the threshold datatype could be minimized narrower than the accumulator datatype in HLS MVAU and VVAU, causing incorrect results when accumulator values exceed the threshold type's range.

The HLS implementation uses the threshold datatype for comparisons. When `MinimizeWeightBitWidth()` reduced threshold dtype to a narrower type than the accumulator (e.g., INT8 thresholds vs INT14 accumulator), accumulator values were truncated during comparison, producing wrong outputs.

Changes
- `matrixvectoractivation.py` / `vectorvectoractivation.py`: Removed threshold minimization logic from base classes (RTL variants don't support embedded thresholds)
- `matrixvectoractivation_hls.py` / `vectorvectoractivation_hls.py`: Added `minimize_weight_bit_width(`) override that:
- Minimizes threshold dtype based on actual values
- Ensures threshold bitwidth ≥ accumulator bitwidth to prevent truncation
- `test_fpgadataflow_mvau.py`: Added test case with small thresholds and extreme inputs to verify the fix
