### PR TITLE
Default RTL elementwise ops to HLS for int/int, use RTL only for float scenarios

### DIFF
--- a/src/finn/custom_op/fpgadataflow/rtl/elementwise_binary_rtl.py
+++ b/src/finn/custom_op/fpgadataflow/rtl/elementwise_binary_rtl.py
@@ -9,7 +9,6 @@
 import numpy as np
 import os
 import shutil
-import warnings
 from qonnx.core.datatype import DataType
 
 from finn.custom_op.fpgadataflow import elementwise_binary
@@ -538,15 +537,6 @@ class ElementwiseBinary_rtl(ElementwiseBinaryOperation, RTLBackend):
         if len(folded_lhs) >= 2:
             return list(folded_lhs[:-1])
         return [1]
-
-    def minimize_weight_bit_width(self, model):
-        # Skip weight bit width minimization for RTL elementwise ops
-        # Input and parameter bitwidth must be identical for RTL implementation
-        warnings.warn(
-            f"{self.onnx_node.name}: Skipping weight bit width minimization for RTL "
-            "elementwise op. Input and parameter bitwidth must be identical."
-        )
-        pass
 
     def _get_rtl_op_name(self):
         """Override in subclasses to return the correct RTL operation name."""

--- a/src/finn/transformation/fpgadataflow/specialize_layers.py
+++ b/src/finn/transformation/fpgadataflow/specialize_layers.py
@@ -300,7 +300,8 @@ def _vvu_rtl_possible(n, fpgapart):
 
 def _elementwise_rtl_possible(n, fpgapart):
     # Checks whether RTL-based ElementwiseOp is possible.
-    # Supports float/float, int/float, float/int, and int/int paths on Versal.
+    # Only supports float/float and int/float paths on Versal.
+    # Int/int uses HLS to avoid bitwidth mismatch issues after MinimizeBitWidth.
     if not is_versal(fpgapart):
         return False
 
@@ -310,26 +311,17 @@ def _elementwise_rtl_possible(n, fpgapart):
 
     lhs_float = lhs_dtype == "FLOAT32"
     rhs_float = rhs_dtype == "FLOAT32"
-    both_int = not lhs_float and not rhs_float
+
+    # Only use RTL for float/float or int/float scenarios
+    # Int/int defaults to HLS to avoid bitwidth mismatch after MinimizeBitWidth
+    if not lhs_float and not rhs_float:
+        return False
 
     # Float inputs must be FLOAT32 (not FLOAT16 etc.)
     if lhs_float and lhs_dtype != "FLOAT32":
         return False
     if rhs_float and rhs_dtype != "FLOAT32":
         return False
-
-    # Int/int constraints: widths and signedness must match
-    if both_int:
-        if lhs_dtype.bitwidth() != rhs_dtype.bitwidth():
-            return False
-        if lhs_dtype.signed() != rhs_dtype.signed():
-            return False
-        # MUL width limits (DSP58 capacity)
-        op = node_inst._operation[0]  # "Add", "Sub", "Mul"
-        if op == "Mul":
-            max_w = 24 if lhs_dtype.signed() else 23
-            if lhs_dtype.bitwidth() > max_w:
-                return False
 
     lhs_style = node_inst.get_nodeattr("lhs_style")
     rhs_style = node_inst.get_nodeattr("rhs_style")

--- a/tests/fpgadataflow/test_fpgadataflow_elementwise_binary_rtl.py
+++ b/tests/fpgadataflow/test_fpgadataflow_elementwise_binary_rtl.py
@@ -82,9 +82,6 @@ def create_elementwise_model(op_type, lhs_dtype, rhs_dtype, lhs_shape, rhs_shape
     "lhs_dtype,rhs_dtype",
     [
         ("FLOAT32", "FLOAT32"),
-        ("INT8", "INT8"),
-        ("UINT8", "UINT8"),
-        ("INT16", "INT16"),
         ("INT8", "FLOAT32"),
     ],
 )
@@ -245,14 +242,13 @@ def test_elementwise_rtl_stitched_ip(op_type, pe):
 @pytest.mark.parametrize(
     "scenario,op_type,lhs_dtype,rhs_dtype,out_dtype,expected_backend",
     [
-        # INT25 signed MUL exceeds DSP58 capacity (max 24-bit for signed)
-        ("wide_mul_fallback", "ElementwiseMul", "INT25", "INT25", "INT50", "hls"),
-        # Mismatched bitwidths -> fallback to HLS
-        ("mismatched_width_fallback", "ElementwiseAdd", "INT8", "INT16", "INT32", "hls"),
-        # Mismatched signedness -> fallback to HLS
-        ("mismatched_sign_fallback", "ElementwiseAdd", "INT8", "UINT8", "INT32", "hls"),
-        # INT24 signed MUL within DSP58 capacity -> should use RTL
-        ("int24_mul_rtl", "ElementwiseMul", "INT24", "INT24", "INT48", "rtl"),
+        # Int/int scenarios always use HLS (RTL only for float scenarios)
+        ("int_int_uses_hls", "ElementwiseAdd", "INT8", "INT8", "INT9", "hls"),
+        ("int_int_mul_uses_hls", "ElementwiseMul", "INT8", "INT8", "INT16", "hls"),
+        # Float/float uses RTL
+        ("float_float_uses_rtl", "ElementwiseAdd", "FLOAT32", "FLOAT32", "FLOAT32", "rtl"),
+        # Int/float uses RTL
+        ("int_float_uses_rtl", "ElementwiseAdd", "INT8", "FLOAT32", "FLOAT32", "rtl"),
     ],
 )
 @pytest.mark.fpgadataflow


### PR DESCRIPTION
RTL elementwise operations require matching input bitwidths for int/int paths. This constraint conflicts with MinimizeBitWidth transformations that run after SpecializeLayers, causing bitwidth mismatches and IP generation failures (e.g., MVAU output minimized to INT14 while following ElementwiseAdd params remain INT32).

This change restricts RTL elementwise to float/float and int/float scenarios only, where the DSP58 floating-point capability provides the most benefit. Int/int operations now default to HLS, which handles varying bitwidths without issue.