### PR TITLE
Adding FIFO tracing capabilities in simulation.

### DIFF
--- a/finn-rtllib/eltwise/eltwise_template.v
+++ b/finn-rtllib/eltwise/eltwise_template.v
@@ -34,7 +34,9 @@ eltwise #(
         .PE($PE$),
         .OP($OP$),
         .B_SCALE($B_SCALE$),
-        .FORCE_BEHAVIORAL($FORCE_BEHAVIORAL$),
+`ifdef FINN_SIMULATION
+        .FORCE_BEHAVIORAL(1),
+`endif
         .A_FLOAT($A_FLOAT$),
         .B_FLOAT($B_FLOAT$),
         .A_WIDTH($A_WIDTH$),

--- a/finn-rtllib/fifo/hdl/fifo_gauge.sv
+++ b/finn-rtllib/fifo/hdl/fifo_gauge.sv
@@ -35,7 +35,7 @@
 module fifo_gauge #(
 	int unsigned  WIDTH,
 	int unsigned  COUNT_WIDTH = 32,
-	parameter  DATA_LOGFILE = ""  // Log consumed data verbosely to this file
+	parameter bit  DEBUG_LOG = 0
 )(
 	input	logic  clk,
 	input	logic  rst,
@@ -52,14 +52,14 @@ module fifo_gauge #(
 	output	logic [COUNT_WIDTH-1:0]  maxcount
 );
 
+	localparam int  STDERR_FD = 32'h8000_0002;
+
 	//-----------------------------------------------------------------------
 	// Monitoring & Debug
 
 	// Transaction counters
 	longint unsigned  ITxnCnt = 0;
 	longint unsigned  OTxnCnt = 0;
-	// Optional hex data trace
-	int  LogFd = (DATA_LOGFILE != "")? $fopen(DATA_LOGFILE, "a") : 0;
 
 	// The internal Queue serving as data buffer and an output register
 	logic [WIDTH-1:0]  Q[$] = {};
@@ -70,8 +70,7 @@ module fifo_gauge #(
 	logic [WIDTH-1:0]  ODat = 'x;
 
 	final begin
-		$display("[%m] MaxFill: %0d; Transactions: in=%0d out=%0d", MaxCount, ITxnCnt, OTxnCnt);
-		if(LogFd)  $fclose(LogFd);
+		$fwrite(STDERR_FD, "[%m] MaxFill: %0d; Transactions: in=%0d out=%0d", MaxCount, ITxnCnt, OTxnCnt);
 	end
 
 	always_ff @(posedge clk) begin
@@ -89,7 +88,7 @@ module fifo_gauge #(
 			// Always take input and track Transactions
 			if(ivld) begin
 				Q.push_back(idat);
-				if(LogFd)  $fwrite(LogFd, "%0x\n", idat);
+				if(DEBUG_LOG)  $fwrite(STDERR_FD, "[FIFOLOG %m] %0x\n", idat);
 				ITxnCnt <= ITxnCnt + 1;
 			end
 			if(OVld && ordy)  OTxnCnt <= OTxnCnt + 1;

--- a/finn-rtllib/fifo/hdl/fifo_gauge.sv
+++ b/finn-rtllib/fifo/hdl/fifo_gauge.sv
@@ -34,7 +34,8 @@
 
 module fifo_gauge #(
 	int unsigned  WIDTH,
-	int unsigned  COUNT_WIDTH = 32
+	int unsigned  COUNT_WIDTH = 32,
+	parameter  DATA_LOGFILE = ""  // Log consumed data verbosely to this file
 )(
 	input	logic  clk,
 	input	logic  rst,
@@ -51,25 +52,47 @@ module fifo_gauge #(
 	output	logic [COUNT_WIDTH-1:0]  maxcount
 );
 
+	//-----------------------------------------------------------------------
+	// Monitoring & Debug
+
+	// Transaction counters
+	longint unsigned  ITxnCnt = 0;
+	longint unsigned  OTxnCnt = 0;
+	// Optional hex data trace
+	int  LogFd = (DATA_LOGFILE != "")? $fopen(DATA_LOGFILE, "a") : 0;
+
 	// The internal Queue serving as data buffer and an output register
 	logic [WIDTH-1:0]  Q[$] = {};
-	logic [COUNT_WIDTH-1:0]  Count    = 0;
-	logic [COUNT_WIDTH-1:0]  MaxCount = 0;
+	longint unsigned  Count    = 0;
+	longint unsigned  MaxCount = 0;
 
 	logic  OVld = 0;
 	logic [WIDTH-1:0]  ODat = 'x;
 
+	final begin
+		$display("[%m] MaxFill: %0d; Transactions: in=%0d out=%0d", MaxCount, ITxnCnt, OTxnCnt);
+		if(LogFd)  $fclose(LogFd);
+	end
+
 	always_ff @(posedge clk) begin
 		if(rst) begin
-			Q        <= {};
+			Q         = {};
 			Count    <= 0;
 			MaxCount <= 0;
 			OVld <= 0;
 			ODat <= 'x;
+
+			ITxnCnt <= 0;
+			OTxnCnt <= 0;
 		end
 		else begin
-			// Always take input
-			if(ivld)  Q.push_back(idat);
+			// Always take input and track Transactions
+			if(ivld) begin
+				Q.push_back(idat);
+				if(LogFd)  $fwrite(LogFd, "%0x\n", idat);
+				ITxnCnt <= ITxnCnt + 1;
+			end
+			if(OVld && ordy)  OTxnCnt <= OTxnCnt + 1;
 
 			// Take Count
 			Count <= Q.size;

--- a/finn-rtllib/fifo/hdl/fifo_gauge.sv
+++ b/finn-rtllib/fifo/hdl/fifo_gauge.sv
@@ -35,7 +35,7 @@
 module fifo_gauge #(
 	int unsigned  WIDTH,
 	int unsigned  COUNT_WIDTH = 32,
-	parameter bit  DEBUG_LOG = 0
+	parameter  DATA_LOGFILE = ""
 )(
 	input	logic  clk,
 	input	logic  rst,
@@ -52,14 +52,13 @@ module fifo_gauge #(
 	output	logic [COUNT_WIDTH-1:0]  maxcount
 );
 
-	localparam int  STDERR_FD = 32'h8000_0002;
-
 	//-----------------------------------------------------------------------
 	// Monitoring & Debug
 
 	// Transaction counters
 	longint unsigned  ITxnCnt = 0;
 	longint unsigned  OTxnCnt = 0;
+	int  LogFd = (DATA_LOGFILE != "")? $fopen(DATA_LOGFILE, "w") : 0;
 
 	// The internal Queue serving as data buffer and an output register
 	logic [WIDTH-1:0]  Q[$] = {};
@@ -70,7 +69,10 @@ module fifo_gauge #(
 	logic [WIDTH-1:0]  ODat = 'x;
 
 	final begin
-		$fwrite(STDERR_FD, "[%m @%0t] MaxFill: %0d; Transactions: in=%0d out=%0d", $time, MaxCount, ITxnCnt, OTxnCnt);
+		if(LogFd) begin
+			$fwrite(LogFd, "[%m @%0t] MaxFill: %0d; Transactions: in=%0d out=%0d\n", $time, MaxCount, ITxnCnt, OTxnCnt);
+			$fclose(LogFd);
+		end
 	end
 
 	always_ff @(posedge clk) begin
@@ -88,7 +90,7 @@ module fifo_gauge #(
 			// Always take input and track Transactions
 			if(ivld) begin
 				Q.push_back(idat);
-				if(DEBUG_LOG)  $fwrite(STDERR_FD, "[FIFOLOG %m @%0t] %0x\n", $time, idat);
+				if(LogFd)  $fwrite(LogFd, "%0x\n", idat);
 				ITxnCnt <= ITxnCnt + 1;
 			end
 			if(OVld && ordy)  OTxnCnt <= OTxnCnt + 1;

--- a/finn-rtllib/fifo/hdl/fifo_gauge.sv
+++ b/finn-rtllib/fifo/hdl/fifo_gauge.sv
@@ -70,7 +70,7 @@ module fifo_gauge #(
 	logic [WIDTH-1:0]  ODat = 'x;
 
 	final begin
-		$fwrite(STDERR_FD, "[%m] MaxFill: %0d; Transactions: in=%0d out=%0d", MaxCount, ITxnCnt, OTxnCnt);
+		$fwrite(STDERR_FD, "[%m @%0t] MaxFill: %0d; Transactions: in=%0d out=%0d", $time, MaxCount, ITxnCnt, OTxnCnt);
 	end
 
 	always_ff @(posedge clk) begin
@@ -88,7 +88,7 @@ module fifo_gauge #(
 			// Always take input and track Transactions
 			if(ivld) begin
 				Q.push_back(idat);
-				if(DEBUG_LOG)  $fwrite(STDERR_FD, "[FIFOLOG %m] %0x\n", idat);
+				if(DEBUG_LOG)  $fwrite(STDERR_FD, "[FIFOLOG %m @%0t] %0x\n", $time, idat);
 				ITxnCnt <= ITxnCnt + 1;
 			end
 			if(OVld && ordy)  OTxnCnt <= OTxnCnt + 1;

--- a/finn-rtllib/fifo/hdl/fifo_gauge_tb.sv
+++ b/finn-rtllib/fifo/hdl/fifo_gauge_tb.sv
@@ -59,7 +59,7 @@ module fifo_gauge_tb;
 	// Depth Monitoring
 	uwire count_t  maxcount;
 
-	fifo_gauge #(.WIDTH(W)) dut (
+	fifo_gauge #(.WIDTH(W), .DATA_LOGFILE("fifo_trace.log")) dut (
 		.clk, .rst,
 		.idat, .ivld, .irdy,
 		.odat, .ovld, .ordy,
@@ -70,6 +70,7 @@ module fifo_gauge_tb;
 	// Stimulus
 	data_t  Q[$] = {};
 	initial begin
+		automatic int  ref_fd = $fopen("fifo_ref.log", "w");
 		idat = 'x;
 		ivld =  0;
 		@(posedge clk iff !rst);
@@ -79,10 +80,12 @@ module fifo_gauge_tb;
 			idat <= data;
 			ivld <= 1;
 			Q.push_back(data);
+			$fwrite(ref_fd, "%0x\n", data);
 			@(posedge clk);
 			idat <= 'x;
 			ivld <=  0;
 		end
+		$fclose(ref_fd);
 	end
 
 	//-----------------------------------------------------------------------

--- a/finn-rtllib/fifo/hdl/fifo_gauge_tb.sv
+++ b/finn-rtllib/fifo/hdl/fifo_gauge_tb.sv
@@ -59,7 +59,7 @@ module fifo_gauge_tb;
 	// Depth Monitoring
 	uwire count_t  maxcount;
 
-	fifo_gauge #(.WIDTH(W), .DEBUG_LOG(1)) dut (
+	fifo_gauge #(.WIDTH(W), .DATA_LOGFILE("fifo_trace.log")) dut (
 		.clk, .rst,
 		.idat, .ivld, .irdy,
 		.odat, .ovld, .ordy,

--- a/finn-rtllib/fifo/hdl/fifo_gauge_tb.sv
+++ b/finn-rtllib/fifo/hdl/fifo_gauge_tb.sv
@@ -59,7 +59,7 @@ module fifo_gauge_tb;
 	// Depth Monitoring
 	uwire count_t  maxcount;
 
-	fifo_gauge #(.WIDTH(W), .DATA_LOGFILE("fifo_trace.log")) dut (
+	fifo_gauge #(.WIDTH(W), .DEBUG_LOG(1)) dut (
 		.clk, .rst,
 		.idat, .ivld, .irdy,
 		.odat, .ovld, .ordy,

--- a/finn-rtllib/fifo/hdl/fifo_template.v
+++ b/finn-rtllib/fifo/hdl/fifo_template.v
@@ -52,7 +52,7 @@ output  $OUT_RANGE$ out0_V_TDATA
 );
 
 `ifdef FINN_SIMULATION
-	fifo_gauge #(.WIDTH($WIDTH$), .COUNT_WIDTH($COUNT_WIDTH$), .DEBUG_LOG($DEBUG_LOG$)) fifo (
+	fifo_gauge #(.WIDTH($WIDTH$), .COUNT_WIDTH($COUNT_WIDTH$), .DATA_LOGFILE("$DATA_LOGFILE$")) fifo (
 		.clk(ap_clk), .rst(!ap_rst_n),
 		.idat(in0_V_TDATA), .ivld(in0_V_TVALID), .irdy(in0_V_TREADY),
 		.odat(out0_V_TDATA), .ovld(out0_V_TVALID), .ordy(out0_V_TREADY),

--- a/finn-rtllib/fifo/hdl/fifo_template.v
+++ b/finn-rtllib/fifo/hdl/fifo_template.v
@@ -52,7 +52,7 @@ output  $OUT_RANGE$ out0_V_TDATA
 );
 
 `ifdef FINN_SIMULATION
-	fifo_gauge #(.WIDTH($WIDTH$), .COUNT_WIDTH($COUNT_WIDTH$)) fifo (
+	fifo_gauge #(.WIDTH($WIDTH$), .COUNT_WIDTH($COUNT_WIDTH$), .DATA_LOGFILE("$DATA_LOGFILE$")) fifo (
 		.clk(ap_clk), .rst(!ap_rst_n),
 		.idat(in0_V_TDATA), .ivld(in0_V_TVALID), .irdy(in0_V_TREADY),
 		.odat(out0_V_TDATA), .ovld(out0_V_TVALID), .ordy(out0_V_TREADY),

