### PR TITLE
Add input validation to execute_onnx

### DIFF
--- a/src/finn/core/onnx_exec.py
+++ b/src/finn/core/onnx_exec.py
@@ -46,6 +46,17 @@ def execute_onnx(model, input_dict, return_full_exec_context=False, start_node=N
     including) those nodes is executed.
     """
 
+    # validate that all provided input names exist in the model
+    # this catches common bugs like using outdated tensor names
+    valid_tensor_names = set(model.get_all_tensor_names())
+    for inp_name in input_dict.keys():
+        if inp_name not in valid_tensor_names:
+            graph_input_names = sorted(t.name for t in model.graph.input)
+            raise ValueError(
+                f"Provided input '{inp_name}' not found in model. "
+                f"Valid graph inputs are: {graph_input_names}"
+            )
+
     # check if model has an execution mode set
     # if None, execute model node using the QONNX-provided execute_onnx impl
     # if set to "rtlsim" execute model using xsi

--- a/tests/transformation/streamline/test_absorb_opposite_transposes.py
+++ b/tests/transformation/streamline/test_absorb_opposite_transposes.py
@@ -74,8 +74,8 @@ def test_absorb_opposite_transposes():
     model = model.transform(InferShapes())
     new_model = model.transform(AbsorbConsecutiveTransposes())
     new_model = new_model.transform(InferShapes())
-    inp_dict = {"top_in": np.random.rand(*shp).astype(np.float32)}
-    assert ox.compare_execution(model, model, inp_dict)
+    inp_dict = {new_model.get_first_global_in(): np.random.rand(*shp).astype(np.float32)}
+    assert ox.compare_execution(new_model, model, inp_dict)
     assert len(new_model.graph.node) == 6
     for n in new_model.graph.node:
         assert new_model.graph.node[0].op_type != "Transpose"

--- a/tests/transformation/streamline/test_move_past_fork.py
+++ b/tests/transformation/streamline/test_move_past_fork.py
@@ -64,7 +64,9 @@ def test_move_past_fork_transpose():
     new_model = model.transform(MoveTransposePastFork())
     new_model = new_model.transform(GiveUniqueNodeNames())
     nodes = new_model.graph.node
-    assert oxe.compare_execution(model, new_model, {"in0": np.random.rand(*shp).astype(np.float32)})
+    assert oxe.compare_execution(
+        model, new_model, {model.get_first_global_in(): np.random.rand(*shp).astype(np.float32)}
+    )
     assert len(nodes) == 5
     assert not new_model.is_fork_node(get_by_name(nodes, "Transpose_0"))
 
@@ -123,7 +125,7 @@ def test_move_past_fork_linear(ch, ifmdim):
     # Transform
     new_model = model.transform(MoveLinearPastFork())
     new_model = new_model.transform(GiveUniqueNodeNames())
-    inp_dict = {"top_in": np.random.rand(*shp).astype(np.float32)}
+    inp_dict = {model.get_first_global_in(): np.random.rand(*shp).astype(np.float32)}
     # Test
     assert oxe.compare_execution(model, new_model, inp_dict)
     nodes = new_model.graph.node

--- a/tests/transformation/streamline/test_sign_to_thres.py
+++ b/tests/transformation/streamline/test_sign_to_thres.py
@@ -61,6 +61,6 @@ def test_sign_to_thres():
     # load one of the test vectors
     raw_i = get_data("qonnx.data", "onnx/mnist-conv/test_data_set_0/input_0.pb")
     input_tensor = onnx.load_tensor_from_string(raw_i)
-    input_dict = {"0": nph.to_array(input_tensor)}
+    input_dict = {model.get_first_global_in(): nph.to_array(input_tensor)}
     assert oxe.compare_execution(model, new_model, input_dict)
     os.remove(export_onnx_path)

--- a/tests/transformation/test_batchnorm_to_affine_bnn_pynq.py
+++ b/tests/transformation/test_batchnorm_to_affine_bnn_pynq.py
@@ -63,7 +63,7 @@ def test_batchnorm_to_affine_cnv_w1a1():
         input_tensor = np.load(fn)["arr_0"].astype(np.float32)
     input_tensor = input_tensor / 255
     assert input_tensor.shape == (1, 3, 32, 32)
-    input_dict = {"0": input_tensor}
+    input_dict = {model.get_first_global_in(): input_tensor}
     output_dict = oxe.execute_onnx(model, input_dict)
     expected = output_dict[list(output_dict.keys())[0]]
     new_model = model.transform(BatchNormToAffine())
@@ -90,6 +90,6 @@ def test_batchnorm_to_affine_lfc_w1a1():
     # load one of the test vectors
     raw_i = get_data("qonnx.data", "onnx/mnist-conv/test_data_set_0/input_0.pb")
     input_tensor = onnx.load_tensor_from_string(raw_i)
-    input_dict = {"0": nph.to_array(input_tensor)}
+    input_dict = {model.get_first_global_in(): nph.to_array(input_tensor)}
     assert oxe.compare_execution(model, new_model, input_dict)
     os.remove(export_onnx_path)

--- a/tests/util/test_onnx_exec.py
+++ b/tests/util/test_onnx_exec.py
@@ -1,0 +1,71 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import pytest
+
+import numpy as np
+import onnx
+import onnx.helper as oh
+from qonnx.core.modelwrapper import ModelWrapper
+
+from finn.core.onnx_exec import execute_onnx
+
+
+def make_simple_model(input_name="in_x", output_name="out_y"):
+    """Create a simple ONNX model with an Identity node for testing."""
+    inp = oh.make_tensor_value_info(input_name, onnx.TensorProto.FLOAT, [1, 4])
+    outp = oh.make_tensor_value_info(output_name, onnx.TensorProto.FLOAT, [1, 4])
+
+    identity_node = oh.make_node("Identity", [input_name], [output_name])
+
+    graph = oh.make_graph([identity_node], "test_graph", [inp], [outp])
+    onnx_model = oh.make_model(
+        graph, producer_name="finn-test", opset_imports=[oh.make_opsetid("", 11)]
+    )
+    return ModelWrapper(onnx_model)
+
+
+@pytest.mark.util
+def test_execute_onnx_valid_input():
+    """Test that execute_onnx works with valid input tensor names."""
+    model = make_simple_model(input_name="in_x", output_name="out_y")
+    input_data = np.random.randn(1, 4).astype(np.float32)
+
+    # Valid input name should work
+    result = execute_onnx(model, {"in_x": input_data})
+
+    assert "out_y" in result
+    assert np.allclose(result["out_y"], input_data)
+
+
+@pytest.mark.util
+def test_execute_onnx_invalid_input_name():
+    """Test that execute_onnx raises ValueError for invalid input tensor names.
+
+    This catches common bugs like using outdated tensor names after model
+    transformations that rename tensors.
+    """
+    model = make_simple_model(input_name="in_x", output_name="out_y")
+    input_data = np.random.randn(1, 4).astype(np.float32)
+
+    # Invalid input name should raise ValueError with helpful message
+    with pytest.raises(ValueError) as excinfo:
+        execute_onnx(model, {"wrong_name": input_data})
+
+    error_msg = str(excinfo.value)
+    assert "wrong_name" in error_msg, "Error should mention the invalid input name"
+    assert "in_x" in error_msg, "Error should list valid input names"
+
+
+@pytest.mark.util
+def test_execute_onnx_multiple_invalid_inputs():
+    """Test that execute_onnx catches invalid names even when mixed with valid ones."""
+    model = make_simple_model(input_name="in_x", output_name="out_y")
+    input_data = np.random.randn(1, 4).astype(np.float32)
+
+    # Mix of valid and invalid names - should fail on the invalid one
+    with pytest.raises(ValueError) as excinfo:
+        execute_onnx(model, {"in_x": input_data, "invalid_tensor": input_data})
+
+    error_msg = str(excinfo.value)
+    assert "invalid_tensor" in error_msg


### PR DESCRIPTION
- Add validation to `execute_onnx` that checks all provided input names exist in the model
- Raises `ValueError` with helpful message listing valid graph inputs if an invalid name is provided
- Add unit tests for the validation in `tests/util/test_onnx_exec.py`