### PR TITLE
Add xsim DSP conflict detection and NaN safeguards for rtlsim

### DIFF
--- a/finn_xsi/finn_xsi/adapter.py
+++ b/finn_xsi/finn_xsi/adapter.py
@@ -45,9 +45,12 @@ def compile_sim_obj(top_module_name, source_list, sim_out_dir, debug=False, beha
         }
         verilog_header_incl_str = " ".join(["--include " + x for x in verilog_headers])
 
-        # sort src list so that configs are loaded first
-        pattern = "swg_pkg"
-        srcs_list = sorted(source_list, key=lambda s: (pattern not in s, s))
+        # sort src list so that packages are loaded first
+        # these packages must be compiled before modules that depend on them
+        pkg_patterns = ["swg_pkg", "mvu_pkg"]
+        srcs_list = sorted(
+            source_list, key=lambda s: (not any(pkg in s for pkg in pkg_patterns), s)
+        )
         for src_line in srcs_list:
             if src_line.endswith(".v"):
                 f.write(f"verilog work {verilog_header_incl_str} {src_line}\n")

--- a/src/finn/builder/build_dataflow_steps.py
+++ b/src/finn/builder/build_dataflow_steps.py
@@ -131,6 +131,7 @@ from finn.util.config import (
     extract_model_config_consolidate_shuffles,
     extract_model_config_to_json,
 )
+from finn.util.fpgadataflow import warn_hls_rtl_dsp_conflict
 from finn.util.mlo_sim import is_mlo, mlo_prehook_func_factory
 from finn.util.test import execute_parent
 
@@ -854,18 +855,35 @@ def step_hw_ipgen(model: ModelWrapper, cfg: DataflowBuildConfig):
             json.dump(estimate_layer_resources_hls, f, indent=2)
 
     if VerificationStepType.NODE_BY_NODE_RTLSIM in cfg._resolve_verification_steps():
-        if cfg.verify_save_rtlsim_waveforms:
+        # Check for HLS+RTL DSP conflict - only skip for MLO models
+        # (unrolled graphs work fine for node-by-node rtlsim)
+        skip_verification = False
+        if is_mlo(model):
             verify_out_dir = cfg.output_dir + "/verification_output"
-            waveform_dir = verify_out_dir + "/node_by_node_rtlsim_waveforms"
-            os.makedirs(waveform_dir, exist_ok=True)
-            abspath = os.path.abspath(waveform_dir)
-            # Set rtlsim_trace on each node BEFORE PrepareRTLSim so compilation uses debug=True
-            for node in model.graph.node:
-                node_inst = getCustomOp(node)
-                node_inst.set_nodeattr("rtlsim_trace", f"{abspath}/{node.name}_rtlsim.wdb")
-        model = model.transform(PrepareRTLSim())
-        model = model.transform(SetExecMode("rtlsim"))
-        verify_step(model, cfg, "node_by_node_rtlsim", need_parent=True)
+            os.makedirs(verify_out_dir, exist_ok=True)
+            skip_verification = warn_hls_rtl_dsp_conflict(
+                model, "node_by_node_rtlsim", verify_out_dir
+            )
+            if skip_verification:
+                print(
+                    "NOTE: This model contains a FINNLoop which is treated as a closed IP "
+                    "during node-by-node rtlsim. The conflicting ops are inside the loop "
+                    "body and cannot be simulated individually."
+                )
+
+        if not skip_verification:
+            if cfg.verify_save_rtlsim_waveforms:
+                verify_out_dir = cfg.output_dir + "/verification_output"
+                waveform_dir = verify_out_dir + "/node_by_node_rtlsim_waveforms"
+                os.makedirs(waveform_dir, exist_ok=True)
+                abspath = os.path.abspath(waveform_dir)
+                # Set rtlsim_trace on each node BEFORE PrepareRTLSim so compilation uses debug=True
+                for node in model.graph.node:
+                    node_inst = getCustomOp(node)
+                    node_inst.set_nodeattr("rtlsim_trace", f"{abspath}/{node.name}_rtlsim.wdb")
+            model = model.transform(PrepareRTLSim())
+            model = model.transform(SetExecMode("rtlsim"))
+            verify_step(model, cfg, "node_by_node_rtlsim", need_parent=True)
     return model
 
 
