### PR TITLE
Fix HLS Requant for 2024.2

### DIFF
--- a/src/finn/custom_op/fpgadataflow/hls/requant_hls.py
+++ b/src/finn/custom_op/fpgadataflow/hls/requant_hls.py
@@ -181,7 +181,7 @@ static inline T clip(T const x, TLo const lo, THi const hi) {
                     float scaled = {compute_expr};
 
                     // Round to nearest integer and clip
-                    int rounded = clip((int)hls::round(scaled), MIN_VAL, MAX_VAL);
+                    int rounded = clip((int)hls::lrint(scaled), MIN_VAL, MAX_VAL);
 
                     // Store output
                     out_buf[p] = TO(rounded);


### PR DESCRIPTION
- Change the HLS round function to achieve II=1 across versions