### PR TITLE
Fix INT32 bias annotation corruption in MoveAddPastMul

### DIFF
--- a/src/finn/transformation/streamline/reorder.py
+++ b/src/finn/transformation/streamline/reorder.py
@@ -91,8 +91,9 @@ class MoveAddPastMul(Transformation):
                     )
                     graph.node.insert(node_ind, new_mul)
                     graph.node.insert(node_ind + 1, new_add)
-                    # replace add value
+                    # replace add value and update datatype annotation
                     model.set_initializer(add_weight_name, BA)
+                    model.set_tensor_datatype(add_weight_name, DataType["FLOAT32"])
                     # remove old nodes
                     graph.node.remove(n)
                     graph.node.remove(consumer)


### PR DESCRIPTION
### Issue

`MoveAddPastMul` transforms Add(B) → Mul(A) into Mul(A) → Add(B * A). When the Add parameter B has an integer datatype annotation (e.g., INT32 from bias quantization), the computed B * A becomes float, but the datatype annotation incorrectly was not updated.

### Fix

After computing BA = B * A, update the datatype annotation to FLOAT32. Later in the flow if this layer becomes a HW layer, an optimization pass will implement the parameter with the smallest possible datatype.