### PR TITLE
Update CreateStitchedIP callers for renamed arg

### DIFF
--- a/tests/end2end/test_end2end_mobilenet_v1.py
+++ b/tests/end2end/test_end2end_mobilenet_v1.py
@@ -469,7 +469,7 @@ def test_end2end_mobilenet_stitched_ip():
         CreateStitchedIP(
             fpga_part,
             target_clk_ns,
-            vitis=False,
+            run_synth=False,
             signature=None,
         )
     )

--- a/tests/fpgadataflow/test_fpgadataflow_concat.py
+++ b/tests/fpgadataflow/test_fpgadataflow_concat.py
@@ -161,7 +161,7 @@ def test_fpgadataflow_concat_stitchedip():
         CreateStitchedIP(
             fpga_part,
             clk_ns,
-            vitis=False,
+            run_synth=False,
         )
     )
     model.set_metadata_prop("exec_mode", "rtlsim")

--- a/tests/fpgadataflow/test_fpgadataflow_convinputgenerator_rtl_dynamic.py
+++ b/tests/fpgadataflow/test_fpgadataflow_convinputgenerator_rtl_dynamic.py
@@ -301,7 +301,7 @@ def test_fpgadataflow_conv_dynamic(cfg):
     model = model.transform(GiveReadableTensorNames())
     model = model.transform(PrepareIP("xc7z020clg400-1", 5))
     model = model.transform(HLSSynthIP())
-    model = model.transform(CreateStitchedIP("xc7z020clg400-1", 5, vitis=do_synth))
+    model = model.transform(CreateStitchedIP("xc7z020clg400-1", 5, run_synth=do_synth))
     model.set_metadata_prop("exec_mode", "rtlsim")
 
     # loop through experiment configurations

--- a/tests/fpgadataflow/test_fpgadataflow_elementwise_binary.py
+++ b/tests/fpgadataflow/test_fpgadataflow_elementwise_binary.py
@@ -380,7 +380,7 @@ def test_elementwise_binary_operation_stitched_ip(
         CreateStitchedIP(
             part,
             10,
-            vitis=False,
+            run_synth=False,
         )
     )
 

--- a/tests/fpgadataflow/test_fpgadataflow_elementwise_binary_rtl.py
+++ b/tests/fpgadataflow/test_fpgadataflow_elementwise_binary_rtl.py
@@ -221,7 +221,7 @@ def test_elementwise_rtl_stitched_ip(op_type, pe):
     model = model.transform(GiveUniqueNodeNames())
     model = model.transform(PrepareIP(VERSAL_PART, 10))
     model = model.transform(HLSSynthIP())
-    model = model.transform(CreateStitchedIP(VERSAL_PART, 10, vitis=False))
+    model = model.transform(CreateStitchedIP(VERSAL_PART, 10, run_synth=False))
 
     # Run stitched IP rtlsim
     model.set_metadata_prop("exec_mode", "rtlsim")

--- a/tests/fpgadataflow/test_fpgadataflow_split.py
+++ b/tests/fpgadataflow/test_fpgadataflow_split.py
@@ -144,7 +144,7 @@ def test_fpgadataflow_split(exec_mode, idt):
             CreateStitchedIP(
                 fpga_part,
                 clk_ns,
-                vitis=False,
+                run_synth=False,
             )
         )
         model.set_metadata_prop("exec_mode", "rtlsim")


### PR DESCRIPTION
c4ac0799 renamed CreateStitchedIP `vitis` arg to `run_synth`. Update tests to match.