@@ -1029,28 +1047,34 @@ def step_create_stitched_ip(model: ModelWrapper, cfg: DataflowBuildConfig):
             skipping step_create_stitched_ip."""
         )
     if VerificationStepType.STITCHED_IP_RTLSIM in cfg._resolve_verification_steps():
-        # prepare ip-stitched rtlsim
-        verify_model = deepcopy(model)
-        verify_model = prepare_for_stitched_ip_rtlsim(verify_model, cfg)
-        # use critical path estimate to set rtlsim liveness threshold
-        # (very conservative)
-        verify_model = verify_model.transform(AnnotateCycles())
-        estimate_network_performance = verify_model.analysis(dataflow_performance)
-        prev_liveness = get_liveness_threshold_cycles()
-        os.environ["LIVENESS_THRESHOLD"] = str(
-            int(estimate_network_performance["critical_path_cycles"] * 1.1 + 50)
-        )
-        if cfg.verify_save_rtlsim_waveforms:
-            verify_out_dir = cfg.output_dir + "/verification_output"
-            waveform_dir = verify_out_dir + "/stitched_ip_rtlsim_waveforms"
-            os.makedirs(waveform_dir, exist_ok=True)
-            abspath = os.path.abspath(waveform_dir)
-            verify_model.set_metadata_prop("rtlsim_trace", abspath + "/verify_rtlsim.wdb")
-        if is_mlo(model):
-            verify_mlo(verify_model, cfg, "stitched_ip_rtlsim")
-        else:
-            verify_step(verify_model, cfg, "stitched_ip_rtlsim", need_parent=True)
-        os.environ["LIVENESS_THRESHOLD"] = str(prev_liveness)
+        # Check for HLS+RTL DSP conflict before rtlsim
+        # (affects both MLO and unrolled graphs for stitched IP rtlsim)
+        verify_out_dir = cfg.output_dir + "/verification_output"
+        os.makedirs(verify_out_dir, exist_ok=True)
+        if not warn_hls_rtl_dsp_conflict(model, "stitched_ip_rtlsim", verify_out_dir):
+            # No conflict - proceed with verification
+            # prepare ip-stitched rtlsim
+            verify_model = deepcopy(model)
+            verify_model = prepare_for_stitched_ip_rtlsim(verify_model, cfg)
+            # use critical path estimate to set rtlsim liveness threshold
+            # (very conservative)
+            verify_model = verify_model.transform(AnnotateCycles())
+            estimate_network_performance = verify_model.analysis(dataflow_performance)
+            prev_liveness = get_liveness_threshold_cycles()
+            os.environ["LIVENESS_THRESHOLD"] = str(
+                int(estimate_network_performance["critical_path_cycles"] * 1.1 + 50)
+            )
+            if cfg.verify_save_rtlsim_waveforms:
+                verify_out_dir = cfg.output_dir + "/verification_output"
+                waveform_dir = verify_out_dir + "/stitched_ip_rtlsim_waveforms"
+                os.makedirs(waveform_dir, exist_ok=True)
+                abspath = os.path.abspath(waveform_dir)
+                verify_model.set_metadata_prop("rtlsim_trace", abspath + "/verify_rtlsim.wdb")
+            if is_mlo(model):
+                verify_mlo(verify_model, cfg, "stitched_ip_rtlsim")
+            else:
+                verify_step(verify_model, cfg, "stitched_ip_rtlsim", need_parent=True)
+            os.environ["LIVENESS_THRESHOLD"] = str(prev_liveness)
     return model
 
 

--- a/src/finn/util/data_packing.py
+++ b/src/finn/util/data_packing.py
@@ -299,6 +299,11 @@ def npy_to_rtlsim_input(input_file, input_dtype, pad_to_nbits, reverse_inner=Tru
         inp = np.load(input_file)
     else:
         raise Exception("input_file must be ndarray or filename for .npy")
+
+    # Check for NaN/Inf before packing for rtlsim
+    assert not np.isnan(inp).any(), "NaN values detected in rtlsim input"
+    assert not np.isinf(inp).any(), "Inf values detected in rtlsim input"
+
     if (
         inp.shape[-1] == 1
         and input_dtype.is_integer()
@@ -330,6 +335,11 @@ def rtlsim_output_to_npy(output, path, dtype, shape, packedBits, targetBits, rev
     )
     # make copy before saving the array
     out_array = out_array.copy()
+
+    # Check for NaN/Inf after unpacking rtlsim output
+    assert not np.isnan(out_array).any(), "NaN values detected in rtlsim output"
+    assert not np.isinf(out_array).any(), "Inf values detected in rtlsim output"
+
     if path is not None:
         np.save(path, out_array)
     return out_array

--- a/src/finn/util/fpgadataflow.py
+++ b/src/finn/util/fpgadataflow.py
@@ -28,6 +28,7 @@
 
 import os
 import warnings
+from qonnx.core.datatype import DataType
 from qonnx.custom_op.registry import getCustomOp, is_custom_op
 from qonnx.util.basic import get_by_name
 
@@ -76,11 +77,14 @@ def is_rtl_node(node):
 
 def detect_hls_rtl_dsp_conflict(model, check_subgraphs=True):
     """
-    Detect if model contains both HLS Elementwise ops and RTL ops using DSPFP32.
+    Detect if model contains both floating-point HLS Elementwise ops and RTL ops using DSPFP32.
 
     This combination causes incorrect simulation results in xsim due to DSP
     primitive initialization conflicts. The hardware is correct - only
     simulation is affected.
+
+    Note: Only HLS Elementwise ops using floating-point datatypes are flagged,
+    as integer-only HLS Elementwise ops don't use DSP primitives.
 
     Args:
         model: ModelWrapper to check
@@ -89,10 +93,9 @@ def detect_hls_rtl_dsp_conflict(model, check_subgraphs=True):
     Returns:
         Tuple of (has_conflict, hls_elementwise_ops, rtl_dsp_ops)
         - has_conflict: bool, True if both types of ops are present