--- a/finn-rtllib/fifo/hdl/fifo_template.v
+++ b/finn-rtllib/fifo/hdl/fifo_template.v
@@ -52,7 +52,7 @@ output  $OUT_RANGE$ out0_V_TDATA
 );
 
 `ifdef FINN_SIMULATION
-	fifo_gauge #(.WIDTH($WIDTH$), .COUNT_WIDTH($COUNT_WIDTH$), .DATA_LOGFILE("$DATA_LOGFILE$")) fifo (
+	fifo_gauge #(.WIDTH($WIDTH$), .COUNT_WIDTH($COUNT_WIDTH$), .DEBUG_LOG($DEBUG_LOG$)) fifo (
 		.clk(ap_clk), .rst(!ap_rst_n),
 		.idat(in0_V_TDATA), .ivld(in0_V_TVALID), .irdy(in0_V_TREADY),
 		.odat(out0_V_TDATA), .ovld(out0_V_TVALID), .ordy(out0_V_TREADY),

--- a/finn-rtllib/fifo/sim.sh
+++ b/finn-rtllib/fifo/sim.sh
@@ -1,11 +1,11 @@
-/****************************************************************************
- * Copyright Advanced Micro Devices, Inc.
- * SPDX-License-Identifier: BSD-3-Clause
- *
- * @brief	FIFO gauge simulation script.
- * @author	Thomas B. Preußer <thomas.preusser@amd.com>
- ***************************************************************************/
 #!/bin/bash
+##############################################################################
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# @brief	FIFO gauge simulation script.
+# @author	Thomas B. Preußer <thomas.preusser@amd.com>
+##############################################################################
 set -euo pipefail
 cd "$(dirname "$0")"
 
@@ -16,10 +16,10 @@ xelab fifo_gauge_tb -debug off -s sim
 xsim sim -runall
 
 echo "---"
-if diff -q fifo_ref.log fifo_trace.log; then
+if diff -q fifo_ref.log <(grep -v '^\[' fifo_trace.log); then
 	echo "PASS: trace matches reference ($(wc -l < fifo_ref.log) lines)"
 else
 	echo "FAIL: trace mismatch"
-	diff fifo_ref.log fifo_trace.log | head -20
+	diff fifo_ref.log fifo_trace_data.log | head -20
 	exit 1
 fi

--- a/finn-rtllib/fifo/sim.sh
+++ b/finn-rtllib/fifo/sim.sh
@@ -1,0 +1,25 @@
+/****************************************************************************
+ * Copyright Advanced Micro Devices, Inc.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * @brief	FIFO gauge simulation script.
+ * @author	Thomas B. Preußer <thomas.preusser@amd.com>
+ ***************************************************************************/
+#!/bin/bash
+set -euo pipefail
+cd "$(dirname "$0")"
+
+rm -f fifo_trace.log fifo_ref.log
+
+xvlog -sv hdl/fifo_gauge.sv hdl/fifo_gauge_tb.sv
+xelab fifo_gauge_tb -debug off -s sim
+xsim sim -runall
+
+echo "---"
+if diff -q fifo_ref.log fifo_trace.log; then
+	echo "PASS: trace matches reference ($(wc -l < fifo_ref.log) lines)"
+else
+	echo "FAIL: trace mismatch"
+	diff fifo_ref.log fifo_trace.log | head -20
+	exit 1
+fi

--- a/finn-rtllib/sim/hdl/sim_ctrl.v
+++ b/finn-rtllib/sim/hdl/sim_ctrl.v
@@ -1,0 +1,7 @@
+module sim_ctrl(input ap_clk, input sim_finish);
+	always @(posedge sim_finish) $finish;
+	// Workaround for XSI bug: final blocks execute prematurely when all
+	// initial blocks complete, rather than at $finish. This never-completing
+	// initial block prevents that.
+	initial forever #1_000_000_000 ;
+endmodule

--- a/finn-rtllib/sim/hdl/sim_ctrl.v
+++ b/finn-rtllib/sim/hdl/sim_ctrl.v
@@ -1,5 +1,4 @@
-module sim_ctrl(input ap_clk, input sim_finish, output sim_ctrl_out);
-	assign sim_ctrl_out = 1'b0;
+module sim_ctrl(input ap_clk, input sim_finish);
 `ifdef FINN_SIMULATION
 	always @(posedge sim_finish) $finish;
 	// This ensures there is always a pending #delay in the event queue,

--- a/finn-rtllib/sim/hdl/sim_ctrl.v
+++ b/finn-rtllib/sim/hdl/sim_ctrl.v
@@ -2,9 +2,8 @@ module sim_ctrl(input ap_clk, input sim_finish, output sim_ctrl_out);
 	assign sim_ctrl_out = 1'b0;
 `ifdef FINN_SIMULATION
 	always @(posedge sim_finish) $finish;
-	// Workaround for XSI bug: final blocks execute prematurely when all
-	// initial blocks complete, rather than at $finish. This never-completing
-	// initial block prevents that.
-	initial forever #1;
+	// This ensures there is always a pending #delay in the event queue, 
+        // preventing the kernel from concluding that the simulation is ending.
+	initial forever #1_000_000_000;
 `endif
 endmodule

--- a/finn-rtllib/sim/hdl/sim_ctrl.v
+++ b/finn-rtllib/sim/hdl/sim_ctrl.v
@@ -1,6 +1,13 @@
+/****************************************************************************
+ * Copyright Advanced Micro Devices, Inc.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * @brief	Simulation control triggering $finish upon asserting sim_finish.
+ * @author	Shane T. Fleming <shane.fleming@amd.com>
+ ***************************************************************************/
 module sim_ctrl(input ap_clk, input sim_finish);
 `ifdef FINN_SIMULATION
-	always @(posedge sim_finish) $finish;
+	initial @(posedge sim_finish) $finish;
 	// This ensures there is always a pending #delay in the event queue,
 	// preventing the kernel from concluding that the simulation is ending.
 	initial forever #1_000_000_000;

--- a/finn-rtllib/sim/hdl/sim_ctrl.v
+++ b/finn-rtllib/sim/hdl/sim_ctrl.v
@@ -1,7 +1,10 @@
-module sim_ctrl(input ap_clk, input sim_finish);
+module sim_ctrl(input ap_clk, input sim_finish, output sim_ctrl_out);
+	assign sim_ctrl_out = 1'b0;
+`ifdef FINN_SIMULATION
 	always @(posedge sim_finish) $finish;
 	// Workaround for XSI bug: final blocks execute prematurely when all
 	// initial blocks complete, rather than at $finish. This never-completing
 	// initial block prevents that.
-	initial forever #1_000_000_000 ;
+	initial forever #1;
+`endif
 endmodule

--- a/finn-rtllib/sim/hdl/sim_ctrl.v
+++ b/finn-rtllib/sim/hdl/sim_ctrl.v
@@ -5,7 +5,12 @@
  * @brief	Simulation control triggering $finish upon asserting sim_finish.
  * @author	Shane T. Fleming <shane.fleming@amd.com>
  ***************************************************************************/
-module sim_ctrl(input ap_clk, input sim_finish);
+module sim_ctrl(input ap_clk, input sim_finish, output sim_ctrl_out);
+	// DO NOT REMOVE: This output prevents the module from being empty during
+	// synthesis. Vivado's hierarchical checkpoint stitching fails on empty
+	// modules (reads the checkpoint twice, causing "Failed to stitch checkpoint"
+	// errors). The output is unused but must remain to produce a non-empty netlist.
+	assign sim_ctrl_out = 1'b0;
 `ifdef FINN_SIMULATION
 	initial @(posedge sim_finish) $finish;
 	// This ensures there is always a pending #delay in the event queue,

--- a/finn-rtllib/sim/hdl/sim_ctrl.v
+++ b/finn-rtllib/sim/hdl/sim_ctrl.v
@@ -2,8 +2,8 @@ module sim_ctrl(input ap_clk, input sim_finish, output sim_ctrl_out);
 	assign sim_ctrl_out = 1'b0;
 `ifdef FINN_SIMULATION
 	always @(posedge sim_finish) $finish;
-	// This ensures there is always a pending #delay in the event queue, 
-        // preventing the kernel from concluding that the simulation is ending.
+	// This ensures there is always a pending #delay in the event queue,
+	// preventing the kernel from concluding that the simulation is ending.
 	initial forever #1_000_000_000;
 `endif
 endmodule

