### PR TITLE
Fix datawidth mismatch in MLO intermediate_frames module

### DIFF
--- a/finn-rtllib/mlo/infrastructure/intermediate_frames.sv
+++ b/finn-rtllib/mlo/infrastructure/intermediate_frames.sv
@@ -399,7 +399,7 @@ logic s_axis_int_tvalid, s_axis_int_tready;
 logic [OLEN_BITS-1:0] s_axis_int_tdata;
 
 logic m_axis_int_tvalid, m_axis_int_tready;
-logic [OLEN_BITS-1:0] m_axis_int_tdata;
+logic [ILEN_BITS-1:0] m_axis_int_tdata;
 
 logic [FM_BEATS_IN_BITS-1:0] cnt_dwc_C = '0;
 always_ff @(posedge aclk) begin

--- a/tests/fpgadataflow/test_fpgadataflow_finnloop.py
+++ b/tests/fpgadataflow/test_fpgadataflow_finnloop.py
@@ -152,7 +152,7 @@ def make_loop_modelwrapper(
             {
                 "NumChannels": mh,
                 "NumOutputStreams": 2,
-                "PE": 2,
+                "PE": 8,
                 "inputDataType": dtype.name,
                 "outFIFODepths": [2, 2],
                 "cpp_interface": "hls_vector",
@@ -323,7 +323,7 @@ def make_loop_modelwrapper(
             f"Thresholding_rtl4{name_suffix}",
             {
                 "NumChannels": mh,
-                "PE": 2,
+                "PE": 4,
                 "numSteps": dtype.get_num_possible_values() - 1,
                 "inputDataType": thresholding_input_dtype.name,
                 "weightDataType": thresholding_input_dtype.name,
@@ -519,7 +519,7 @@ def test_finnloop_end2end_mlo(
         "step_create_dataflow_partition",
         # "step_specialize_layers",
         "step_loop_rolling",
-        "step_target_fps_parallelization",
+        # "step_target_fps_parallelization",
         "step_apply_folding_config",
         "step_minimize_bit_width",
         "step_generate_estimate_reports",
@@ -532,7 +532,6 @@ def test_finnloop_end2end_mlo(
     cfg = build_cfg.DataflowBuildConfig(
         output_dir=tmp_output_dir,
         steps=steps,
-        target_fps=1000,
         synth_clk_period_ns=10.0,
         board="V80",
         rtlsim_batch_size=100,


### PR DESCRIPTION
When the first and last layers of an MLO loop body have different PE values (and thus different stream widths), the intermediate frame buffer would fail due to a width mismatch. The axis_fifo_adapter datawidth converter outputs ILEN_BITS width, but the signal it connected to was declared as OLEN_BITS.

Addressed in RTL code and test added to verify correct behaviour.