-        - hls_elementwise_ops: list of HLS Elementwise node names
+        - hls_elementwise_ops: list of floating-point HLS Elementwise node names
         - rtl_dsp_ops: list of RTL DSP node names (LayerNorm_rtl, Elementwise*_rtl)
     """
-
     # RTL ops that use DSPFP32 primitive (via binopf.sv)
     RTL_DSP_OPS = {
         "LayerNorm_rtl",
@@ -110,9 +113,23 @@ def detect_hls_rtl_dsp_conflict(model, check_subgraphs=True):
         for node in nodes:
             full_name = f"{prefix}{node.name}" if prefix else node.name
 
-            # Check for HLS Elementwise ops
+            # Check for HLS Elementwise ops with floating-point datatypes
             if node.op_type.startswith("Elementwise") and node.domain == HLS_DOMAIN:
-                hls_elementwise_ops.append(full_name)
+                try:
+                    node_inst = getCustomOp(node)
+                    # Check if any of the datatypes are floating-point
+                    lhs_dtype = DataType[node_inst.get_nodeattr("lhs_dtype")]
+                    rhs_dtype = DataType[node_inst.get_nodeattr("rhs_dtype")]
+                    out_dtype = DataType[node_inst.get_nodeattr("out_dtype")]
+                    if (
+                        lhs_dtype.get_canonical_name().startswith("FLOAT")
+                        or rhs_dtype.get_canonical_name().startswith("FLOAT")
+                        or out_dtype.get_canonical_name().startswith("FLOAT")
+                    ):
+                        hls_elementwise_ops.append(full_name)
+                except (KeyError, AttributeError):
+                    # If we can't check datatypes, assume it could be floating-point
+                    hls_elementwise_ops.append(full_name)
 
             # Check for RTL ops using DSPFP32
             if node.op_type in RTL_DSP_OPS:

--- a/src/finn/util/fpgadataflow.py
+++ b/src/finn/util/fpgadataflow.py
@@ -26,7 +26,9 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from qonnx.custom_op.registry import is_custom_op
+import os
+import warnings
+from qonnx.custom_op.registry import getCustomOp, is_custom_op
 from qonnx.util.basic import get_by_name
 
 
@@ -70,3 +72,113 @@ def is_rtl_node(node):
                     is_node = True
 
     return is_node
+
+
+def detect_hls_rtl_dsp_conflict(model, check_subgraphs=True):
+    """
+    Detect if model contains both HLS Elementwise ops and RTL ops using DSPFP32.
+
+    This combination causes incorrect simulation results in xsim due to DSP
+    primitive initialization conflicts. The hardware is correct - only
+    simulation is affected.
+
+    Args:
+        model: ModelWrapper to check
+        check_subgraphs: If True, also check inside FINNLoop bodies
+
+    Returns:
+        Tuple of (has_conflict, hls_elementwise_ops, rtl_dsp_ops)
+        - has_conflict: bool, True if both types of ops are present
+        - hls_elementwise_ops: list of HLS Elementwise node names
+        - rtl_dsp_ops: list of RTL DSP node names (LayerNorm_rtl, Elementwise*_rtl)
+    """
+
+    # RTL ops that use DSPFP32 primitive (via binopf.sv)
+    RTL_DSP_OPS = {
+        "LayerNorm_rtl",
+        "ElementwiseAdd_rtl",
+        "ElementwiseSub_rtl",
+        "ElementwiseMul_rtl",
+    }
+
+    HLS_DOMAIN = "finn.custom_op.fpgadataflow.hls"
+
+    hls_elementwise_ops = []
+    rtl_dsp_ops = []
+
+    def check_nodes(nodes, prefix=""):
+        for node in nodes:
+            full_name = f"{prefix}{node.name}" if prefix else node.name
+
+            # Check for HLS Elementwise ops
+            if node.op_type.startswith("Elementwise") and node.domain == HLS_DOMAIN:
+                hls_elementwise_ops.append(full_name)
+
+            # Check for RTL ops using DSPFP32
+            if node.op_type in RTL_DSP_OPS:
+                rtl_dsp_ops.append(full_name)
+
+            # Check inside FINNLoop bodies
+            if check_subgraphs and node.op_type == "FINNLoop":
+                try:
+                    loop_inst = getCustomOp(node)
+                    loop_body = loop_inst.get_nodeattr("body")
+                    check_nodes(loop_body.graph.node, prefix=f"{full_name}/")
+                except (KeyError, AttributeError):
+                    pass
+
+    check_nodes(model.graph.node)
+
+    has_conflict = len(hls_elementwise_ops) > 0 and len(rtl_dsp_ops) > 0
+    return has_conflict, hls_elementwise_ops, rtl_dsp_ops
+
+
+def warn_hls_rtl_dsp_conflict(model, verification_type, output_dir=None):
+    """
+    Check for HLS+RTL DSP conflict and issue warning if detected.
+
+    This is used to warn users before running rtlsim verification when the
+    model contains both HLS Elementwise ops and RTL ops that use DSPFP32.
+    This combination causes incorrect simulation results in xsim due to
+    conflicting DSP primitive initializations.
+
+    Args:
+        model: ModelWrapper to check
+        verification_type: String describing the verification type
+        output_dir: Directory where verification outputs would be saved (optional)
+                    If provided, writes warning to a .txt file there
+
+    Returns:
+        bool: True if conflict was detected (and verification should be skipped)
+    """
+    has_conflict, hls_ops, rtl_ops = detect_hls_rtl_dsp_conflict(model)
+
+    if has_conflict:
+        warning_msg = (
+            f"\n{'='*70}\n"
+            f"HLS+RTL DSP CONFLICT DETECTED - SKIPPING {verification_type.upper()}\n"
+            f"{'='*70}\n"
+            f"The model contains both HLS Elementwise ops and RTL ops using DSPFP32.\n"
+            f"This causes INCORRECT simulation results in xsim.\n"
+            f"\n"
+            f"HLS Elementwise ops: {hls_ops}\n"
+            f"RTL DSP ops (DSPFP32): {rtl_ops}\n"
+            f"\n"
+            f"The HARDWARE implementation is CORRECT - only xsim is affected.\n"
+            f"Skipping {verification_type} verification.\n"
+            f"{'='*70}\n"
+        )
+
+        warnings.warn(warning_msg, UserWarning)
+
+        # Also save warning to file in output directory
+        if output_dir is not None:
+            log_file = os.path.join(output_dir, f"{verification_type}_SKIPPED_DSP_CONFLICT.txt")
+            try:
+                with open(log_file, "w") as f:
+                    f.write(warning_msg)
+            except (IOError, OSError):
+                pass  # Don't fail if we can't write the log file
+
+        return True
+    return False

--- a/tests/fpgadataflow/test_fpgadataflow_layernorm.py
+++ b/tests/fpgadataflow/test_fpgadataflow_layernorm.py
@@ -13,6 +13,8 @@
 import pytest
 
 import numpy as np
+import os
+import warnings
 from onnx import TensorProto, helper
 from qonnx.core.datatype import DataType
 from qonnx.core.modelwrapper import ModelWrapper
@@ -23,6 +25,8 @@ from qonnx.transformation.infer_shapes import InferShapes
 from qonnx.transformation.merge_onnx_models import MergeONNXModels
 from qonnx.util.basic import gen_finn_dt_tensor, qonnx_make_model
 
+import finn.builder.build_dataflow as build
+import finn.builder.build_dataflow_config as build_cfg
 import finn.core.onnx_exec as oxe
 import finn.transformation.fpgadataflow.convert_to_hw_layers as to_hw
 from finn.analysis.fpgadataflow.exp_cycles_per_layer import exp_cycles_per_layer
@@ -39,6 +43,7 @@ from finn.transformation.fpgadataflow.set_exec_mode import SetExecMode
 from finn.transformation.fpgadataflow.set_fifo_depths import InsertAndSetFIFODepths
 from finn.transformation.fpgadataflow.specialize_layers import SpecializeLayers
 from finn.transformation.streamline.extract_norm_scale_bias import ExtractNormScaleBias
+from finn.util.basic import make_build_dir
 
 test_fpga_part = "xcvc1902-vsva2197-2MP-e-S"
 target_clk_ns = 5
@@ -324,3 +329,220 @@ def test_extract_norm_scale_bias(idt, ishape, has_scale, has_bias):
 
     y_out = oxe.execute_onnx(model, input_t)[model.graph.output[0].name]
     assert (y_ref == y_out).all()
+
+
+def create_mul_layernorm_model(idt, ishape, mul_param_shape):
+    """
+    Create a model: INT8 input -> Mul (FLOAT32 param) -> LayerNorm (scale, bias).
+
+    This model triggers the HLS+RTL DSP conflict when specialized:
+    - Mul with INT8 input and FLOAT32 param -> ElementwiseMul_hls (uses DSP for multiplication)
+    - LayerNorm with FLOAT32 -> LayerNorm_rtl (uses DSPFP32)
+    """
+    inp = helper.make_tensor_value_info("inp", TensorProto.FLOAT, ishape)
+    outp = helper.make_tensor_value_info("outp", TensorProto.FLOAT, ishape)
+    mul_param = helper.make_tensor_value_info("mul_param", TensorProto.FLOAT, mul_param_shape)
+    scale = helper.make_tensor_value_info("scale", TensorProto.FLOAT, [ishape[-1]])
+    bias = helper.make_tensor_value_info("bias", TensorProto.FLOAT, [ishape[-1]])
+
+    # Mul node: INT8 input * FLOAT32 param -> FLOAT32 output
+    mul_node = helper.make_node(
+        "Mul",
+        inputs=["inp", "mul_param"],
+        outputs=["mul_out"],
+        name="Mul_0",
+    )
+
+    # LayerNorm node with scale and bias
+    ln_node = helper.make_node(
+        "LayerNormalization",
+        inputs=["mul_out", "scale", "bias"],
+        outputs=["outp"],
+        name="LayerNorm_0",
+        epsilon=1e-5,
+        axis=-1,
+        stash_type=1,
+    )
+
+    # Intermediate value info
+    mul_out_vi = helper.make_tensor_value_info("mul_out", TensorProto.FLOAT, ishape)
+
+    graph = helper.make_graph(
+        nodes=[mul_node, ln_node],
+        name="mul_layernorm_graph",
+        inputs=[inp, mul_param, scale, bias],
+        outputs=[outp],
+        value_info=[mul_out_vi],
+    )
+    model = qonnx_make_model(graph, producer_name="mul_layernorm_test")
+    model = ModelWrapper(model)
+
+    # Set initializers
+    mul_param_data = gen_finn_dt_tensor(DataType["FLOAT32"], mul_param_shape)
+    scale_data = gen_finn_dt_tensor(DataType["FLOAT32"], [ishape[-1]])
+    bias_data = gen_finn_dt_tensor(DataType["FLOAT32"], [ishape[-1]])
+
+    model.set_initializer("mul_param", mul_param_data)
+    model.set_initializer("scale", scale_data)
+    model.set_initializer("bias", bias_data)
+
+    # Set tensor datatypes
+    model.set_tensor_datatype("inp", idt)
+    model.set_tensor_datatype("mul_param", DataType["FLOAT32"])
+    model.set_tensor_datatype("mul_out", DataType["FLOAT32"])
+    model.set_tensor_datatype("scale", DataType["FLOAT32"])
+    model.set_tensor_datatype("bias", DataType["FLOAT32"])
+    model.set_tensor_datatype("outp", DataType["FLOAT32"])
+
+    return model
+
+
+@pytest.mark.fpgadataflow
+@pytest.mark.vivado
+@pytest.mark.slow
+def test_hls_rtl_dsp_conflict_detection():
+    """
+    Test that HLS+RTL DSP conflict is detected and verification is skipped.
+
+    This test creates a model with:
+    - INT8 input -> Mul (FLOAT32 param) -> ElementwiseMul_hls (uses DSP)
+    - LayerNorm with scale/bias -> LayerNorm_rtl (uses DSPFP32)
+
+    When running stitched_ip_rtlsim verification, the DSP conflict should be
+    detected and verification skipped with a warning. The hardware is correct,
+    only xsim simulation produces incorrect results due to DSP initialization
+    conflicts.
+    """
+    ishape = [1, 32]
+    mul_param_shape = [ishape[-1]]
+    idt = DataType["INT8"]
+
+    # Create model
+    model = create_mul_layernorm_model(idt, ishape, mul_param_shape)
+
+    # Generate reference input/output
+    input_data = gen_finn_dt_tensor(idt, ishape)
+    input_t = {"inp": input_data}
+
+    y_ref = oxe.execute_onnx(model, input_t)["outp"]
+
+    # Apply transformations
+    model = model.transform(InferShapes())
+    model = model.transform(InferDataTypes())
+
+    # Extract scale/bias from LayerNorm
+    model = model.transform(ExtractNormScaleBias())
+
+    # Convert to HW layers
+    model = model.transform(to_hw.InferLayerNorm())
+    model = model.transform(to_hw.InferElementwiseBinaryOperation())
+
+    # Verify transformation worked
+    input_t = {"inp": input_data}
+    y_hw = oxe.execute_onnx(model, input_t)["outp"]
+    assert np.allclose(y_ref, y_hw, rtol=1e-3, atol=2**-4), "HW transformation changed output"
+
+    # Specialize layers - this will create:
+    # - ElementwiseMul_hls (INT8 input doesn't qualify for RTL, needs FLOAT32)
+    # - LayerNorm_rtl (FLOAT32 input qualifies for RTL)
+    # - ElementwiseMul_rtl and ElementwiseAdd_rtl for scale/bias
+    model = model.transform(SpecializeLayers(test_fpga_part))
+    model = model.transform(GiveUniqueNodeNames())
+
+    # Check that we have the conflict-causing combination
+    hls_elementwise_ops = [
+        n.name
+        for n in model.graph.node
+        if n.op_type.startswith("Elementwise") and n.domain == "finn.custom_op.fpgadataflow.hls"
+    ]
+    rtl_dsp_ops = [
+        n.name
+        for n in model.graph.node
+        if n.op_type
+        in ["LayerNorm_rtl", "ElementwiseAdd_rtl", "ElementwiseSub_rtl", "ElementwiseMul_rtl"]
+    ]
+
+    assert len(hls_elementwise_ops) > 0, "Expected at least one HLS Elementwise op"
+    assert len(rtl_dsp_ops) > 0, "Expected at least one RTL DSP op"
+
+    # Setup build directory
+    tmp_output_dir = make_build_dir("build_dsp_conflict_test_")
+
+    np.save(tmp_output_dir + "/input.npy", input_data)
+    np.save(tmp_output_dir + "/expected_output.npy", y_ref)
+    model.save(tmp_output_dir + "/model.onnx")
+
+    # Build steps - convert to HW through IP stitching
+    steps = [
+        "step_create_dataflow_partition",
+        "step_target_fps_parallelization",
+        "step_apply_folding_config",
+        "step_minimize_bit_width",
+        "step_generate_estimate_reports",
+        "step_hw_codegen",
+        "step_hw_ipgen",
+        "step_set_fifo_depths",
+        "step_create_stitched_ip",
+    ]
+
+    # Request verification steps that will trigger DSP conflict detection
+    verif_steps = [
+        "folded_hls_cppsim",
+        "node_by_node_rtlsim",
+        "stitched_ip_rtlsim",
+    ]
+
+    cfg = build_cfg.DataflowBuildConfig(
+        output_dir=tmp_output_dir,
+        steps=steps,
+        target_fps=1000,
+        synth_clk_period_ns=target_clk_ns,
+        board="V80",
+        verify_steps=verif_steps,
+        verify_input_npy=tmp_output_dir + "/input.npy",
+        verify_expected_output_npy=tmp_output_dir + "/expected_output.npy",
+        generate_outputs=[
+            build_cfg.DataflowOutputType.ESTIMATE_REPORTS,
+            build_cfg.DataflowOutputType.STITCHED_IP,
+        ],
+    )
+
+    # Capture warnings during build
+    with warnings.catch_warnings(record=True) as caught_warnings:
+        warnings.simplefilter("always")
+        build.build_dataflow_cfg(tmp_output_dir + "/model.onnx", cfg)
+
+    # Check that DSP conflict warning was issued
+    dsp_conflict_warnings = [
+        w for w in caught_warnings if "HLS+RTL DSP CONFLICT DETECTED" in str(w.message)
+    ]
+    assert len(dsp_conflict_warnings) > 0, (
+        "Expected DSP conflict warning to be issued. "
+        f"Found warnings: {[str(w.message)[:100] for w in caught_warnings]}"
+    )
+
+    # Verify cppsim still passed (not affected by DSP conflict)
+    verif_dir = tmp_output_dir + "/verification_output"
+
+    # Check that the warning log file was created in the verification folder
+    stitched_conflict_file = os.path.join(verif_dir, "stitched_ip_rtlsim_SKIPPED_DSP_CONFLICT.txt")
+    assert os.path.isfile(
+        stitched_conflict_file
+    ), f"Expected DSP conflict log file at {stitched_conflict_file}"
+    cppsim_success = os.path.join(verif_dir, "verify_folded_hls_cppsim_0_SUCCESS.npy")
+    assert os.path.isfile(
+        cppsim_success
+    ), f"cppsim verification should have passed - check {verif_dir}"
+
+    # Verify cppsim still passed (not affected by DSP conflict)
+    verif_dir = tmp_output_dir + "/verification_output"
+    rtlsim_success = os.path.join(verif_dir, "verify_node_by_node_rtlsim_0_SUCCESS.npy")
+    assert os.path.isfile(
+        rtlsim_success
+    ), f"node_by_node_rtlsim verification should have passed - check {verif_dir}"
+
+    # Verify that stitched_ip_rtlsim was skipped (no SUCCESS file)
+    stitched_success = os.path.join(verif_dir, "verify_stitched_ip_rtlsim_0_SUCCESS.npy")
+    assert not os.path.isfile(
+        stitched_success
+    ), "stitched_ip_rtlsim should have been skipped due to DSP conflict"

--- a/tests/fpgadataflow/test_fpgadataflow_layernorm.py
+++ b/tests/fpgadataflow/test_fpgadataflow_layernorm.py
@@ -534,8 +534,6 @@ def create_layernorm_threshold_mul_model(ishape):
     but the HLS Elementwise uses integer datatypes (after quantization via
     MultiThreshold), so it should NOT trigger the DSP conflict detection.
     """