--- a/finn_xsi/finn_xsi/adapter.py
+++ b/finn_xsi/finn_xsi/adapter.py
@@ -157,6 +157,10 @@ def reset_rtlsim(
 
 
 def close_rtlsim(sim):
+    sim_finish = sim.top.getPort("sim_finish")
+    if sim_finish is not None:
+        sim_finish.set(1).write_back()
+        sim.cycle({})
     del sim
 
 

--- a/finn_xsi/finn_xsi/sim_engine.py
+++ b/finn_xsi/finn_xsi/sim_engine.py
@@ -24,30 +24,28 @@ class SimEngine:
             if p.isInput():
                 p.clear().write_back()
 
-        def cycle(updates):
-            # Rising Edge
-            clk.set(1).write_back()
+        # Match C++ driver structure: separate half_cycle calls with run(5) each
+        def half_cycle(up):
+            """Single half-cycle matching C++ driver behavior."""
+            clk.set(up).write_back()
             if clk2x is not None:
                 clk2x.set(1).write_back()
-            # Updates after Active Edge
-            top.run(1)
+                top.run(5)
+                clk2x.set(0).write_back()
+                top.run(5)
+            else:
+                top.run(5)
+
+        def cycle(updates):
+            # Clock down - matches C++ cycle(0)
+            half_cycle(0)
+
+            # Clock up - matches C++ cycle(1)
+            half_cycle(1)
+
+            # Write port updates after clock up (matching C++ structure)
             for port, update in updates.items():
                 port.set_hexstr(update).write_back()
-
-            # Edges inactive on interface & finish Cycle
-            if clk2x is None:
-                top.run(4999)
-                clk.set(0).write_back()
-                top.run(5000)
-            else:
-                top.run(2499)
-                clk2x.set(0).write_back()
-                top.run(2500)
-                clk.set(0).write_back()
-                clk2x.set(1).write_back()
-                top.run(2500)
-                clk2x.set(0).write_back()
-                top.run(2500)
 
         self.top = top
         self.cycle = cycle

--- a/finn_xsi/finn_xsi/sim_engine.py
+++ b/finn_xsi/finn_xsi/sim_engine.py
@@ -24,28 +24,21 @@ class SimEngine:
             if p.isInput():
                 p.clear().write_back()
 
-        # Match C++ driver structure: separate half_cycle calls with run(5) each
         def half_cycle(up):
-            """Single half-cycle matching C++ driver behavior."""
             clk.set(up).write_back()
             if clk2x is not None:
                 clk2x.set(1).write_back()
-                top.run(5)
+                top.run(25)
                 clk2x.set(0).write_back()
-                top.run(5)
+                top.run(25)
             else:
-                top.run(5)
+                top.run(50)
 
         def cycle(updates):
-            # Clock down - matches C++ cycle(0)
-            half_cycle(0)
-
-            # Clock up - matches C++ cycle(1)
             half_cycle(1)
-
-            # Write port updates after clock up (matching C++ structure)
             for port, update in updates.items():
                 port.set_hexstr(update).write_back()
+            half_cycle(0)
 
         self.top = top
         self.cycle = cycle

--- a/finn_xsi/rtlsim_xsi.cpp
+++ b/finn_xsi/rtlsim_xsi.cpp
@@ -14,6 +14,7 @@
 #include <sstream>
 #include <fstream>
 #include <chrono>
+#include <map>
 #include <vector>
 #include <tuple>
 #include <functional>
@@ -34,6 +35,7 @@ int main(int argc, char *argv[]) {
 
 	// Ultimate Simulation Summary
 	std::string  synopsis;
+	std::map<std::string, unsigned>  maxcounts;
 
 	{ // RTL Simulation
 
@@ -245,6 +247,27 @@ int main(int argc, char *argv[]) {
 			"RUNTIME_S\t" << std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now() - begin).count();
 		synopsis = bld.str();
 
+		// Read maxcount ports before $finish tears down the design
+		for(Port &p : top.ports()) {
+			if(p.isOutput()) {
+				char const *const  name = p.name();
+				if(std::strncmp(name, "maxcount", 8) == 0) {
+					p.read();
+					maxcounts[name] = p.as_unsigned();
+				}
+			}
+		}
+
+		// Trigger $finish via sim_finish port so that final blocks execute
+		{
+			Port *const  sim_finish = top.getPort("sim_finish");
+			if(sim_finish) {
+				sim_finish->set(1).write_back();
+				cycle(0);
+				cycle(1);
+			}
+		}
+
 	} // done simulation
 
 	// Dump Simulation Statistics to stdout and results.txt
@@ -258,14 +281,8 @@ int main(int argc, char *argv[]) {
 	{ // Synopsis and `max_count` readings to results file
 		std::ofstream  results_file("results.txt", std::ios::out | std::ios::trunc);
 		results_file << synopsis << std::endl;
-		for(Port &p : top.ports()) {
-			if(p.isOutput()) {
-				char const *const  name = p.name();
-				if(std::strncmp(name, "maxcount", 8) == 0) {
-					p.read();
-					results_file << name << '\t' << p.as_unsigned() << std::endl;
-				}
-			}
+		for(auto const &[name, val] : maxcounts) {
+			results_file << name << '\t' << val << std::endl;
 		}
 	}
 

--- a/finn_xsi/rtlsim_xsi.cpp
+++ b/finn_xsi/rtlsim_xsi.cpp
@@ -21,7 +21,7 @@
 #include "xsi_finn.hpp"
 #include "rtlsim_config.hpp"
 
-int main(int argc, char *argv[]) {
+int main(int const  argc, char const *const  argv[]) {
 
 	// Load Kernel and Design
 	xsi::Kernel  kernel(kernel_libname);
@@ -54,11 +54,11 @@ int main(int argc, char *argv[]) {
 			size_t  job_size;
 			size_t  job_txns;  // [0:job_size]
 			size_t  total_txns;
-			size_t  first_complete; // First completion timestamp
 
 			union {
 				// Input Stream
 				struct {
+					size_t  first_complete; // First completion timestamp
 					size_t  job_ticks;      // throttle if job_size < job_ticks
 					size_t  await_iter;     // iteration allowing start of next job
 				};
@@ -94,7 +94,8 @@ int main(int argc, char *argv[]) {
 		}
 
 		// Find Global Control & Run Startup Sequence
-		std::function<void(bool)>  cycle;
+		std::function<void(std::vector<std::reference_wrapper<Port>>&)>  cycle;
+		std::vector<std::reference_wrapper<Port>>  to_write;
 		{
 			Port *const  clk   = top.getPort("ap_clk");
 			Port *const  clk2x = top.getPort("ap_clk2x");
@@ -103,24 +104,30 @@ int main(int argc, char *argv[]) {
 				std::cerr << "No clock found on the design." << std::endl;
 				return  1;
 			}
-			cycle = clk2x?
-				std::function<void(bool)>([&top, clk, clk2x](bool const  up) mutable {
+			cycle = [half = clk2x?
+				std::function<void(bool)>([&top, clk, clk2x](bool const  up) {
 					clk->set(up).write_back();
 					clk2x->set(1).write_back();
-					top.run(5);
+					top.run(25);
 					clk2x->set(0).write_back();
-					top.run(5);
+					top.run(25);
 				}) :
-				std::function<void(bool)>([&top, clk](bool const  up) mutable {
+				std::function<void(bool)>([&top, clk](bool const  up) {
 					clk->set(up).write_back();
-					top.run(5);
-				});
+					top.run(50);
+				})
+			](std::vector<std::reference_wrapper<Port>> &to_write) {
+				half(1);
+				for(Port &p : to_write)  p.write_back();
+				to_write.clear();
+				half(0);
+			};
 
 			// Reset all Inputs, Wait for Reset Period
 			for(Port &p : top.ports()) { if(p.isInput())  p.clear().write_back(); };
 			if(rst_n) {
-				for(unsigned  i = 0; i < 16; i++) { cycle(0); cycle(1); }
-				rst_n->set(1).write_back();
+				for(unsigned  i = 0; i < 16; i++)  cycle(to_write);
+				to_write.emplace_back(rst_n->set(1));
 			}
 		}
 
@@ -128,17 +135,13 @@ int main(int argc, char *argv[]) {
 		std::cout << "Starting data feed with idle-output timeout of " << max_iters << " cycles ...\n" << std::endl;
 
 		// Make all Inputs valid & all Outputs ready
-		for(auto &s : istreams)  s.port_vld.set(1).write_back();
-		for(auto &s : ostreams)  s.port_rdy.set(1).write_back();
+		for(auto &s : istreams)  to_write.emplace_back(s.port_vld.set(1));
+		for(auto &s : ostreams)  to_write.emplace_back(s.port_rdy.set(1));
+		cycle(to_write);  // flush & settle before first read
 
 		// Enter Simulation Loop and track Progress
 		auto const  begin = std::chrono::steady_clock::now();
-		std::vector<std::reference_wrapper<Port>>  to_write;
 		while(true) {
-
-			//-------------------------------------------------------------------
-			// Clock down - then read signal updates from design
-			cycle(0);
 
 			// check for transactions on input streams
 			for(auto &s : istreams) {
@@ -146,7 +149,7 @@ int main(int argc, char *argv[]) {
 				bool const  rdy = s.port_rdy.read()[0];
 				if(vld && !rdy)  continue;
 
-				// Track successgul Transactions
+				// Track successful Transactions
 				if(vld) {
 					s.job_txns++;
 					if(++s.total_txns == s.job_size * n_inferences)  itodo--;
@@ -194,12 +197,8 @@ int main(int argc, char *argv[]) {
 			}
 
 			//-------------------------------------------------------------------
-			// Clock up - then write signal updates back to design
-			cycle(1);
-
-			// Write back Ports with registered updates
-			for(Port &p : to_write)  p.write_back();
-			to_write.clear();
+			// Advance clock: rise, write back, fall
+			cycle(to_write);
 
 			// Show a progress message once in a while
 			if(++iters % 10000 == 0) {

--- a/finn_xsi/rtlsim_xsi.cpp
+++ b/finn_xsi/rtlsim_xsi.cpp
@@ -257,21 +257,21 @@ int main(int const  argc, char const *const  argv[]) {
 			}
 		}
 
-		// Trigger $finish via sim_finish port so that final blocks execute
-		{
-			Port *const  sim_finish = top.getPort("sim_finish");
-			if(sim_finish) {
-				to_write.emplace_back(sim_finish->set(1));
-				cycle(to_write);
-			}
-		}
-
 	} // done simulation
 
 	// Dump Simulation Statistics to stdout and results.txt
 	std::cout << '\n' << synopsis << std::endl;
 
-	{ // Log error info to file
+	// Trigger $finish so that final blocks execute
+	{
+		Port *const  sim_finish = top.getPort("sim_finish");
+		if(sim_finish) {
+			sim_finish->set(1).write_back();
+			top.run(1);
+		}
+	}
+
+	{ // Log error info to file (includes final block output)
 		std::ofstream  error_file("fifosim.err", std::ios::out | std::ios::trunc);
 		error_file << top.get_error_info();
 	}

--- a/finn_xsi/rtlsim_xsi.cpp
+++ b/finn_xsi/rtlsim_xsi.cpp
@@ -261,9 +261,8 @@ int main(int const  argc, char const *const  argv[]) {
 		{
 			Port *const  sim_finish = top.getPort("sim_finish");
 			if(sim_finish) {
-				sim_finish->set(1).write_back();
-				cycle(0);
-				cycle(1);
+				to_write.emplace_back(sim_finish->set(1));
+				cycle(to_write);
 			}
 		}
 

--- a/src/finn/analysis/fpgadataflow/fifo_transaction_counts.py
+++ b/src/finn/analysis/fpgadataflow/fifo_transaction_counts.py
@@ -47,9 +47,7 @@ def _count(model, apply_to_subgraphs):
         for node in model.graph.node:
             # FINNLoop re-streams its body once per iteration; generic subgraphs run once
             multiplier = (
-                getCustomOp(node).get_nodeattr("iteration")
-                if node.op_type == "FINNLoop"
-                else 1
+                getCustomOp(node).get_nodeattr("iteration") if node.op_type == "FINNLoop" else 1
             )
             for attr in node.attribute:
                 if attr.type == onnx.AttributeProto.GRAPH:

--- a/src/finn/analysis/fpgadataflow/fifo_transaction_counts.py
+++ b/src/finn/analysis/fpgadataflow/fifo_transaction_counts.py
@@ -1,0 +1,59 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import numpy as np
+import onnx
+from qonnx.custom_op.registry import getCustomOp
+
+
+def _has_fifos(model):
+    if any(n.op_type.startswith("StreamingFIFO") for n in model.graph.node):
+        return True
+    for node in model.graph.node:
+        for attr in node.attribute:
+            if attr.type == onnx.AttributeProto.GRAPH:
+                if _has_fifos(model.make_subgraph_modelwrapper(attr.g)):
+                    return True
+    return False
+
+
+def fifo_transaction_counts(model, apply_to_subgraphs=False):
+    """Return the expected number of stream transactions each FIFO should carry.
+
+    Requires a model that already has FIFOs inserted. Returns a dict mapping FIFO
+    name -> expected transaction count, where the count is the per-frame
+    transaction count (np.prod(folded_shape[:-1])) multiplied by the iteration
+    count of any enclosing FINNLoop.
+
+    With apply_to_subgraphs=True the pass descends into subgraphs (e.g. FINNLoop
+    bodies). FIFOs are keyed by their node name directly (body FIFOs should already
+    be uniquely named via GiveUniqueNodeNames with the FINNLoop prefix).
+    """
+    assert _has_fifos(model), (
+        "fifo_transaction_counts requires a model with FIFOs inserted "
+        "(run InsertFIFO / set_fifo_depths first)"
+    )
+    return _count(model, apply_to_subgraphs)
+
+
+def _count(model, apply_to_subgraphs):
+    ret = {}
+    for node in model.graph.node:
+        if node.op_type.startswith("StreamingFIFO"):
+            folded_shape = getCustomOp(node).get_nodeattr("folded_shape")
+            per_frame = int(np.prod(folded_shape[:-1])) if len(folded_shape) > 1 else 1
+            ret[node.name] = per_frame
+    if apply_to_subgraphs:
+        for node in model.graph.node:
+            # FINNLoop re-streams its body once per iteration; generic subgraphs run once
+            multiplier = (
+                getCustomOp(node).get_nodeattr("iteration")
+                if node.op_type == "FINNLoop"
+                else 1
+            )
+            for attr in node.attribute:
+                if attr.type == onnx.AttributeProto.GRAPH:
+                    subgraph = model.make_subgraph_modelwrapper(attr.g)
+                    for k, v in _count(subgraph, apply_to_subgraphs=True).items():
+                        ret[k] = v * multiplier
+    return ret

--- a/src/finn/builder/build_dataflow.py
+++ b/src/finn/builder/build_dataflow.py
@@ -45,7 +45,10 @@ from finn.builder.build_dataflow_config import (
     DataflowBuildConfig,
     default_build_dataflow_steps,
 )
-from finn.builder.build_dataflow_steps import _maybe_enable_verify_behavioral, build_dataflow_step_lookup
+from finn.builder.build_dataflow_steps import (
+    _maybe_enable_verify_behavioral,
+    build_dataflow_step_lookup,
+)
 
 
 # adapted from https://stackoverflow.com/a/39215961

--- a/src/finn/builder/build_dataflow.py
+++ b/src/finn/builder/build_dataflow.py
@@ -45,7 +45,7 @@ from finn.builder.build_dataflow_config import (
     DataflowBuildConfig,
     default_build_dataflow_steps,
 )
-from finn.builder.build_dataflow_steps import build_dataflow_step_lookup
+from finn.builder.build_dataflow_steps import _maybe_enable_verify_behavioral, build_dataflow_step_lookup
 
 
 # adapted from https://stackoverflow.com/a/39215961
@@ -133,6 +133,8 @@ def build_dataflow_cfg(model_filename, cfg: DataflowBuildConfig):
     # create the output dir if it doesn't exist
     if not os.path.exists(cfg.output_dir):
         os.makedirs(cfg.output_dir)
+
+    _maybe_enable_verify_behavioral(cfg)
 
     # Run configuration checks
     config_report = run_all_config_checks(cfg)

--- a/src/finn/builder/build_dataflow_config.py
+++ b/src/finn/builder/build_dataflow_config.py
@@ -303,8 +303,10 @@ class DataflowBuildConfig:
     #: Default is 2
     fifosim_n_inferences: Optional[int] = 2
 
-    #: Enable saving waveforms from simulation-based FIFO sizing
-    #: Only relevant if auto_fifo_strategy = LARGEFIFO_RTLSIM
+    #: Enable saving waveforms from simulation-based FIFO sizing.
+    #: Applies to the LARGEFIFO_RTLSIM strategy as well as the characterize
+    #: strategy (used for MLO/FINNLoop models), where it traces the per-node
+    #: characterization simulations.
     fifosim_save_waveform: Optional[bool] = False
 
     debug_fifo: Optional[bool] = False

--- a/src/finn/builder/build_dataflow_config.py
+++ b/src/finn/builder/build_dataflow_config.py
@@ -382,6 +382,13 @@ class DataflowBuildConfig:
     #: rtlsim, otherwise they will be replaced by RTL implementations.
     rtlsim_use_vivado_comps: Optional[bool] = True
 
+    #: Use behavioral simulation for RTLSim verification steps.
+    #: When True, passes -define FINN_SIMULATION to xelab, enabling faster
+    #: behavioral models for DSP-heavy modules (MVU, LayerNorm, Elementwise)
+    #: and fifo_gauge (with debug capabilities) instead of Q_srl.
+    #: Does not affect FIFO sizing which always uses behavioral simulation.
+    verify_rtlsim_behavioral: Optional[bool] = False
+
     #: If set to True, the FINN compiler tries to create an MLO design based on
     #: loop_body_hierarchy and loop_body_range
     mlo: Optional[bool] = False

--- a/src/finn/builder/build_dataflow_config.py
+++ b/src/finn/builder/build_dataflow_config.py
@@ -307,6 +307,8 @@ class DataflowBuildConfig:
     #: Only relevant if auto_fifo_strategy = LARGEFIFO_RTLSIM
     fifosim_save_waveform: Optional[bool] = False
 
+    debug_fifo: Optional[bool] = False
+
     #: Target clock frequency (in nanoseconds) for Vitis HLS synthesis.
     #: e.g. `hls_clk_period_ns=5.0` will target a 200 MHz clock.
     #: If not specified it will default to synth_clk_period_ns

--- a/src/finn/builder/build_dataflow_steps.py
+++ b/src/finn/builder/build_dataflow_steps.py
@@ -143,10 +143,6 @@ from finn.util.test import execute_parent
 from finn.util.vivado import parse_ooc_synth_results
 
 
-def _fifo_debug_dir(cfg):
-    return cfg.output_dir + "/debug/fifo_logs"
-
-
 def _maybe_enable_verify_behavioral(cfg):
     if cfg.debug_fifo and not cfg.verify_rtlsim_behavioral:
         print(
@@ -154,33 +150,6 @@ def _maybe_enable_verify_behavioral(cfg):
             "the verify phase uses fifo_gauge and produces per-FIFO logs."
         )
         cfg.verify_rtlsim_behavioral = True
-
-
-def _retarget_fifo_log_paths(model, cfg):
-    if not cfg.debug_fifo:
-        return model
-    dbg_dir = _fifo_debug_dir(cfg)
-    os.makedirs(dbg_dir, exist_ok=True)
-    for node in model.get_nodes_by_op_type("StreamingFIFO_rtl"):
-        inst = getCustomOp(node)
-        old_path = inst.get_nodeattr("debug_log_path")
-        new_path = os.path.abspath(os.path.join(dbg_dir, node.name + ".log"))
-        if old_path and old_path != new_path and os.path.isfile(old_path):
-            os.rename(old_path, new_path)
-        inst.set_nodeattr("debug_log_path", new_path)
-    return model
-
-
-def mark_fifo_debug_phase(cfg, phase_name):
-    if not cfg.debug_fifo:
-        return
-    dbg_dir = _fifo_debug_dir(cfg)
-    os.makedirs(dbg_dir, exist_ok=True)
-    for fn in os.listdir(dbg_dir):
-        if not fn.endswith(".log"):
-            continue
-        with open(os.path.join(dbg_dir, fn), "a") as f:
-            f.write(f"=== phase: {phase_name} ===\n")
 
 
 def verify_step(
@@ -350,14 +319,13 @@ def prepare_loop_ops_fifo_sizing(node, cfg):
             swg_exception=cfg.default_swg_exception,
             vivado_ram_style=cfg.large_fifo_mem_style,
             fifosim_input_throttle=cfg.fifosim_input_throttle,
-            debug_log_dir=(_fifo_debug_dir(cfg) if cfg.debug_fifo else None),
+            debug_log=cfg.debug_fifo,
         )
     )
     loop_model = loop_model.transform(SplitLargeFIFOs())
     loop_model = loop_model.transform(RemoveShallowFIFOs())
     loop_model = loop_model.transform(GiveUniqueNodeNames(prefix=node.name + "_"))
     loop_model = loop_model.transform(GiveReadableTensorNames())
-    loop_model = _retarget_fifo_log_paths(loop_model, cfg)
     node_inst.set_nodeattr("body", loop_model.graph)
 
 
@@ -1012,7 +980,6 @@ def step_set_fifo_depths(model: ModelWrapper, cfg: DataflowBuildConfig):
                 model.set_metadata_prop(
                     "rtlsim_trace", os.path.abspath(report_dir) + "/fifosim_trace.wdb"
                 )
-            mark_fifo_debug_phase(cfg, "fifo_sizing")
             model = model.transform(
                 InsertAndSetFIFODepths(
                     cfg._resolve_fpga_part(),
@@ -1021,7 +988,7 @@ def step_set_fifo_depths(model: ModelWrapper, cfg: DataflowBuildConfig):
                     vivado_ram_style=cfg.large_fifo_mem_style,
                     fifosim_input_throttle=cfg.fifosim_input_throttle,
                     cfg_n_inferences=cfg.fifosim_n_inferences,
-                    debug_log_dir=(_fifo_debug_dir(cfg) if cfg.debug_fifo else None),
+                    debug_log=cfg.debug_fifo,
                 )
             )
             model = model.transform(GiveUniqueNodeNames())
@@ -1153,7 +1120,6 @@ def step_create_stitched_ip(model: ModelWrapper, cfg: DataflowBuildConfig):
             # prepare ip-stitched rtlsim
             verify_model = deepcopy(model)
             verify_model = prepare_for_stitched_ip_rtlsim(verify_model, cfg)
-            mark_fifo_debug_phase(cfg, "verify_stitched_ip_rtlsim")
             # use critical path estimate to set rtlsim liveness threshold
             # (very conservative)
             verify_model = verify_model.transform(AnnotateCycles())
@@ -1207,7 +1173,6 @@ def step_measure_rtlsim_performance(model: ModelWrapper, cfg: DataflowBuildConfi
         # Use behav=False for performance measurement to use real RTL components
         # instead of behavioral models (FINN_SIMULATION affects FIFOs, MVU, LayerNorm,
         # and RTL elementwise ops)
-        mark_fifo_debug_phase(cfg, "rtlsim_perf")
         rtlsim_perf_dict = xsi_fifosim(model, rtlsim_bs, max_iters=max_iters, behav=False)
         # keep keys consistent between the Python and C++-styles
         cycles = rtlsim_perf_dict["cycles"]

--- a/src/finn/builder/build_dataflow_steps.py
+++ b/src/finn/builder/build_dataflow_steps.py
@@ -907,7 +907,7 @@ def step_hw_ipgen(model: ModelWrapper, cfg: DataflowBuildConfig):
                 for node in model.graph.node:
                     node_inst = getCustomOp(node)
                     node_inst.set_nodeattr("rtlsim_trace", f"{abspath}/{node.name}_rtlsim.wdb")
-            model = model.transform(PrepareRTLSim())
+            model = model.transform(PrepareRTLSim(behav=cfg.verify_rtlsim_behavioral))
             model = model.transform(SetExecMode("rtlsim"))
             verify_step(model, cfg, "node_by_node_rtlsim", need_parent=True)
             # Clear rtlsim_trace attributes to prevent later simulations from
@@ -1123,6 +1123,8 @@ def step_create_stitched_ip(model: ModelWrapper, cfg: DataflowBuildConfig):
                 os.makedirs(waveform_dir, exist_ok=True)
                 abspath = os.path.abspath(waveform_dir)
                 verify_model.set_metadata_prop("rtlsim_trace", abspath + "/verify_rtlsim.wdb")
+            if cfg.verify_rtlsim_behavioral:
+                verify_model.set_metadata_prop("rtlsim_behavioral", "1")
             if is_mlo(model):
                 verify_mlo(verify_model, cfg, "stitched_ip_rtlsim")
             else:

--- a/src/finn/builder/build_dataflow_steps.py
+++ b/src/finn/builder/build_dataflow_steps.py
@@ -143,6 +143,37 @@ from finn.util.test import execute_parent
 from finn.util.vivado import parse_ooc_synth_results
 
 
+def _fifo_debug_live_dir(cfg):
+    return cfg.output_dir + "/debug/_live"
+
+
+def _maybe_enable_verify_behavioral(cfg):
+    if cfg.debug_fifo and not cfg.verify_rtlsim_behavioral:
+        print(
+            "[debug_fifo] forcing verify_rtlsim_behavioral=True so that "
+            "the verify phase uses fifo_gauge and produces per-FIFO logs."
+        )
+        cfg.verify_rtlsim_behavioral = True
+
+
+def snapshot_fifo_logs(cfg, phase_subdir):
+    if not cfg.debug_fifo:
+        return
+    live_dir = _fifo_debug_live_dir(cfg)
+    if not os.path.isdir(live_dir):
+        return
+    dest_dir = cfg.output_dir + "/debug/" + phase_subdir
+    os.makedirs(dest_dir, exist_ok=True)
+    for fn in os.listdir(live_dir):
+        if not fn.endswith(".log"):
+            continue
+        src = os.path.join(live_dir, fn)
+        if not os.path.isfile(src) or os.path.getsize(src) == 0:
+            continue
+        shutil.copyfile(src, os.path.join(dest_dir, fn))
+        open(src, "w").close()
+
+
 def verify_step(
     model: ModelWrapper,
     cfg: DataflowBuildConfig,
@@ -310,6 +341,7 @@ def prepare_loop_ops_fifo_sizing(node, cfg):
             swg_exception=cfg.default_swg_exception,
             vivado_ram_style=cfg.large_fifo_mem_style,
             fifosim_input_throttle=cfg.fifosim_input_throttle,
+            debug_log_dir=(_fifo_debug_live_dir(cfg) if cfg.debug_fifo else None),
         )
     )
     loop_model = loop_model.transform(SplitLargeFIFOs())
@@ -850,6 +882,13 @@ def step_hw_codegen(model: ModelWrapper, cfg: DataflowBuildConfig):
     loop_nodes = model.get_nodes_by_op_type("FINNLoop")
     for node in loop_nodes:
         prepare_loop_ops_fifo_sizing(node, cfg)
+    snapshot_fifo_logs(cfg, "fifo_sizing")
+    if cfg.debug_fifo:
+        for loop_node in loop_nodes:
+            body_model = getCustomOp(loop_node).get_nodeattr("body")
+            for fifo_node in body_model.get_nodes_by_op_type("StreamingFIFO_rtl"):
+                getCustomOp(fifo_node).set_nodeattr("debug_log_path", "")
+            getCustomOp(loop_node).set_nodeattr("body", body_model.graph)
     model = model.transform(
         PrepareIP(cfg._resolve_fpga_part(), cfg._resolve_hls_clk_period()),
         apply_to_subgraphs=True,
@@ -978,6 +1017,7 @@ def step_set_fifo_depths(model: ModelWrapper, cfg: DataflowBuildConfig):
                     vivado_ram_style=cfg.large_fifo_mem_style,
                     fifosim_input_throttle=cfg.fifosim_input_throttle,
                     cfg_n_inferences=cfg.fifosim_n_inferences,
+                    debug_log_dir=(_fifo_debug_live_dir(cfg) if cfg.debug_fifo else None),
                 )
             )
             model = model.transform(GiveUniqueNodeNames())
@@ -1043,6 +1083,7 @@ def step_set_fifo_depths(model: ModelWrapper, cfg: DataflowBuildConfig):
     # this will only run for the new nodes (e.g. FIFOs and DWCs)
     model = model.transform(PrepareIP(cfg._resolve_fpga_part(), cfg._resolve_hls_clk_period()))
     model = model.transform(HLSSynthIP(cfg._resolve_fpga_part()))
+    snapshot_fifo_logs(cfg, "fifo_sizing")
     return model
 
 
@@ -1130,6 +1171,7 @@ def step_create_stitched_ip(model: ModelWrapper, cfg: DataflowBuildConfig):
             else:
                 verify_step(verify_model, cfg, "stitched_ip_rtlsim", need_parent=True)
             os.environ["LIVENESS_THRESHOLD"] = str(prev_liveness)
+            snapshot_fifo_logs(cfg, "verify_stitched_ip_rtlsim")
     return model
 
 
@@ -1190,6 +1232,7 @@ def step_measure_rtlsim_performance(model: ModelWrapper, cfg: DataflowBuildConfi
         if cfg.verify_save_rtlsim_waveforms:
             # restore original trace depth
             os.environ["RTLSIM_TRACE_DEPTH"] = str(orig_rtlsim_trace_depth)
+        snapshot_fifo_logs(cfg, "rtlsim_perf")
 
     else:
         print(

--- a/src/finn/builder/build_dataflow_steps.py
+++ b/src/finn/builder/build_dataflow_steps.py
@@ -143,8 +143,8 @@ from finn.util.test import execute_parent
 from finn.util.vivado import parse_ooc_synth_results
 
 
-def _fifo_debug_live_dir(cfg):
-    return cfg.output_dir + "/debug/_live"
+def _fifo_debug_dir(cfg):
+    return cfg.output_dir + "/debug/fifo_logs"
 
 
 def _maybe_enable_verify_behavioral(cfg):
@@ -156,23 +156,31 @@ def _maybe_enable_verify_behavioral(cfg):
         cfg.verify_rtlsim_behavioral = True
 
 
-def snapshot_fifo_logs(cfg, phase_subdir):
+def _retarget_fifo_log_paths(model, cfg):
+    if not cfg.debug_fifo:
+        return model
+    dbg_dir = _fifo_debug_dir(cfg)
+    os.makedirs(dbg_dir, exist_ok=True)
+    for node in model.get_nodes_by_op_type("StreamingFIFO_rtl"):
+        inst = getCustomOp(node)
+        old_path = inst.get_nodeattr("debug_log_path")
+        new_path = os.path.abspath(os.path.join(dbg_dir, node.name + ".log"))
+        if old_path and old_path != new_path and os.path.isfile(old_path):
+            os.rename(old_path, new_path)
+        inst.set_nodeattr("debug_log_path", new_path)
+    return model
+
+
+def mark_fifo_debug_phase(cfg, phase_name):
     if not cfg.debug_fifo:
         return
-    live_dir = _fifo_debug_live_dir(cfg)
-    if not os.path.isdir(live_dir):
-        return
-    dest_dir = cfg.output_dir + "/debug/" + phase_subdir
-    os.makedirs(dest_dir, exist_ok=True)
-    for fn in os.listdir(live_dir):
+    dbg_dir = _fifo_debug_dir(cfg)
+    os.makedirs(dbg_dir, exist_ok=True)
+    for fn in os.listdir(dbg_dir):
         if not fn.endswith(".log"):
             continue
-        src = os.path.join(live_dir, fn)
-        if not os.path.isfile(src) or os.path.getsize(src) == 0:
-            continue
-        shutil.copyfile(src, os.path.join(dest_dir, fn))
-    # Delete _live folder to ensure clean state for next simulation
-    shutil.rmtree(live_dir)
+        with open(os.path.join(dbg_dir, fn), "a") as f:
+            f.write(f"=== phase: {phase_name} ===\n")
 
 
 def verify_step(
@@ -342,13 +350,14 @@ def prepare_loop_ops_fifo_sizing(node, cfg):
             swg_exception=cfg.default_swg_exception,
             vivado_ram_style=cfg.large_fifo_mem_style,
             fifosim_input_throttle=cfg.fifosim_input_throttle,
-            debug_log_dir=(_fifo_debug_live_dir(cfg) if cfg.debug_fifo else None),
+            debug_log_dir=(_fifo_debug_dir(cfg) if cfg.debug_fifo else None),
         )
     )
     loop_model = loop_model.transform(SplitLargeFIFOs())
     loop_model = loop_model.transform(RemoveShallowFIFOs())
     loop_model = loop_model.transform(GiveUniqueNodeNames(prefix=node.name + "_"))
     loop_model = loop_model.transform(GiveReadableTensorNames())
+    loop_model = _retarget_fifo_log_paths(loop_model, cfg)
     node_inst.set_nodeattr("body", loop_model.graph)
 
 
@@ -883,13 +892,6 @@ def step_hw_codegen(model: ModelWrapper, cfg: DataflowBuildConfig):
     loop_nodes = model.get_nodes_by_op_type("FINNLoop")
     for node in loop_nodes:
         prepare_loop_ops_fifo_sizing(node, cfg)
-    snapshot_fifo_logs(cfg, "fifo_sizing")
-    if cfg.debug_fifo:
-        for loop_node in loop_nodes:
-            body_model = getCustomOp(loop_node).get_nodeattr("body")
-            for fifo_node in body_model.get_nodes_by_op_type("StreamingFIFO_rtl"):
-                getCustomOp(fifo_node).set_nodeattr("debug_log_path", "")
-            getCustomOp(loop_node).set_nodeattr("body", body_model.graph)
     model = model.transform(
         PrepareIP(cfg._resolve_fpga_part(), cfg._resolve_hls_clk_period()),
         apply_to_subgraphs=True,
@@ -1010,6 +1012,7 @@ def step_set_fifo_depths(model: ModelWrapper, cfg: DataflowBuildConfig):
                 model.set_metadata_prop(
                     "rtlsim_trace", os.path.abspath(report_dir) + "/fifosim_trace.wdb"
                 )
+            mark_fifo_debug_phase(cfg, "fifo_sizing")
             model = model.transform(
                 InsertAndSetFIFODepths(
                     cfg._resolve_fpga_part(),
@@ -1018,7 +1021,7 @@ def step_set_fifo_depths(model: ModelWrapper, cfg: DataflowBuildConfig):
                     vivado_ram_style=cfg.large_fifo_mem_style,
                     fifosim_input_throttle=cfg.fifosim_input_throttle,
                     cfg_n_inferences=cfg.fifosim_n_inferences,
-                    debug_log_dir=(_fifo_debug_live_dir(cfg) if cfg.debug_fifo else None),
+                    debug_log_dir=(_fifo_debug_dir(cfg) if cfg.debug_fifo else None),
                 )
             )
             model = model.transform(GiveUniqueNodeNames())
@@ -1084,7 +1087,6 @@ def step_set_fifo_depths(model: ModelWrapper, cfg: DataflowBuildConfig):
     # this will only run for the new nodes (e.g. FIFOs and DWCs)
     model = model.transform(PrepareIP(cfg._resolve_fpga_part(), cfg._resolve_hls_clk_period()))
     model = model.transform(HLSSynthIP(cfg._resolve_fpga_part()))
-    snapshot_fifo_logs(cfg, "fifo_sizing")
     return model
 
 
@@ -1151,9 +1153,7 @@ def step_create_stitched_ip(model: ModelWrapper, cfg: DataflowBuildConfig):
             # prepare ip-stitched rtlsim
             verify_model = deepcopy(model)
             verify_model = prepare_for_stitched_ip_rtlsim(verify_model, cfg)
-            # Ensure _live folder exists for debug_fifo logging
-            if cfg.debug_fifo:
-                os.makedirs(_fifo_debug_live_dir(cfg), exist_ok=True)
+            mark_fifo_debug_phase(cfg, "verify_stitched_ip_rtlsim")
             # use critical path estimate to set rtlsim liveness threshold
             # (very conservative)
             verify_model = verify_model.transform(AnnotateCycles())
@@ -1175,7 +1175,6 @@ def step_create_stitched_ip(model: ModelWrapper, cfg: DataflowBuildConfig):
             else:
                 verify_step(verify_model, cfg, "stitched_ip_rtlsim", need_parent=True)
             os.environ["LIVENESS_THRESHOLD"] = str(prev_liveness)
-            snapshot_fifo_logs(cfg, "verify_stitched_ip_rtlsim")
     return model
 
 
@@ -1208,6 +1207,7 @@ def step_measure_rtlsim_performance(model: ModelWrapper, cfg: DataflowBuildConfi
         # Use behav=False for performance measurement to use real RTL components
         # instead of behavioral models (FINN_SIMULATION affects FIFOs, MVU, LayerNorm,
         # and RTL elementwise ops)
+        mark_fifo_debug_phase(cfg, "rtlsim_perf")
         rtlsim_perf_dict = xsi_fifosim(model, rtlsim_bs, max_iters=max_iters, behav=False)
         # keep keys consistent between the Python and C++-styles
         cycles = rtlsim_perf_dict["cycles"]
@@ -1239,7 +1239,6 @@ def step_measure_rtlsim_performance(model: ModelWrapper, cfg: DataflowBuildConfi
         if cfg.verify_save_rtlsim_waveforms:
             # restore original trace depth
             os.environ["RTLSIM_TRACE_DEPTH"] = str(orig_rtlsim_trace_depth)
-        snapshot_fifo_logs(cfg, "rtlsim_perf")
 
     else:
         print(

--- a/src/finn/builder/build_dataflow_steps.py
+++ b/src/finn/builder/build_dataflow_steps.py
@@ -1205,7 +1205,10 @@ def step_measure_rtlsim_performance(model: ModelWrapper, cfg: DataflowBuildConfi
         perf = model.analysis(dataflow_performance)
         latency = perf["critical_path_cycles"]
         max_iters = latency * 1.1 + 50
-        rtlsim_perf_dict = xsi_fifosim(model, rtlsim_bs, max_iters=max_iters)
+        # Use behav=False for performance measurement to use real RTL components
+        # instead of behavioral models (FINN_SIMULATION affects FIFOs, MVU, LayerNorm,
+        # and RTL elementwise ops)
+        rtlsim_perf_dict = xsi_fifosim(model, rtlsim_bs, max_iters=max_iters, behav=False)
         # keep keys consistent between the Python and C++-styles
         cycles = rtlsim_perf_dict["cycles"]
         clk_ns = cfg.synth_clk_period_ns

--- a/src/finn/builder/build_dataflow_steps.py
+++ b/src/finn/builder/build_dataflow_steps.py
@@ -1003,9 +1003,22 @@ def step_set_fifo_depths(model: ModelWrapper, cfg: DataflowBuildConfig):
                     create_shallow_fifos=True,
                 )
             )
-            # Clean up characterization attributes after FIFO sizing
+            # Clean up characterization attributes after FIFO sizing. The
+            # io_chrc arrays are offloaded to sidecar .npy files referenced by
+            # the io_chrc_*_file attrs; unlink those files before dropping the
+            # attrs so we don't leak them.
             for node in model.graph.node:
-                for attr_name in ["io_chrc_period", "io_chrc_in", "io_chrc_out"]:
+                for file_attr_name in ["io_chrc_in_file", "io_chrc_out_file"]:
+                    attr = get_by_name(node.attribute, file_attr_name)
+                    if attr is not None:
+                        fname = attr.s.decode("utf-8")
+                        if fname != "" and os.path.isfile(fname):
+                            os.remove(fname)
+                for attr_name in [
+                    "io_chrc_period",
+                    "io_chrc_in_file",
+                    "io_chrc_out_file",
+                ]:
                     attr = get_by_name(node.attribute, attr_name)
                     if attr is not None:
                         node.attribute.remove(attr)

--- a/src/finn/builder/build_dataflow_steps.py
+++ b/src/finn/builder/build_dataflow_steps.py
@@ -152,6 +152,31 @@ def _maybe_enable_verify_behavioral(cfg):
         cfg.verify_rtlsim_behavioral = True
 
 
+def _fifo_debug_live_dir(cfg):
+    return cfg.output_dir + "/debug/fifo_logs/_live"
+
+
+def snapshot_fifo_logs(cfg, phase_name, loop_context=None):
+    if not cfg.debug_fifo:
+        return
+    live_dir = _fifo_debug_live_dir(cfg)
+    if not os.path.isdir(live_dir):
+        return
+    prefix = (loop_context + "_") if loop_context else None
+    subdir = loop_context or "main"
+    dest_dir = os.path.join(cfg.output_dir, "debug", "fifo_logs", phase_name, subdir)
+    os.makedirs(dest_dir, exist_ok=True)
+    for fn in os.listdir(live_dir):
+        if not fn.endswith(".log"):
+            continue
+        if prefix is not None and not fn.startswith(prefix):
+            continue
+        src = os.path.join(live_dir, fn)
+        dst = os.path.join(dest_dir, fn)
+        shutil.copy2(src, dst)
+        open(src, "w").close()
+
+
 def verify_step(
     model: ModelWrapper,
     cfg: DataflowBuildConfig,
@@ -319,9 +344,11 @@ def prepare_loop_ops_fifo_sizing(node, cfg):
             swg_exception=cfg.default_swg_exception,
             vivado_ram_style=cfg.large_fifo_mem_style,
             fifosim_input_throttle=cfg.fifosim_input_throttle,
-            debug_log=cfg.debug_fifo,
+            debug_log_dir=(_fifo_debug_live_dir(cfg) if cfg.debug_fifo else None),
+            debug_log_prefix=node.name + "_",
         )
     )
+    snapshot_fifo_logs(cfg, "fifo_sizing", loop_context=node.name)
     loop_model = loop_model.transform(SplitLargeFIFOs())
     loop_model = loop_model.transform(RemoveShallowFIFOs())
     loop_model = loop_model.transform(GiveUniqueNodeNames(prefix=node.name + "_"))
@@ -988,9 +1015,10 @@ def step_set_fifo_depths(model: ModelWrapper, cfg: DataflowBuildConfig):
                     vivado_ram_style=cfg.large_fifo_mem_style,
                     fifosim_input_throttle=cfg.fifosim_input_throttle,
                     cfg_n_inferences=cfg.fifosim_n_inferences,
-                    debug_log=cfg.debug_fifo,
+                    debug_log_dir=(_fifo_debug_live_dir(cfg) if cfg.debug_fifo else None),
                 )
             )
+            snapshot_fifo_logs(cfg, "fifo_sizing")
             model = model.transform(GiveUniqueNodeNames())
             loop_nodes = model.get_nodes_by_op_type("FINNLoop")
             for loop_node in loop_nodes:
@@ -1138,8 +1166,12 @@ def step_create_stitched_ip(model: ModelWrapper, cfg: DataflowBuildConfig):
                 verify_model.set_metadata_prop("rtlsim_behavioral", "1")
             if is_mlo(model):
                 verify_mlo(verify_model, cfg, "stitched_ip_rtlsim")
+                for loop_node in verify_model.get_nodes_by_op_type("FINNLoop"):
+                    snapshot_fifo_logs(cfg, "stitched_ip_rtlsim", loop_context=loop_node.name)
+                snapshot_fifo_logs(cfg, "stitched_ip_rtlsim")
             else:
                 verify_step(verify_model, cfg, "stitched_ip_rtlsim", need_parent=True)
+                snapshot_fifo_logs(cfg, "stitched_ip_rtlsim")
             os.environ["LIVENESS_THRESHOLD"] = str(prev_liveness)
     return model
 

--- a/src/finn/builder/build_dataflow_steps.py
+++ b/src/finn/builder/build_dataflow_steps.py
@@ -171,7 +171,8 @@ def snapshot_fifo_logs(cfg, phase_subdir):
         if not os.path.isfile(src) or os.path.getsize(src) == 0:
             continue
         shutil.copyfile(src, os.path.join(dest_dir, fn))
-        open(src, "w").close()
+    # Delete _live folder to ensure clean state for next simulation
+    shutil.rmtree(live_dir)
 
 
 def verify_step(
@@ -1150,6 +1151,9 @@ def step_create_stitched_ip(model: ModelWrapper, cfg: DataflowBuildConfig):
             # prepare ip-stitched rtlsim
             verify_model = deepcopy(model)
             verify_model = prepare_for_stitched_ip_rtlsim(verify_model, cfg)
+            # Ensure _live folder exists for debug_fifo logging
+            if cfg.debug_fifo:
+                os.makedirs(_fifo_debug_live_dir(cfg), exist_ok=True)
             # use critical path estimate to set rtlsim liveness threshold
             # (very conservative)
             verify_model = verify_model.transform(AnnotateCycles())

--- a/src/finn/builder/build_dataflow_steps.py
+++ b/src/finn/builder/build_dataflow_steps.py
@@ -979,10 +979,22 @@ def step_set_fifo_depths(model: ModelWrapper, cfg: DataflowBuildConfig):
                 PrepareIP(cfg._resolve_fpga_part(), cfg._resolve_hls_clk_period())
             )
             model = model.transform(HLSSynthIP(cfg._resolve_fpga_part()))
+            if cfg.fifosim_save_waveform:
+                report_dir = cfg.output_dir + "/report"
+                os.makedirs(report_dir, exist_ok=True)
+                for node in model.graph.node:
+                    node_inst = getCustomOp(node)
+                    node_inst.set_nodeattr(
+                        "rtlsim_trace",
+                        os.path.abspath(report_dir) + f"/{node.name}_fifosim_trace.wdb",
+                    )
             model = model.transform(PrepareRTLSim(behav=True))
             model = model.transform(AnnotateCycles())
             period = model.analysis(dataflow_performance)["max_cycles"] + 10
             model = model.transform(DeriveCharacteristic(period))
+            if cfg.fifosim_save_waveform:
+                for node in model.graph.node:
+                    getCustomOp(node).set_nodeattr("rtlsim_trace", "")
             model = model.transform(DeriveFIFOSizes())
             model = model.transform(
                 InsertFIFO(

--- a/src/finn/core/rtlsim_exec.py
+++ b/src/finn/core/rtlsim_exec.py
@@ -296,7 +296,7 @@ def rtlsim_exec_cppxsi(
     runsim_cmd = ["bash", "run_rtlsim.sh"]
     with open(sim_base + "/run_rtlsim.sh", "w") as f:
         f.write(
-            f"LD_LIBRARY_PATH={runsim_env['LD_LIBRARY_PATH']} ./rtlsim_xsi > rtlsim_xsi_log.txt"
+            f"LD_LIBRARY_PATH={runsim_env['LD_LIBRARY_PATH']} ./rtlsim_xsi > rtlsim_xsi_log.txt 2> rtlsim_xsi_stderr.log"
         )
     launch_process_helper(runsim_cmd, cwd=sim_base)
 

--- a/src/finn/core/rtlsim_exec.py
+++ b/src/finn/core/rtlsim_exec.py
@@ -341,8 +341,10 @@ def rtlsim_exec_finnxsi(model, execution_context, pre_hook=None, post_hook=None)
         top_module_name = top_module_file_name.strip(".v")
         single_src_dir = make_build_dir("rtlsim_" + top_module_name + "_")
         debug = not (trace_file is None or trace_file == "")
+        rtlsim_behavioral = model.get_metadata_prop("rtlsim_behavioral")
+        behav = rtlsim_behavioral is not None and rtlsim_behavioral == "1"
         rtlsim_so = finnxsi.compile_sim_obj(
-            top_module_name, all_verilog_srcs, single_src_dir, debug=debug
+            top_module_name, all_verilog_srcs, single_src_dir, debug=debug, behav=behav
         )
         # save generated lib filename in attribute
         model.set_metadata_prop("rtlsim_so", rtlsim_so[0] + "/" + rtlsim_so[1])

--- a/src/finn/core/rtlsim_exec.py
+++ b/src/finn/core/rtlsim_exec.py
@@ -123,11 +123,14 @@ def rtlsim_exec_cppxsi(
     dummy_data_mode=False,
     timeout_cycles=None,
     throttle_cycles=0,
+    behav=True,
 ):
     """Use XSI C++ rtl simulation to execute given model with stitched IP.
     The dummy_data_mode flag controls whether the simulation is driven by
     dummy data or real data. The execution_context parameter must be formatted
     according to whether dummy or real data is used.
+    If behav=True (default), FINN_SIMULATION is defined and fifo_gauge is used.
+    If behav=False, Q_srl is used instead (no debug logging).
     Example with dummy_data = True:
         execution_context = {
             "inputs" : {"<name_of_input_stream>" : <number_of_transactions>},
@@ -176,7 +179,7 @@ def rtlsim_exec_cppxsi(
         single_src_dir = make_build_dir("rtlsim_" + top_module_name + "_")
         debug = not (trace_file is None or trace_file == "")
         rtlsim_so = finnxsi.compile_sim_obj(
-            top_module_name, all_verilog_srcs, single_src_dir, debug=debug, behav=True
+            top_module_name, all_verilog_srcs, single_src_dir, debug=debug, behav=behav
         )
         # save generated lib filename in attribute
         model.set_metadata_prop("rtlsim_so", rtlsim_so[0] + "/" + rtlsim_so[1])

--- a/src/finn/core/rtlsim_exec.py
+++ b/src/finn/core/rtlsim_exec.py
@@ -295,8 +295,11 @@ def rtlsim_exec_cppxsi(
     runsim_env["LD_LIBRARY_PATH"] = get_vivado_root() + "/lib/lnx64.o"
     runsim_cmd = ["bash", "run_rtlsim.sh"]
     with open(sim_base + "/run_rtlsim.sh", "w") as f:
+        ld_path = runsim_env["LD_LIBRARY_PATH"]
         f.write(
-            f"LD_LIBRARY_PATH={runsim_env['LD_LIBRARY_PATH']} ./rtlsim_xsi > rtlsim_xsi_log.txt 2> rtlsim_xsi_stderr.log"
+            f"LD_LIBRARY_PATH={ld_path}"
+            " ./rtlsim_xsi > rtlsim_xsi_log.txt"
+            " 2> rtlsim_xsi_stderr.log"
         )
     launch_process_helper(runsim_cmd, cwd=sim_base)
 

--- a/src/finn/custom_op/fpgadataflow/hwcustomop.py
+++ b/src/finn/custom_op/fpgadataflow/hwcustomop.py
@@ -85,9 +85,13 @@ class HWCustomOp(CustomOp):
             "inFIFODepths": ("ints", False, [2]),
             "outFIFODepths": ("ints", False, [2]),
             "output_hook": ("s", False, ""),
-            # accumulated characteristic function over two periods
-            "io_chrc_in": ("t", False, np.asarray([], dtype=np.int32)),
-            "io_chrc_out": ("t", False, np.asarray([], dtype=np.int32)),
+            # accumulated characteristic function over two periods; the arrays
+            # themselves are offloaded to sidecar .npy files (their shape is
+            # (n_streams, 2*period), which for large periods would blow the
+            # ONNX ModelProto past protobuf's 2GB limit). These attrs hold the
+            # paths to those files; see get_io_chrc_in()/get_io_chrc_out().
+            "io_chrc_in_file": ("s", False, ""),
+            "io_chrc_out_file": ("s", False, ""),
             # the period for which the characterization was run
             "io_chrc_period": ("i", False, 0),
             # amount of zero padding inserted during chrc.
@@ -540,10 +544,43 @@ class HWCustomOp(CustomOp):
             all_txns_out[out_idx, :] = txn_out
             all_pad_out.append(pad_out)
 
-        self.set_nodeattr("io_chrc_in", all_txns_in)
-        self.set_nodeattr("io_chrc_out", all_txns_out)
+        # Offload the (potentially very large) characteristic arrays to sidecar
+        # .npy files rather than storing them as ONNX tensor attributes, which
+        # would otherwise push the ModelProto past protobuf's 2GB message limit
+        # (the arrays are shape (n_streams, 2*period)).
+        code_gen_dir = self.get_nodeattr("code_gen_dir_ipgen")
+        assert code_gen_dir != "", (
+            "code_gen_dir_ipgen not set for %s; cannot store io_chrc sidecar files"
+            % self.onnx_node.name
+        )
+        in_file = os.path.join(code_gen_dir, "io_chrc_in.npy")
+        out_file = os.path.join(code_gen_dir, "io_chrc_out.npy")
+        np.save(in_file, all_txns_in)
+        np.save(out_file, all_txns_out)
+        self.set_nodeattr("io_chrc_in_file", in_file)
+        self.set_nodeattr("io_chrc_out_file", out_file)
         self.set_nodeattr("io_chrc_pads_in", all_pad_in)
         self.set_nodeattr("io_chrc_pads_out", all_pad_out)
+
+    def get_io_chrc_in(self):
+        """Load the input characteristic array from its sidecar .npy file.
+
+        Returns an array of shape (n_streams, 2*period), or an empty (0, 0)
+        int32 array if characterization has not been run for this node."""
+        fname = self.get_nodeattr("io_chrc_in_file")
+        if fname == "" or not os.path.isfile(fname):
+            return np.empty((0, 0), dtype=np.int32)
+        return np.load(fname)
+
+    def get_io_chrc_out(self):
+        """Load the output characteristic array from its sidecar .npy file.
+
+        Returns an array of shape (n_streams, 2*period), or an empty (0, 0)
+        int32 array if characterization has not been run for this node."""
+        fname = self.get_nodeattr("io_chrc_out_file")
+        if fname == "" or not os.path.isfile(fname):
+            return np.empty((0, 0), dtype=np.int32)
+        return np.load(fname)
 
     def adapt_for_loop_body(self, input_types):
         """

--- a/src/finn/custom_op/fpgadataflow/hwcustomop.py
+++ b/src/finn/custom_op/fpgadataflow/hwcustomop.py
@@ -479,13 +479,18 @@ class HWCustomOp(CustomOp):
         for k in txns_out.keys():
             txns_out[k] = sim.trace_stream(k + sname)
         # For characterization, use period as liveness threshold directly
-        total_cycle_count = finnxsi.rtlsim_multi_io(
-            sim,
-            io_dict,
-            num_out_values=self.get_number_output_values(),
-            sname=sname,
-            liveness_threshold=period,
-        )
+        try:
+            total_cycle_count = finnxsi.rtlsim_multi_io(
+                sim,
+                io_dict,
+                num_out_values=self.get_number_output_values(),
+                sname=sname,
+                liveness_threshold=period,
+            )
+        finally:
+            # Assert sim_finish to trigger $finish so that SystemVerilog final
+            # blocks execute, which flush and close the fifo_gauge log files.
+            self.close_rtlsim(sim)
         self.set_nodeattr("cycles_rtlsim", total_cycle_count)
         assert (
             total_cycle_count <= period

--- a/src/finn/custom_op/fpgadataflow/rtl/elementwise_binary_rtl.py
+++ b/src/finn/custom_op/fpgadataflow/rtl/elementwise_binary_rtl.py
@@ -151,7 +151,6 @@ class ElementwiseBinary_rtl(ElementwiseBinaryOperation, RTLBackend):
             "PE": pe,
             "OP": op_name,
             "B_SCALE": 1.0,
-            "FORCE_BEHAVIORAL": 0,
             "A_FLOAT": 1 if lhs_float else 0,
             "B_FLOAT": 1 if rhs_float else 0,
             "A_WIDTH": a_width,

--- a/src/finn/custom_op/fpgadataflow/rtl/finn_loop.py
+++ b/src/finn/custom_op/fpgadataflow/rtl/finn_loop.py
@@ -972,6 +972,17 @@ class FINNLoop(HWCustomOp, RTLBackend):
             "connect_bd_net [get_bd_pins %s/%s] [get_bd_pins %s/%s]"
             % (self.onnx_node.name, clk_name, finn_ip_name, clk_name)
         )
+        # Expose the loop body's sim_finish control to the top of the FINNLoop IP.
+        # The body's stitched IP carries a sim_ctrl (inserted by CreateStitchedIP)
+        # whose sim_finish input triggers $finish. Asserting it during rtlsim runs
+        # the SystemVerilog final blocks that flush and close the fifo_gauge log
+        # files; without this the gauge logs are left unflushed/empty during
+        # characterization-based FIFO sizing.
+        cmd.append("create_bd_pin -dir I /%s/sim_finish" % self.onnx_node.name)
+        cmd.append(
+            "connect_bd_net [get_bd_pins %s/sim_finish] [get_bd_pins %s/sim_finish]"
+            % (self.onnx_node.name, finn_ip_name)
+        )
         # "externalize" some of the loop shell signals
         ext_signals = loop_body_intf_names["aximm"]
         for sig in ext_signals:
@@ -1013,6 +1024,7 @@ class FINNLoop(HWCustomOp, RTLBackend):
         cmd.append("set_property name out0_V [get_bd_intf_ports out0_V_0]")
         cmd.append("set_property name m_axi_hbm [get_bd_intf_ports m_axi_hbm_0]")
         cmd.append("set_property name done_if [get_bd_ports done_if_0]")
+        cmd.append("set_property name sim_finish [get_bd_ports sim_finish_0]")
         # set property name for aximm interfaces
         ext_signals = loop_body_intf_names["aximm"]
         for sig in ext_signals:

--- a/src/finn/custom_op/fpgadataflow/rtl/streamingfifo_rtl.py
+++ b/src/finn/custom_op/fpgadataflow/rtl/streamingfifo_rtl.py
@@ -96,7 +96,7 @@ class StreamingFIFO_rtl(StreamingFIFO, RTLBackend):
         code_gen_dict["$OUT_RANGE$"] = "[{}:0]".format(in_width - 1)
         code_gen_dict["$WIDTH$"] = str(in_width)
         code_gen_dict["$DEPTH$"] = str(depth)
-        code_gen_dict["$DEBUG_LOG$"] = str(self.get_nodeattr("debug_log"))
+        code_gen_dict["$DATA_LOGFILE$"] = self.get_nodeattr("debug_log_path")
         # apply code generation to templates
         code_gen_dir = self.get_nodeattr("code_gen_dir_ipgen")
         with open(template_path, "r") as f:

--- a/src/finn/custom_op/fpgadataflow/rtl/streamingfifo_rtl.py
+++ b/src/finn/custom_op/fpgadataflow/rtl/streamingfifo_rtl.py
@@ -96,7 +96,7 @@ class StreamingFIFO_rtl(StreamingFIFO, RTLBackend):
         code_gen_dict["$OUT_RANGE$"] = "[{}:0]".format(in_width - 1)
         code_gen_dict["$WIDTH$"] = str(in_width)
         code_gen_dict["$DEPTH$"] = str(depth)
-        code_gen_dict["$DATA_LOGFILE$"] = self.get_nodeattr("debug_log_path")
+        code_gen_dict["$DEBUG_LOG$"] = str(self.get_nodeattr("debug_log"))
         # apply code generation to templates
         code_gen_dir = self.get_nodeattr("code_gen_dir_ipgen")
         with open(template_path, "r") as f:

--- a/src/finn/custom_op/fpgadataflow/rtl/streamingfifo_rtl.py
+++ b/src/finn/custom_op/fpgadataflow/rtl/streamingfifo_rtl.py
@@ -96,6 +96,7 @@ class StreamingFIFO_rtl(StreamingFIFO, RTLBackend):
         code_gen_dict["$OUT_RANGE$"] = "[{}:0]".format(in_width - 1)
         code_gen_dict["$WIDTH$"] = str(in_width)
         code_gen_dict["$DEPTH$"] = str(depth)
+        code_gen_dict["$DATA_LOGFILE$"] = self.get_nodeattr("debug_log_path")
         # apply code generation to templates
         code_gen_dir = self.get_nodeattr("code_gen_dir_ipgen")
         with open(template_path, "r") as f:

--- a/src/finn/custom_op/fpgadataflow/streamingfifo.py
+++ b/src/finn/custom_op/fpgadataflow/streamingfifo.py
@@ -64,7 +64,7 @@ class StreamingFIFO(HWCustomOp):
                 # the FIFO does not need its own FIFOs
                 "inFIFODepths": ("ints", False, [0]),
                 "outFIFODepths": ("ints", False, [0]),
-                "debug_log": ("i", False, 0),
+                "debug_log_path": ("s", False, ""),
             }
         )
 

--- a/src/finn/custom_op/fpgadataflow/streamingfifo.py
+++ b/src/finn/custom_op/fpgadataflow/streamingfifo.py
@@ -64,6 +64,7 @@ class StreamingFIFO(HWCustomOp):
                 # the FIFO does not need its own FIFOs
                 "inFIFODepths": ("ints", False, [0]),
                 "outFIFODepths": ("ints", False, [0]),
+                "debug_log_path": ("s", False, ""),
             }
         )
 

--- a/src/finn/custom_op/fpgadataflow/streamingfifo.py
+++ b/src/finn/custom_op/fpgadataflow/streamingfifo.py
@@ -64,7 +64,7 @@ class StreamingFIFO(HWCustomOp):
                 # the FIFO does not need its own FIFOs
                 "inFIFODepths": ("ints", False, [0]),
                 "outFIFODepths": ("ints", False, [0]),
-                "debug_log_path": ("s", False, ""),
+                "debug_log": ("i", False, 0),
             }
         )
 

--- a/src/finn/qnn-data/build_dataflow/build.py
+++ b/src/finn/qnn-data/build_dataflow/build.py
@@ -48,6 +48,7 @@ cfg = build.DataflowBuildConfig(
     synth_clk_period_ns=10.0,
     board=platform_name,
     shell_flow_type=build_cfg.ShellFlowType.VIVADO_ZYNQ,
+    debug_fifo=True,
     generate_outputs=[
         build_cfg.DataflowOutputType.PYNQ_DRIVER,
         build_cfg.DataflowOutputType.STITCHED_IP,

--- a/src/finn/qnn-data/build_dataflow/dataflow_build_config.json
+++ b/src/finn/qnn-data/build_dataflow/dataflow_build_config.json
@@ -9,6 +9,7 @@
   "shell_flow_type": "vivado_zynq",
   "verify_save_rtlsim_waveforms": true,
   "fifosim_save_waveform": true,
+  "debug_fifo": true,
   "verify_steps": [
     "initial_python",
     "streamlined_python",

--- a/src/finn/transformation/fpgadataflow/create_stitched_ip.py
+++ b/src/finn/transformation/fpgadataflow/create_stitched_ip.py
@@ -403,9 +403,7 @@ class CreateStitchedIP(Transformation):
         self.connect_cmds.append(
             "make_bd_pins_external [get_bd_pins %s/sim_finish]" % sim_ctrl_name
         )
-        self.connect_cmds.append(
-            "set_property name sim_finish [get_bd_ports sim_finish_0]"
-        )
+        self.connect_cmds.append("set_property name sim_finish [get_bd_ports sim_finish_0]")
 
     def apply(self, model):
         # ensure non-relative readmemh .dat files

--- a/src/finn/transformation/fpgadataflow/create_stitched_ip.py
+++ b/src/finn/transformation/fpgadataflow/create_stitched_ip.py
@@ -390,6 +390,23 @@ class CreateStitchedIP(Transformation):
         self.connect_cmds.append("set_property name s_axilite_info [get_bd_intf_ports s_axi_0]")
         self.connect_cmds.append("assign_bd_address")
 
+    def insert_sim_ctrl(self):
+        sim_ctrl_src = "$::env(FINN_ROOT)/finn-rtllib/sim/hdl/sim_ctrl.v"
+        sim_ctrl_name = "sim_ctrl_0"
+        self.create_cmds.append("add_files -norecurse %s" % sim_ctrl_src)
+        self.create_cmds.append(
+            "create_bd_cell -type module -reference sim_ctrl %s" % sim_ctrl_name
+        )
+        self.connect_cmds.append(
+            "connect_bd_net [get_bd_ports ap_clk] [get_bd_pins %s/ap_clk]" % sim_ctrl_name
+        )
+        self.connect_cmds.append(
+            "make_bd_pins_external [get_bd_pins %s/sim_finish]" % sim_ctrl_name
+        )
+        self.connect_cmds.append(
+            "set_property name sim_finish [get_bd_ports sim_finish_0]"
+        )
+
     def apply(self, model):
         # ensure non-relative readmemh .dat files
         model = model.transform(ReplaceVerilogRelPaths())
@@ -466,6 +483,8 @@ class CreateStitchedIP(Transformation):
             # extract number of checksum layer from graph
             checksum_layers = model.get_nodes_by_op_type("CheckSum_hls")
             self.insert_signature(len(checksum_layers))
+
+        self.insert_sim_ctrl()
 
         # create a temporary folder for the project
         prjname = "finn_vivado_stitch_proj"

--- a/src/finn/transformation/fpgadataflow/derive_characteristic.py
+++ b/src/finn/transformation/fpgadataflow/derive_characteristic.py
@@ -29,11 +29,34 @@
 
 
 import qonnx.custom_op.registry as registry
-import warnings
-from qonnx.core.modelwrapper import ModelWrapper
 from qonnx.transformation.base import NodeLocalTransformation
 
 from finn.util.fpgadataflow import is_hls_node, is_rtl_node
+
+
+def _assert_no_reconvergent_residuals(model):
+    """Raise if the model contains a reconvergent residual, i.e. a two-stream
+    ElementwiseAdd join.
+
+    Characterization-based FIFO sizing derives each consumer's requirement from
+    its first input characteristic only (io_chrc_in[0]), so a node that joins
+    two live streams (a residual add fed by a stream fork) cannot be sized
+    correctly. Detect this up front and fail with a clear message rather than
+    after the (potentially hours-long) characterization rtlsim. FINNLoop bodies
+    are opaque here (the loop is an IP core at this stage), so no descent into
+    subgraphs is needed.
+    """
+    for node in model.graph.node:
+        if "ElementwiseAdd" in node.op_type:
+            inst = registry.getCustomOp(node)
+            if inst.get_nodeattr("lhs_style") == "input" and (
+                inst.get_nodeattr("rhs_style") == "input"
+            ):
+                raise RuntimeError(
+                    "Characterize FIFO sizing is not supported for models with "
+                    "reconvergent residual paths (two-stream ElementwiseAdd '%s' "
+                    "fed by a stream fork). Use a different auto_fifo_strategy." % node.name
+                )
 
 
 class DeriveCharacteristic(NodeLocalTransformation):
@@ -52,10 +75,14 @@ class DeriveCharacteristic(NodeLocalTransformation):
       NodeLocalTransformation for more details.
     """
 
-    def __init__(self, period, num_workers=None, manual_bypass=False):
+    def __init__(self, period, num_workers=None):
         super().__init__(num_workers=num_workers)
         self.period = period
-        self.manual_bypass = manual_bypass
+
+    def apply(self, model):
+        # fail fast on unsupported topologies before the (long) characterization
+        _assert_no_reconvergent_residuals(model)
+        return super().apply(model)
 
     def applyNodeLocal(self, node):
         op_type = node.op_type
@@ -68,57 +95,6 @@ class DeriveCharacteristic(NodeLocalTransformation):
                 # exception if op_type is not supported
                 raise Exception("Custom op_type %s is currently not supported." % op_type)
         return (node, False)
-
-    def apply(self, model: ModelWrapper):
-        (model, run_again) = super().apply(model)
-        if not self.manual_bypass:
-            return (model, run_again)
-        # apply manual fix for DuplicateStreams and ElementwiseAdd for
-        # simple residual reconvergent paths with bypass
-        addstrm_nodes = model.get_nodes_by_op_type("ElementwiseAdd_hls")
-        for addstrm_node in addstrm_nodes:
-            # skip ElementwiseAdd nodes that have constant inputs (not two streams)
-            addstrm_inst = registry.getCustomOp(addstrm_node)
-            if addstrm_inst.get_nodeattr("lhs_style") != "input":
-                continue
-            if addstrm_inst.get_nodeattr("rhs_style") != "input":
-                continue
-            # we currently only support the case where one branch is
-            # a bypass
-            b0 = model.find_producer(addstrm_node.input[0])
-            b1 = model.find_producer(addstrm_node.input[1])
-            if (b0 is None) or (b1 is None):
-                warnings.warn("Found unsupported ElementwiseAdd, skipping")
-                return (model, run_again)
-            b0_is_bypass = b0.op_type == "DuplicateStreams_hls"
-            b1_is_bypass = b1.op_type == "DuplicateStreams_hls"
-            if (not b0_is_bypass) and (not b1_is_bypass):
-                warnings.warn("Found unsupported ElementwiseAdd, skipping")
-                return (model, run_again)
-            ds_node = b0 if b0_is_bypass else b1
-            comp_branch_last = b1 if b0_is_bypass else b0
-
-            ds_comp_bout = ds_node.output[0] if b0_is_bypass else ds_node.output[1]
-            comp_branch_first = model.find_consumer(ds_comp_bout)
-            if comp_branch_first is None or comp_branch_last is None:
-                warnings.warn("Found unsupported DuplicateStreams, skipping")
-                return (model, run_again)
-            comp_branch_last = registry.getCustomOp(comp_branch_last)
-            comp_branch_first = registry.getCustomOp(comp_branch_first)
-            # for DuplicateStreams, use comp_branch_first's input characterization
-            # for ElementwiseAdd, use comp_branch_last's output characterization
-            period = comp_branch_first.get_nodeattr("io_chrc_period")
-            comp_branch_first_f = comp_branch_first.get_nodeattr("io_characteristic")[: 2 * period]
-            comp_branch_last_f = comp_branch_last.get_nodeattr("io_characteristic")[2 * period :]
-            ds_node_inst = registry.getCustomOp(ds_node)
-            addstrm_node_inst = registry.getCustomOp(addstrm_node)
-            ds_node_inst.set_nodeattr("io_chrc_period", period)
-            ds_node_inst.set_nodeattr("io_characteristic", comp_branch_first_f * 2)
-            addstrm_node_inst.set_nodeattr("io_chrc_period", period)
-            addstrm_node_inst.set_nodeattr("io_characteristic", comp_branch_last_f * 2)
-            warnings.warn(f"Set {ds_node.name} chrc. from {comp_branch_first.onnx_node.name}")
-            warnings.warn(f"Set {addstrm_node.name} chrc. from {comp_branch_last.onnx_node.name}")
-        return (model, run_again)
 
 
 class DeriveFIFOSizes(NodeLocalTransformation):
@@ -143,7 +119,7 @@ class DeriveFIFOSizes(NodeLocalTransformation):
                 prod = registry.getCustomOp(node)
                 assert not (op_type.startswith("StreamingFIFO")), "Found existing FIFOs"
                 period = prod.get_nodeattr("io_chrc_period")
-                prod_chrc = prod.get_nodeattr("io_chrc_out")[0]
+                prod_chrc = prod.get_io_chrc_out()[0]
                 assert len(prod_chrc) == 2 * period, "Found unexpected characterization attribute"
                 if any([x > 2 for x in prod.get_nodeattr("outFIFODepths")]):
                     # FIFO depth already set, can skip this node
@@ -160,7 +136,7 @@ class DeriveFIFOSizes(NodeLocalTransformation):
                         out_fifo_depths.append(self.io_fifo_depth)
                         continue
                     cons = registry.getCustomOp(cons_node)
-                    cons_chrc = cons.get_nodeattr("io_chrc_in")[0]
+                    cons_chrc = cons.get_io_chrc_in()[0]
                     # find minimum phase shift satisfying the constraint
                     pshift_min = period - 1
                     for pshift_cand in range(period):

--- a/src/finn/transformation/fpgadataflow/set_fifo_depths.py
+++ b/src/finn/transformation/fpgadataflow/set_fifo_depths.py
@@ -27,9 +27,8 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import os
-
 import numpy as np
+import os
 import warnings
 from onnx import TensorProto, helper
 from qonnx.core.datatype import DataType

--- a/src/finn/transformation/fpgadataflow/set_fifo_depths.py
+++ b/src/finn/transformation/fpgadataflow/set_fifo_depths.py
@@ -27,6 +27,8 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import os
+
 import numpy as np
 import warnings
 from onnx import TensorProto, helper
@@ -278,7 +280,8 @@ class InsertAndSetFIFODepths(Transformation):
         vivado_ram_style="auto",
         fifosim_input_throttle=True,
         cfg_n_inferences=2,
-        debug_log=False,
+        debug_log_dir=None,
+        debug_log_prefix="",
     ):
         super().__init__()
         self.fpgapart = fpgapart
@@ -291,7 +294,8 @@ class InsertAndSetFIFODepths(Transformation):
         self.cfg_n_inferences = cfg_n_inferences
         self.mlo_max_iter = 0
         self.ind_map = {}
-        self.debug_log = debug_log
+        self.debug_log_dir = debug_log_dir
+        self.debug_log_prefix = debug_log_prefix
 
     def apply(self, model):
         model = model.transform(GiveUniqueNodeNames())
@@ -408,9 +412,13 @@ class InsertAndSetFIFODepths(Transformation):
             if (self.max_depth is not None) and (node.get_nodeattr("depth") != self.max_depth):
                 node.set_nodeattr("depth", self.max_depth)
 
-        if self.debug_log:
+        if self.debug_log_dir is not None:
+            os.makedirs(os.path.abspath(self.debug_log_dir), exist_ok=True)
             for node in model.get_nodes_by_op_type("StreamingFIFO_rtl"):
-                getCustomOp(node).set_nodeattr("debug_log", 1)
+                log_path = os.path.abspath(
+                    os.path.join(self.debug_log_dir, self.debug_log_prefix + node.name + ".log")
+                )
+                getCustomOp(node).set_nodeattr("debug_log_path", log_path)
 
         # insert FIFOs and do all transformations for RTLsim
         model = model.transform(AnnotateCycles())

--- a/src/finn/transformation/fpgadataflow/set_fifo_depths.py
+++ b/src/finn/transformation/fpgadataflow/set_fifo_depths.py
@@ -28,7 +28,6 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import numpy as np
-import os
 import warnings
 from onnx import TensorProto, helper
 from qonnx.core.datatype import DataType
@@ -279,7 +278,7 @@ class InsertAndSetFIFODepths(Transformation):
         vivado_ram_style="auto",
         fifosim_input_throttle=True,
         cfg_n_inferences=2,
-        debug_log_dir=None,
+        debug_log=False,
     ):
         super().__init__()
         self.fpgapart = fpgapart
@@ -292,7 +291,7 @@ class InsertAndSetFIFODepths(Transformation):
         self.cfg_n_inferences = cfg_n_inferences
         self.mlo_max_iter = 0
         self.ind_map = {}
-        self.debug_log_dir = debug_log_dir
+        self.debug_log = debug_log
 
     def apply(self, model):
         model = model.transform(GiveUniqueNodeNames())
@@ -409,11 +408,9 @@ class InsertAndSetFIFODepths(Transformation):
             if (self.max_depth is not None) and (node.get_nodeattr("depth") != self.max_depth):
                 node.set_nodeattr("depth", self.max_depth)
 
-        if self.debug_log_dir is not None:
-            os.makedirs(os.path.abspath(self.debug_log_dir), exist_ok=True)
+        if self.debug_log:
             for node in model.get_nodes_by_op_type("StreamingFIFO_rtl"):
-                log_path = os.path.abspath(os.path.join(self.debug_log_dir, node.name + ".log"))
-                getCustomOp(node).set_nodeattr("debug_log_path", log_path)
+                getCustomOp(node).set_nodeattr("debug_log", 1)
 
         # insert FIFOs and do all transformations for RTLsim
         model = model.transform(AnnotateCycles())

--- a/src/finn/transformation/fpgadataflow/set_fifo_depths.py
+++ b/src/finn/transformation/fpgadataflow/set_fifo_depths.py
@@ -196,12 +196,14 @@ class CapConvolutionFIFODepths(Transformation):
         return (model, False)
 
 
-def xsi_fifosim(model, n_inferences, max_iters=None, throttle_cycles=0):
+def xsi_fifosim(model, n_inferences, max_iters=None, throttle_cycles=0, behav=True):
     """Create a XSI model of stitched IP and use a simple C++
     driver to drive the input stream. Useful for FIFO sizing, latency
     and throughput measurement. If max_iters is None, use the default
     liveness threshold instead. throttle_cycles can be used for throttling
-    the input stream every time a frame is finished."""
+    the input stream every time a frame is finished.
+    If behav=True (default), FINN_SIMULATION is defined and fifo_gauge is used.
+    If behav=False, Q_srl is used instead (no debug logging)."""
 
     iname = model.get_first_global_in()
     first_node = model.find_consumer(iname)
@@ -218,6 +220,7 @@ def xsi_fifosim(model, n_inferences, max_iters=None, throttle_cycles=0):
         dummy_data_mode=True,
         timeout_cycles=max_iters,
         throttle_cycles=throttle_cycles,
+        behav=behav,
     )
 
     return ret_dict

--- a/src/finn/transformation/fpgadataflow/set_fifo_depths.py
+++ b/src/finn/transformation/fpgadataflow/set_fifo_depths.py
@@ -28,6 +28,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import numpy as np
+import os
 import warnings
 from onnx import TensorProto, helper
 from qonnx.core.datatype import DataType
@@ -406,13 +407,9 @@ class InsertAndSetFIFODepths(Transformation):
                 node.set_nodeattr("depth", self.max_depth)
 
         if self.debug_log_dir is not None:
-            import os as _os
-
-            _os.makedirs(_os.path.abspath(self.debug_log_dir), exist_ok=True)
+            os.makedirs(os.path.abspath(self.debug_log_dir), exist_ok=True)
             for node in model.get_nodes_by_op_type("StreamingFIFO_rtl"):
-                log_path = _os.path.abspath(
-                    _os.path.join(self.debug_log_dir, node.name + ".log")
-                )
+                log_path = os.path.abspath(os.path.join(self.debug_log_dir, node.name + ".log"))
                 getCustomOp(node).set_nodeattr("debug_log_path", log_path)
 
         # insert FIFOs and do all transformations for RTLsim

--- a/src/finn/transformation/fpgadataflow/set_fifo_depths.py
+++ b/src/finn/transformation/fpgadataflow/set_fifo_depths.py
@@ -275,6 +275,7 @@ class InsertAndSetFIFODepths(Transformation):
         vivado_ram_style="auto",
         fifosim_input_throttle=True,
         cfg_n_inferences=2,
+        debug_log_dir=None,
     ):
         super().__init__()
         self.fpgapart = fpgapart
@@ -287,6 +288,7 @@ class InsertAndSetFIFODepths(Transformation):
         self.cfg_n_inferences = cfg_n_inferences
         self.mlo_max_iter = 0
         self.ind_map = {}
+        self.debug_log_dir = debug_log_dir
 
     def apply(self, model):
         model = model.transform(GiveUniqueNodeNames())
@@ -402,6 +404,16 @@ class InsertAndSetFIFODepths(Transformation):
             # check depths and fix as necessary
             if (self.max_depth is not None) and (node.get_nodeattr("depth") != self.max_depth):
                 node.set_nodeattr("depth", self.max_depth)
+
+        if self.debug_log_dir is not None:
+            import os as _os
+
+            _os.makedirs(_os.path.abspath(self.debug_log_dir), exist_ok=True)
+            for node in model.get_nodes_by_op_type("StreamingFIFO_rtl"):
+                log_path = _os.path.abspath(
+                    _os.path.join(self.debug_log_dir, node.name + ".log")
+                )
+                getCustomOp(node).set_nodeattr("debug_log_path", log_path)
 
         # insert FIFOs and do all transformations for RTLsim
         model = model.transform(AnnotateCycles())

--- a/tests/fpgadataflow/test_fifo_transaction_counts.py
+++ b/tests/fpgadataflow/test_fifo_transaction_counts.py
@@ -17,15 +17,13 @@ from finn.transformation.fpgadataflow.insert_fifo import InsertFIFO
 
 
 def make_multi_fclayer_model(ch, wdt, adt, nnodes):
-    """Build a chain of MVAU_hls nodes (no activation) directly as HLS layers, 
+    """Build a chain of MVAU_hls nodes (no activation) directly as HLS layers,
     mirroring tests/fpgadataflow/test_set_folding.py."""
     W = np.random.randint(wdt.min(), wdt.max() + 1, size=(ch, ch)).astype(np.float32)
 
     tensors = [helper.make_tensor_value_info("inp", TensorProto.FLOAT, [1, ch])]
     for i in range(1, nnodes):
-        tensors.append(
-            helper.make_tensor_value_info("inter_" + str(i), TensorProto.FLOAT, [1, ch])
-        )
+        tensors.append(helper.make_tensor_value_info("inter_" + str(i), TensorProto.FLOAT, [1, ch]))
     tensors.append(helper.make_tensor_value_info("outp", TensorProto.FLOAT, [1, ch]))
 
     nodes = []
@@ -106,9 +104,7 @@ def test_fifo_transaction_counts_finnloop_iteration():
         inputDataType=dtype.name,
         outputDataType=dtype.name,
     )
-    top = helper.make_graph(
-        nodes=[loop_node], name="top", inputs=[top_in], outputs=[top_out]
-    )
+    top = helper.make_graph(nodes=[loop_node], name="top", inputs=[top_in], outputs=[top_out])
     model = ModelWrapper(qonnx_make_model(top, producer_name="loop-model"))
 
     # insert FIFOs in the body subgraph (and around the loop at the top level)

--- a/tests/fpgadataflow/test_fifo_transaction_counts.py
+++ b/tests/fpgadataflow/test_fifo_transaction_counts.py
@@ -1,0 +1,143 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import pytest
+
+import numpy as np
+from functools import partial
+from onnx import TensorProto, helper
+from qonnx.core.datatype import DataType
+from qonnx.core.modelwrapper import ModelWrapper
+from qonnx.custom_op.registry import getCustomOp
+from qonnx.transformation.general import GiveUniqueNodeNames
+from qonnx.util.basic import qonnx_make_model
+
+from finn.analysis.fpgadataflow.fifo_transaction_counts import fifo_transaction_counts
+from finn.transformation.fpgadataflow.insert_fifo import InsertFIFO
+
+
+def make_multi_fclayer_model(ch, wdt, adt, nnodes):
+    """Build a chain of MVAU_hls nodes (no activation) directly as HLS layers, 
+    mirroring tests/fpgadataflow/test_set_folding.py."""
+    W = np.random.randint(wdt.min(), wdt.max() + 1, size=(ch, ch)).astype(np.float32)
+
+    tensors = [helper.make_tensor_value_info("inp", TensorProto.FLOAT, [1, ch])]
+    for i in range(1, nnodes):
+        tensors.append(
+            helper.make_tensor_value_info("inter_" + str(i), TensorProto.FLOAT, [1, ch])
+        )
+    tensors.append(helper.make_tensor_value_info("outp", TensorProto.FLOAT, [1, ch]))
+
+    nodes = []
+    for i in range(nnodes):
+        nodes.append(
+            helper.make_node(
+                "MVAU_hls",
+                [tensors[i].name, "weights_" + str(i)],
+                [tensors[i + 1].name],
+                domain="finn.custom_op.fpgadataflow.hls",
+                backend="fpgadataflow",
+                MW=ch,
+                MH=ch,
+                SIMD=1,
+                PE=1,
+                inputDataType=adt.name,
+                weightDataType=wdt.name,
+                outputDataType=adt.name,
+                ActVal=0,
+                binaryXnorMode=0,
+                noActivation=1,
+            )
+        )
+
+    graph = helper.make_graph(
+        nodes=nodes, name="fclayer_graph", inputs=[tensors[0]], outputs=[tensors[-1]]
+    )
+    model = ModelWrapper(qonnx_make_model(graph, producer_name="fclayer-model"))
+    model.set_tensor_datatype("inp", adt)
+    model.set_tensor_datatype("outp", adt)
+    for i in range(1, nnodes + 1):
+        if tensors[i].name != "outp":
+            model.graph.value_info.append(tensors[i])
+        model.set_initializer("weights_" + str(i - 1), W)
+        model.set_tensor_datatype("weights_" + str(i - 1), wdt)
+    return model
+
+
+@pytest.mark.fpgadataflow
+def test_fifo_transaction_counts_inserted_fifos():
+    # build a chain of hw layers (CH=128, PE=SIMD=1) and let InsertFIFO place FIFOs
+    # in between the layers as well as at the graph input and output
+    ch = 128
+    nnodes = 5
+    model = make_multi_fclayer_model(ch, DataType["INT4"], DataType["INT4"], nnodes)
+    model = model.transform(GiveUniqueNodeNames())
+    model = model.transform(InsertFIFO(create_shallow_fifos=True))
+    model = model.transform(GiveUniqueNodeNames())
+
+    result = model.analysis(fifo_transaction_counts)
+
+    # InsertFIFO adds one FIFO between each pair of layers plus one at the graph
+    # input and one at the output: (nnodes - 1) + 2 FIFOs
+    assert len(result) == (nnodes - 1) + 2
+    # with PE=SIMD=1 every FIFO carries one transaction per element, i.e. CH per frame
+    assert all(v == ch for v in result.values())
+
+
+@pytest.mark.fpgadataflow
+def test_fifo_transaction_counts_finnloop_iteration():
+    ch = 64
+    nnodes = 4
+    iteration = 3
+    dtype = DataType["INT4"]
+    body = make_multi_fclayer_model(ch, dtype, dtype, nnodes)
+
+    top_in = helper.make_tensor_value_info("inp", TensorProto.FLOAT, [1, ch])
+    top_out = helper.make_tensor_value_info("outp", TensorProto.FLOAT, [1, ch])
+    loop_node = helper.make_node(
+        "FINNLoop",
+        ["inp"],
+        ["outp"],
+        name="FINNLoop_0",
+        domain="finn.custom_op.fpgadataflow.rtl",
+        backend="fpgadataflow",
+        body=body.graph,
+        iteration=iteration,
+        inputDataType=dtype.name,
+        outputDataType=dtype.name,
+    )
+    top = helper.make_graph(
+        nodes=[loop_node], name="top", inputs=[top_in], outputs=[top_out]
+    )
+    model = ModelWrapper(qonnx_make_model(top, producer_name="loop-model"))
+
+    # insert FIFOs in the body subgraph (and around the loop at the top level)
+    model = model.transform(InsertFIFO(create_shallow_fifos=True), apply_to_subgraphs=True)
+
+    model = model.transform(GiveUniqueNodeNames())
+    for ln in model.get_nodes_by_op_type("FINNLoop"):
+        inst = getCustomOp(ln)
+        loop_body = inst.get_nodeattr("body")
+        loop_body = loop_body.transform(GiveUniqueNodeNames(prefix=ln.name + "_"))
+        inst.set_nodeattr("body", loop_body.graph)
+
+    # without descending, only the top-level FIFOs around the loop are visible
+    top_only = model.analysis(fifo_transaction_counts)
+    # descending multiplies body FIFO counts by the loop iteration count
+    result = model.analysis(partial(fifo_transaction_counts, apply_to_subgraphs=True))
+
+    # top level: an input and an output FIFO around the loop, counted once (×1)
+    assert sorted(top_only.values()) == [ch, ch]
+    # body: (nnodes - 1) internal + input + output FIFOs, each counted ×iteration,
+    # plus the two top-level FIFOs (×1)
+    n_body_fifos = (nnodes - 1) + 2
+    assert sorted(result.values()) == sorted([ch] * 2 + [ch * iteration] * n_body_fifos)
+
+
+@pytest.mark.fpgadataflow
+def test_fifo_transaction_counts_requires_fifos():
+    # a model without any FIFOs must raise a clear assertion
+    model = make_multi_fclayer_model(64, DataType["INT4"], DataType["INT4"], 3)
+    model = model.transform(GiveUniqueNodeNames())
+    with pytest.raises(AssertionError):
+        model.analysis(fifo_transaction_counts)

--- a/tests/fpgadataflow/test_fpgadataflow_mvau.py
+++ b/tests/fpgadataflow/test_fpgadataflow_mvau.py
@@ -731,8 +731,8 @@ def test_mvau_fifocharacterize_rtlsim(
     node_inst = getCustomOp(model.graph.node[0])
     period_attr = node_inst.get_nodeattr("io_chrc_period")
     assert period_attr == exp_total_cycles
-    chrc_in = node_inst.get_nodeattr("io_chrc_in")
-    chrc_out = node_inst.get_nodeattr("io_chrc_out")
+    chrc_in = node_inst.get_io_chrc_in()
+    chrc_out = node_inst.get_io_chrc_out()
     if mem_mode == "internal_decoupled":
         assert chrc_in.shape == (2, 2 * exp_total_cycles)
     else:

--- a/tests/util/test_build_dataflow.py
+++ b/tests/util/test_build_dataflow.py
@@ -103,3 +103,19 @@ def test_end2end_build_dataflow_directory():
             assert os.path.isfile(
                 node_waveform_dir + f"/{node.name}_rtlsim_{i}.wdb"
             ), f"Missing waveform for node {node.name} in batch {i}"
+
+    # Check debug_fifo log files were created (enabled in dataflow_build_config.json)
+    fifo_log_base = output_dir + "/debug/fifo_logs"
+    assert os.path.isdir(fifo_log_base), "FIFO debug log directory not created"
+
+    # Check that fifo_sizing phase logs were created
+    fifo_sizing_dir = fifo_log_base + "/fifo_sizing/main"
+    assert os.path.isdir(fifo_sizing_dir), "FIFO sizing log directory not created"
+    fifo_sizing_logs = [f for f in os.listdir(fifo_sizing_dir) if f.endswith(".log")]
+    assert len(fifo_sizing_logs) > 0, "No FIFO debug logs created during fifo_sizing phase"
+
+    # Check that stitched_ip_rtlsim phase logs were created
+    stitched_rtlsim_dir = fifo_log_base + "/stitched_ip_rtlsim/main"
+    assert os.path.isdir(stitched_rtlsim_dir), "Stitched IP rtlsim log directory not created"
+    stitched_logs = [f for f in os.listdir(stitched_rtlsim_dir) if f.endswith(".log")]
+    assert len(stitched_logs) > 0, "No FIFO debug logs created during stitched_ip_rtlsim phase"


### PR DESCRIPTION
Improving debug capabilities by fifo_gauge and improved behavioral simulation support for verification.

What is in this PR:
- FIFO debug logging: fifo_gauge now logs all transactions to file and tracks transaction counts / max fill. Enable with `debug_fifo=True` in build config. Logs are snapshotted after fifo_sizing and
  stitched_ip_rtlsim phases to output_dir/debug/fifo_logs/.
- Consolidated simulation shutdown: New sim_ctrl module triggers `$finish` when `sim_finish` is asserted, ensuring SystemVerilog final blocks execute and flush log files. Exposed through stitched IP and FINNLoop hierarchy.
 - Behavioral RTLSim verification: New `verify_rtlsim_behavioral` flag passes -define FINN_SIMULATION to xelab, using fifo_gauge (with debug) instead of Q_srl and behavioral DSP models. Auto-enabled when `debug_fifo=true`.
- Consistent FINN_SIMULATION pattern: Elementwise ops now use the same ifdef FINN_SIMULATION pattern as MVU/LayerNorm.
- Characterization data offloading: `io_chrc_in/io_chrc_out` arrays stored as sidecar .npy files to avoid protobuf's 2GB limit.
- New analysis pass: `fifo_transaction_counts` computes expected transaction counts per FIFO for validation.