### PR TITLE
Add quicktest verify option for minimal install verification

### DIFF
--- a/docker/quicktest.sh
+++ b/docker/quicktest.sh
@@ -1,12 +1,15 @@
 #!/bin/bash
 
-: ${PYTEST_PARALLEL=auto}
+: ${PYTEST_PARALLEL=2}
 
 cd $FINN_ROOT
 # check if command line argument is empty or not present
 if [ -z $1 ]; then
   echo "Running quicktest: not (vivado or slow or board) with pytest-xdist"
   pytest -m 'not (vivado or slow or vitis or board or notebooks or bnn_pynq)' --dist=loadfile -n $PYTEST_PARALLEL
+elif [ $1 = "verify" ]; then
+  echo "Running verification tests (minimal install verification with Vivado)"
+  $FINN_ROOT/scripts/quicktest-local.sh vivado
 elif [ $1 = "main" ]; then
   echo "Running main test suite: not (rtlsim or end2end) with pytest-xdist"
   pytest -k 'not (rtlsim or end2end)' --dist=loadfile -n $PYTEST_PARALLEL
@@ -23,4 +26,11 @@ elif [ $1 = "full" ]; then
   $0 end2end;
 else
   echo "Unrecognized argument to quicktest.sh"
+  echo "Available options:"
+  echo "  (no arg)      - Run quicktest (non-vivado, non-slow tests)"
+  echo "  verify        - Minimal install verification with Vivado tests"
+  echo "  main          - Main test suite (no rtlsim or end2end)"
+  echo "  rtlsim        - RTL simulation tests"
+  echo "  end2end       - End-to-end tests"
+  echo "  full          - Full test suite (main + rtlsim + end2end)"
 fi

--- a/docker/quicktest.sh
+++ b/docker/quicktest.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-: ${PYTEST_PARALLEL=2}
+: ${PYTEST_PARALLEL=auto}
 
 cd $FINN_ROOT
 # check if command line argument is empty or not present

--- a/docs/finn/getting_started.rst
+++ b/docs/finn/getting_started.rst
@@ -10,7 +10,7 @@ Quickstart
 1. Install Docker to run `without root <https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user>`_
 2. Set up ``FINN_XILINX_PATH`` and ``FINN_XILINX_VERSION`` environment variables pointing respectively to the Xilinx tools installation directory and version (e.g. ``FINN_XILINX_PATH=/opt/Xilinx`` and ``FINN_XILINX_VERSION=2022.2``)
 3. Clone the FINN compiler from the repo: ``git clone https://github.com/Xilinx/finn/`` and go into the directory where it is cloned
-4. Execute ``./run-docker.sh quicktest`` to verify your installation.
+4. Execute ``./run-docker.sh quicktest verify`` to verify your installation. It is normal to see warnings during the tests - FINN uses warnings to inform users about certain conditions. As long as all tests pass, your installation is successful.
 5. Optionally, follow the instructions on :ref:`PYNQ board first-time setup`, :ref:`Vitis-based Alveo first-time setup`, or :ref:`Slash-based Alveo first-time setup` for board setup.
 6. Optionally, set up a `Vivado/Vitis license`_.
 7. All done! See :ref:`Running FINN in Docker` for the various options on how to run the FINN compiler.

--- a/scripts/quicktest-local.sh
+++ b/scripts/quicktest-local.sh
@@ -78,11 +78,14 @@ fi
 gecho "  PASSED"
 echo ""
 
-# Test 2: Basic transformation tests (no Vivado required)
-gecho "Test 2: Basic transformation tests..."
+# Test 2: Streamline transformation tests (no Vivado required)
+gecho "Test 2: Streamline transformation tests..."
 
 cd "$FINN_ROOT"
-pytest tests/transformation/ \
+# Run only streamline tests - these are stable and don't have xfail/skip
+pytest tests/transformation/streamline/test_collapse_repeated_op.py \
+    tests/transformation/streamline/test_move_past_fork.py \
+    tests/transformation/streamline/test_factor_out_mul_sign_magnitude.py \
     -m "not vivado and not slow and not vitis" \
     --maxfail=3 \
     -q \
@@ -98,7 +101,11 @@ echo ""
 # Test 3: Utility tests
 gecho "Test 3: Utility tests..."
 
-pytest tests/util/ \
+# Run specific util tests that don't have xfail/skip
+pytest tests/util/test_create.py \
+    tests/util/test_onnx_exec.py \
+    tests/util/test_config.py \
+    tests/util/test_modelwrapper.py \
     -m "not vivado and not slow" \
     --maxfail=3 \
     -q \
@@ -117,7 +124,7 @@ if [ "$MODE" = "vivado" ]; then
         gecho "Test 4a: Vivado cppsim test (HLS LayerNorm)..."
 
         # cppsim test - tests HLS C++ simulation
-        pytest -k "test_fpgadataflow_hls_layernorm and cppsim and idt0" \
+        pytest -k "test_fpgadataflow_hls_layernorm and cppsim and idt0 and ishape0" \
             -v \
             --maxfail=1 \
             --tb=short
@@ -132,7 +139,7 @@ if [ "$MODE" = "vivado" ]; then
         gecho "Test 4b: Vivado node-by-node rtlsim test (HLS LayerNorm)..."
 
         # node_by_node rtlsim test - tests RTL simulation per node
-        pytest -k "test_fpgadataflow_hls_layernorm and node_by_node and idt0" \
+        pytest -k "test_fpgadataflow_hls_layernorm and node_by_node and idt0 and ishape0" \
             -v \
             --maxfail=1 \
             --tb=short
@@ -147,7 +154,7 @@ if [ "$MODE" = "vivado" ]; then
         gecho "Test 4c: Vivado stitched IP rtlsim test (HLS LayerNorm)..."
 
         # stitched_ip rtlsim test - tests RTL simulation of stitched IP
-        pytest -k "test_fpgadataflow_hls_layernorm and stitched_ip and idt0" \
+        pytest -k "test_fpgadataflow_hls_layernorm and stitched_ip and idt0 and ishape0" \
             -v \
             --maxfail=1 \
             --tb=short


### PR DESCRIPTION
Adds a new verify option to quicktest.sh that runs a minimal, reliable test suite for verifying FINN installations. This provides a faster alternative to the full quicktest and avoids confusing users with skipped/xfail test results.

Changes:
- docker/quicktest.sh: Added verify option that calls scripts/quicktest-local.sh
- scripts/quicktest-local.sh: Updated to run specific stable tests without xfail/skip markers
- docs/finn/getting_started.rst: Updated step 4 to recommend quicktest verify and added note about warnings being normal

Usage:
./run-docker.sh quicktest verify