-    from qonnx.util.basic import qonnx_make_model
-
     num_channels = ishape[-1]
 
     inp = helper.make_tensor_value_info("inp", TensorProto.FLOAT, ishape)

--- a/tests/fpgadataflow/test_fpgadataflow_layernorm.py
+++ b/tests/fpgadataflow/test_fpgadataflow_layernorm.py
@@ -12,6 +12,7 @@
 
 import pytest
 
+import json
 import numpy as np
 import os
 import warnings
@@ -437,6 +438,16 @@ def test_hls_rtl_dsp_conflict_detection():
     np.save(tmp_output_dir + "/expected_output.npy", y_ref)
     model.save(tmp_output_dir + "/model.onnx")
 
+    # Create specialize_layers config to force the first Mul to use HLS implementation.
+    # This future-proofs the test for when RTL gets int+float->float support.
+    specialize_config = {
+        "Defaults": {},
+        "ElementwiseMul_0": {"preferred_impl_style": "hls"},
+    }
+    specialize_config_file = tmp_output_dir + "/specialize_layers_config.json"
+    with open(specialize_config_file, "w") as f:
+        json.dump(specialize_config, f)
+
     # Build steps - includes conversion to HW layers and specialization
     steps = [
         "step_convert_to_hw",
@@ -465,6 +476,7 @@ def test_hls_rtl_dsp_conflict_detection():
         target_fps=1000,
         synth_clk_period_ns=target_clk_ns,
         board="V80",
+        specialize_layers_config_file=specialize_config_file,
         verify_steps=verif_steps,
         verify_input_npy=tmp_output_dir + "/input.npy",
         verify_expected_output_npy=tmp_output_dir + "/expected_output.npy",

--- a/tests/fpgadataflow/test_fpgadataflow_layernorm.py
+++ b/tests/fpgadataflow/test_fpgadataflow_layernorm.py
@@ -417,53 +417,18 @@ def test_hls_rtl_dsp_conflict_detection():
     mul_param_shape = [ishape[-1]]
     idt = DataType["INT8"]
 
-    # Create model
+    # Create model and prepare for build
     model = create_mul_layernorm_model(idt, ishape, mul_param_shape)
 
     # Generate reference input/output
     input_data = gen_finn_dt_tensor(idt, ishape)
     input_t = {"inp": input_data}
-
     y_ref = oxe.execute_onnx(model, input_t)["outp"]
 
-    # Apply transformations
+    # Apply minimal transformations - build flow handles the rest
     model = model.transform(InferShapes())
     model = model.transform(InferDataTypes())
-
-    # Extract scale/bias from LayerNorm
     model = model.transform(ExtractNormScaleBias())
-
-    # Convert to HW layers
-    model = model.transform(to_hw.InferLayerNorm())
-    model = model.transform(to_hw.InferElementwiseBinaryOperation())
-
-    # Verify transformation worked
-    input_t = {"inp": input_data}
-    y_hw = oxe.execute_onnx(model, input_t)["outp"]
-    assert np.allclose(y_ref, y_hw, rtol=1e-3, atol=2**-4), "HW transformation changed output"
-
-    # Specialize layers - this will create:
-    # - ElementwiseMul_hls (INT8 input doesn't qualify for RTL, needs FLOAT32)
-    # - LayerNorm_rtl (FLOAT32 input qualifies for RTL)
-    # - ElementwiseMul_rtl and ElementwiseAdd_rtl for scale/bias
-    model = model.transform(SpecializeLayers(test_fpga_part))
-    model = model.transform(GiveUniqueNodeNames())
-
-    # Check that we have the conflict-causing combination
-    hls_elementwise_ops = [
-        n.name
-        for n in model.graph.node
-        if n.op_type.startswith("Elementwise") and n.domain == "finn.custom_op.fpgadataflow.hls"
-    ]
-    rtl_dsp_ops = [
-        n.name
-        for n in model.graph.node
-        if n.op_type
-        in ["LayerNorm_rtl", "ElementwiseAdd_rtl", "ElementwiseSub_rtl", "ElementwiseMul_rtl"]
-    ]
-
-    assert len(hls_elementwise_ops) > 0, "Expected at least one HLS Elementwise op"
-    assert len(rtl_dsp_ops) > 0, "Expected at least one RTL DSP op"
 
     # Setup build directory
     tmp_output_dir = make_build_dir("build_dsp_conflict_test_")
@@ -472,9 +437,11 @@ def test_hls_rtl_dsp_conflict_detection():
     np.save(tmp_output_dir + "/expected_output.npy", y_ref)
     model.save(tmp_output_dir + "/model.onnx")
 
-    # Build steps - convert to HW through IP stitching
+    # Build steps - includes conversion to HW layers and specialization
     steps = [
+        "step_convert_to_hw",
         "step_create_dataflow_partition",
+        "step_specialize_layers",
         "step_target_fps_parallelization",
         "step_apply_folding_config",
         "step_minimize_bit_width",
@@ -534,8 +501,7 @@ def test_hls_rtl_dsp_conflict_detection():
         cppsim_success
     ), f"cppsim verification should have passed - check {verif_dir}"
 
-    # Verify cppsim still passed (not affected by DSP conflict)
-    verif_dir = tmp_output_dir + "/verification_output"
+    # Verify node_by_node_rtlsim passed (not affected by DSP conflict for non-MLO)
     rtlsim_success = os.path.join(verif_dir, "verify_node_by_node_rtlsim_0_SUCCESS.npy")
     assert os.path.isfile(
         rtlsim_success
@@ -546,3 +512,198 @@ def test_hls_rtl_dsp_conflict_detection():
     assert not os.path.isfile(
         stitched_success
     ), "stitched_ip_rtlsim should have been skipped due to DSP conflict"
+
+
+def create_layernorm_threshold_mul_model(ishape):
+    """
+    Create a model: LayerNorm -> MultiThreshold -> Mul (INT param).
+
+    This model has both RTL DSP ops (LayerNorm_rtl) and HLS Elementwise ops,
+    but the HLS Elementwise uses integer datatypes (after quantization via
+    MultiThreshold), so it should NOT trigger the DSP conflict detection.
+    """
+    from qonnx.util.basic import qonnx_make_model
+
+    num_channels = ishape[-1]
+
+    inp = helper.make_tensor_value_info("inp", TensorProto.FLOAT, ishape)
+    outp = helper.make_tensor_value_info("outp", TensorProto.FLOAT, ishape)
+    scale = helper.make_tensor_value_info("scale", TensorProto.FLOAT, [num_channels])
+    bias = helper.make_tensor_value_info("bias", TensorProto.FLOAT, [num_channels])
+    thresh = helper.make_tensor_value_info("thresh", TensorProto.FLOAT, [num_channels, 255])
+    mul_param = helper.make_tensor_value_info("mul_param", TensorProto.FLOAT, [num_channels])
+
+    # LayerNorm (will become LayerNorm_rtl)
+    ln_node = helper.make_node(
+        "LayerNormalization",
+        inputs=["inp", "scale", "bias"],
+        outputs=["ln_out"],
+        name="LayerNorm_0",
+        epsilon=1e-5,
+        axis=-1,
+        stash_type=1,
+    )
+
+    # MultiThreshold to quantize to INT8
+    mt_node = helper.make_node(
+        "MultiThreshold",
+        inputs=["ln_out", "thresh"],
+        outputs=["mt_out"],
+        domain="qonnx.custom_op.general",
+        out_dtype="INT8",
+        out_bias=-128.0,
+        out_scale=1.0,
+        data_layout="NC",
+    )
+
+    # Mul with integer parameter (INT8 * INT8 -> INT16)
+    # After MultiThreshold, input is INT8, param will be INT8
+    mul_node = helper.make_node(
+        "Mul",
+        inputs=["mt_out", "mul_param"],
+        outputs=["outp"],
+        name="Mul_int",
+    )
+
+    # Intermediate value infos
+    ln_out_vi = helper.make_tensor_value_info("ln_out", TensorProto.FLOAT, ishape)
+    mt_out_vi = helper.make_tensor_value_info("mt_out", TensorProto.FLOAT, ishape)
+
+    graph = helper.make_graph(
+        nodes=[ln_node, mt_node, mul_node],
+        name="ln_thresh_mul_graph",
+        inputs=[inp, scale, bias, thresh, mul_param],
+        outputs=[outp],
+        value_info=[ln_out_vi, mt_out_vi],
+    )
+    model = qonnx_make_model(graph, producer_name="ln_thresh_mul_test")
+    model = ModelWrapper(model)
+
+    # Set initializers
+    scale_data = np.ones(num_channels, dtype=np.float32)
+    bias_data = np.zeros(num_channels, dtype=np.float32)
+    # Create thresholds for 256 levels (INT8 range)
+    thresh_data = np.zeros((num_channels, 255), dtype=np.float32)
+    for ch in range(num_channels):
+        thresh_data[ch, :] = np.linspace(-10.0, 10.0, 255)
+    # Integer mul param (small integers)
+    mul_param_data = np.ones(num_channels, dtype=np.float32) * 2.0
+
+    model.set_initializer("scale", scale_data)
+    model.set_initializer("bias", bias_data)
+    model.set_initializer("thresh", thresh_data)
+    model.set_initializer("mul_param", mul_param_data)
+
+    # Set tensor datatypes
+    model.set_tensor_datatype("inp", DataType["FLOAT32"])
+    model.set_tensor_datatype("ln_out", DataType["FLOAT32"])
+    model.set_tensor_datatype("mt_out", DataType["INT8"])
+    model.set_tensor_datatype("mul_param", DataType["INT8"])
+    model.set_tensor_datatype("outp", DataType["INT16"])
+    model.set_tensor_datatype("scale", DataType["FLOAT32"])
+    model.set_tensor_datatype("bias", DataType["FLOAT32"])
+    model.set_tensor_datatype("thresh", DataType["FLOAT32"])
+
+    return model
+
+
+@pytest.mark.slow
+@pytest.mark.vivado
+@pytest.mark.fpgadataflow
+def test_integer_hls_elementwise_no_dsp_conflict():
+    """
+    Test that integer-only HLS Elementwise ops do NOT trigger DSP conflict detection.
+
+    This test creates a model with:
+    - LayerNorm -> LayerNorm_rtl (uses DSPFP32)
+    - MultiThreshold -> quantizes to INT8
+    - Mul (INT8 * INT8) -> ElementwiseMul_hls (integer, no DSP conflict)
+
+    The model has HLS Elementwise ops AND RTL DSP ops, but since the HLS
+    Elementwise uses integer datatypes (not floating-point), NO DSP conflict
+    should be detected and stitched_ip_rtlsim should run successfully.
+    """
+    ishape = [1, 32]
+
+    # Create model and prepare for build
+    model = create_layernorm_threshold_mul_model(ishape)
+
+    # Generate reference input/output
+    input_data = gen_finn_dt_tensor(DataType["FLOAT32"], ishape)
+    input_t = {"inp": input_data}
+    y_ref = oxe.execute_onnx(model, input_t)["outp"]
+
+    # Apply minimal transformations - build flow handles the rest
+    model = model.transform(InferShapes())
+    model = model.transform(InferDataTypes())
+    model = model.transform(ExtractNormScaleBias())
+
+    # Setup build directory
+    tmp_output_dir = make_build_dir("build_int_elementwise_test_")
+
+    np.save(tmp_output_dir + "/input.npy", input_data)
+    np.save(tmp_output_dir + "/expected_output.npy", y_ref)
+    model.save(tmp_output_dir + "/model.onnx")
+
+    # Build steps - includes conversion to HW layers and specialization
+    steps = [
+        "step_convert_to_hw",
+        "step_create_dataflow_partition",
+        "step_specialize_layers",
+        "step_target_fps_parallelization",
+        "step_apply_folding_config",
+        "step_minimize_bit_width",
+        "step_generate_estimate_reports",
+        "step_hw_codegen",
+        "step_hw_ipgen",
+        "step_set_fifo_depths",
+        "step_create_stitched_ip",
+    ]
+
+    # Request verification steps - stitched_ip_rtlsim should NOT be skipped
+    verif_steps = [
+        "folded_hls_cppsim",
+        "stitched_ip_rtlsim",
+    ]
+
+    cfg = build_cfg.DataflowBuildConfig(
+        output_dir=tmp_output_dir,
+        steps=steps,
+        target_fps=1000,
+        synth_clk_period_ns=target_clk_ns,
+        board="V80",
+        verify_steps=verif_steps,
+        verify_input_npy=tmp_output_dir + "/input.npy",
+        verify_expected_output_npy=tmp_output_dir + "/expected_output.npy",
+        generate_outputs=[
+            build_cfg.DataflowOutputType.ESTIMATE_REPORTS,
+            build_cfg.DataflowOutputType.STITCHED_IP,
+        ],
+    )
+
+    # Capture warnings during build
+    with warnings.catch_warnings(record=True) as caught_warnings:
+        warnings.simplefilter("always")
+        build.build_dataflow_cfg(tmp_output_dir + "/model.onnx", cfg)
+
+    # Check that NO DSP conflict warning was issued
+    dsp_conflict_warnings = [
+        w for w in caught_warnings if "HLS+RTL DSP CONFLICT DETECTED" in str(w.message)
+    ]
+    assert len(dsp_conflict_warnings) == 0, (
+        f"No DSP conflict warning should be issued for integer HLS Elementwise. "
+        f"Found warnings: {[str(w.message)[:100] for w in dsp_conflict_warnings]}"
+    )
+
+    # Verify that stitched_ip_rtlsim ran successfully (was NOT skipped)
+    verif_dir = tmp_output_dir + "/verification_output"
+    stitched_success = os.path.join(verif_dir, "verify_stitched_ip_rtlsim_0_SUCCESS.npy")
+    assert os.path.isfile(
+        stitched_success
+    ), f"stitched_ip_rtlsim should have run (not skipped) and passed - check {verif_dir}"
+
+    # Verify no conflict log file was created
+    stitched_conflict_file = os.path.join(verif_dir, "stitched_ip_rtlsim_SKIPPED_DSP_CONFLICT.txt")
+    assert not os.path.isfile(
+        stitched_conflict_file
+    ), f"No DSP conflict log file should exist at {stitched_conflict_file}"


### PR DESCRIPTION
This PR addresses an xsim simulation bug that occurs when HLS Elementwise ops coexist with RTL ops using DSPFP32 primitives (LayerNorm_rtl, ElementwiseAdd_rtl, etc.) in a single IP. The conflicting DSP initializations cause HLS kernels to output zeros. The hardware is correct, only xsim simulation is affected.

Changes:

- NaN/Inf detection in rtlsim data conversion (data_packing.py): Added assert checks in npy_to_rtlsim_input() and rtlsim_output_to_npy() to catch invalid values early with clear error messages.
- HLS+RTL DSP conflict detection (fpgadataflow.py): Added `detect_hls_rtl_dsp_conflict()` and `warn_hls_rtl_dsp_conflict()` functions to identify problematic op combinations, including inside FINNLoop bodies.
- Build step integration (build_dataflow_steps.py):
  - For node_by_node_rtlsim: Skip verification only for MLO models, the subgraph in FINNLoop is one IP
  - For stitched_ip_rtlsim: Always check and skip if conflict detected
  - Writes warning log file to verification_output/ folder
- mvu_pkg import order fix (adapter.py): Added mvu_pkg to package patterns for correct xsim compilation order.
- Test (test_fpgadataflow_layernorm.py): Added test for DSP conflict detection with mixed HLS/RTL model.
