### PR TITLE
Fix tests

### DIFF
--- a/src/finn/builder/build_dataflow_steps.py
+++ b/src/finn/builder/build_dataflow_steps.py
@@ -483,7 +483,7 @@ def step_convert_to_hw(model: ModelWrapper, cfg: DataflowBuildConfig):
     model = apply_if_relevant(
         model,
         ["MultiThreshold", "Quant"],
-        to_hw.InferRequantLayer(bitwidth_threshold=8),
+        to_hw.InferRequantLayer(bitwidth_threshold=cfg.requant_bitwidth_threshold),
         "high-bitwidth input quantization as requant",
     )
     model = apply_if_relevant(

--- a/src/finn/custom_op/fpgadataflow/rtl/elementwise_binary_rtl.py
+++ b/src/finn/custom_op/fpgadataflow/rtl/elementwise_binary_rtl.py
@@ -9,6 +9,7 @@
 import numpy as np
 import os
 import shutil
+import warnings
 from qonnx.core.datatype import DataType
 
 from finn.custom_op.fpgadataflow import elementwise_binary
@@ -539,7 +540,13 @@ class ElementwiseBinary_rtl(ElementwiseBinaryOperation, RTLBackend):
         return [1]
 
     def minimize_weight_bit_width(self, model):
-        super().minimize_weight_bit_width(model)
+        # Skip weight bit width minimization for RTL elementwise ops
+        # Input and parameter bitwidth must be identical for RTL implementation
+        warnings.warn(
+            f"{self.onnx_node.name}: Skipping weight bit width minimization for RTL "
+            "elementwise op. Input and parameter bitwidth must be identical."
+        )
+        pass
 
     def _get_rtl_op_name(self):
         """Override in subclasses to return the correct RTL operation name."""

--- a/tests/end2end/test_end2end_bnn_pynq.py
+++ b/tests/end2end/test_end2end_bnn_pynq.py
@@ -844,8 +844,11 @@ class TestEnd2End:
             pytest.skip("VITIS_PATH not set")
         prev_chkpt_name = get_checkpoint_name(board, topology, wbits, abits, "linking")
         model = load_test_checkpoint_or_skip(prev_chkpt_name)
-        if build_data["toolchain"] == "vitis-xrt" and topology == "tfc":
-            model = model.transform(MakeCPPDriver("vitis-xrt", version="latest"))
+        if build_data["toolchain"] == "vitis-xrt":
+            if topology == "tfc":
+                model = model.transform(MakeCPPDriver("vitis-xrt", version="latest"))
+            else:
+                model = model.transform(MakePYNQDriver("vitis-xrt"))
         elif build_data["toolchain"] == "pynq":
             model = model.transform(MakePYNQDriver("zynq-iodma"))
         else:

--- a/tests/fpgadataflow/test_fpgadataflow_layernorm.py
+++ b/tests/fpgadataflow/test_fpgadataflow_layernorm.py
@@ -655,6 +655,16 @@ def test_integer_hls_elementwise_no_dsp_conflict():
     np.save(tmp_output_dir + "/expected_output.npy", y_ref)
     model.save(tmp_output_dir + "/model.onnx")
 
+    # Create specialize_layers_config to force HLS for ElementwiseMul
+    # This ensures we test HLS elementwise + RTL DSP coexistence
+    specialize_config = {
+        "Defaults": {},
+        "ElementwiseMul_0": {"preferred_impl_style": "hls"},
+    }
+    specialize_config_path = tmp_output_dir + "/specialize_layers_config.json"
+    with open(specialize_config_path, "w") as f:
+        json.dump(specialize_config, f)
+
     # Build steps - includes conversion to HW layers and specialization
     steps = [
         "step_convert_to_hw",
@@ -682,6 +692,7 @@ def test_integer_hls_elementwise_no_dsp_conflict():
         target_fps=1000,
         synth_clk_period_ns=target_clk_ns,
         board="VCK190",
+        specialize_layers_config_file=specialize_config_path,
         verify_steps=verif_steps,
         verify_input_npy=tmp_output_dir + "/input.npy",
         verify_expected_output_npy=tmp_output_dir + "/expected_output.npy",
@@ -695,6 +706,32 @@ def test_integer_hls_elementwise_no_dsp_conflict():
     with warnings.catch_warnings(record=True) as caught_warnings:
         warnings.simplefilter("always")
         build.build_dataflow_cfg(tmp_output_dir + "/model.onnx", cfg)
+
+    # Check that layers were specialized as expected:
+    intermediate_model_path = tmp_output_dir + "/intermediate_models/step_specialize_layers.onnx"
+    assert os.path.isfile(
+        intermediate_model_path
+    ), f"Intermediate model not found at {intermediate_model_path}"
+    specialized_model = ModelWrapper(intermediate_model_path)
+    op_types = [n.op_type for n in specialized_model.graph.node]
+
+    # Check LayerNorm is RTL
+    ln_rtl_nodes = specialized_model.get_nodes_by_op_type("LayerNorm_rtl")
+    assert (
+        len(ln_rtl_nodes) == 1
+    ), f"Expected exactly 1 LayerNorm_rtl, found {len(ln_rtl_nodes)}. Op types: {op_types}"
+
+    # Check Thresholding is RTL
+    thr_rtl_nodes = specialized_model.get_nodes_by_op_type("Thresholding_rtl")
+    assert (
+        len(thr_rtl_nodes) == 1
+    ), f"Expected exactly 1 Thresholding_rtl, found {len(thr_rtl_nodes)}. Op types: {op_types}"
+
+    # Check ElementwiseMul is HLS
+    mul_hls_nodes = specialized_model.get_nodes_by_op_type("ElementwiseMul_hls")
+    assert (
+        len(mul_hls_nodes) == 1
+    ), f"Expected exactly 1 ElementwiseMul_hls, found {len(mul_hls_nodes)}. Op types: {op_types}"
 
     # Check that NO DSP conflict warning was issued
     dsp_conflict_warnings = [


### PR DESCRIPTION
- [x] Don't allow parameter bitwidth minimization for RTL Elementwise Op because input and parameter bitwidth need to be the same
- [x] Fix Layernorm test by ensuring that correct layers get derived
- [x] Use cfg.requant_bitwidth_threshold for all occurrences of InferRequant
- [x] Fix make driver step in bnn pynq tests for Alveo U250 