### PR TITLE
Report Invalid Custom Op Configs

### DIFF
--- a/src/finn/transformation/general.py
+++ b/src/finn/transformation/general.py
@@ -92,6 +92,11 @@ class ApplyConfig(Transformation):
                 # set node attributes from specified configuration
                 for attr_name, value in node_config.items():
                     inst.set_nodeattr(attr_name, value)
+            elif node_config:
+                warnings.warn(
+                    "\nHW configuration for node %s was ignored because %s is not a custom op. "
+                    "Configs can only be applied to custom ops." % (config_key, node.name)
+                )
 
             # Recursively handle nested subgraphs
             for attr in node.attribute:

--- a/src/finn/transformation/general.py
+++ b/src/finn/transformation/general.py
@@ -42,6 +42,7 @@ class ApplyConfig(Transformation):
         self.node_filter = node_filter
         self.used_configurations = ["Defaults"]
         self.missing_configurations = []
+        self.ignored_non_custom_configurations = []
 
     def configure_network(self, graph_proto, model_config, subgraph_hier):
         # Configure network - graph_proto can be a GraphProto or ModelWrapper
@@ -66,9 +67,6 @@ class ApplyConfig(Transformation):
                 self.missing_configurations += [node.name]
                 node_config = {}
 
-            if node_config:
-                self.used_configurations += [config_key]
-
             if is_custom_op(node.domain, node.op_type):
                 inst = getCustomOp(node)
 
@@ -92,11 +90,11 @@ class ApplyConfig(Transformation):
                 # set node attributes from specified configuration
                 for attr_name, value in node_config.items():
                     inst.set_nodeattr(attr_name, value)
+
+                if node_config:
+                    self.used_configurations += [config_key]
             elif node_config:
-                warnings.warn(
-                    "\nHW configuration for node %s was ignored because %s is not a custom op. "
-                    "Configs can only be applied to custom ops." % (config_key, node.name)
-                )
+                self.ignored_non_custom_configurations += [(config_key, node.op_type)]
 
             # Recursively handle nested subgraphs
             for attr in node.attribute:
@@ -127,9 +125,29 @@ class ApplyConfig(Transformation):
         if len(unique_missing) > 0:
             warnings.warn("\nNo HW configuration for nodes: " + ", ".join(unique_missing))
 
+        # Check for matched configs that couldn't be applied because they were
+        # specified for standard ONNX nodes instead of custom ops.
+        unique_non_custom = list(dict.fromkeys(self.ignored_non_custom_configurations))
+        if len(unique_non_custom) > 0:
+            formatted_non_custom = [
+                "{} ({})".format(config_key, op_type) for config_key, op_type in unique_non_custom
+            ]
+            warnings.warn(
+                "\nHW configurations for non-custom nodes were ignored: "
+                + ", ".join(formatted_non_custom)
+                + ". Configs can only be applied to custom ops."
+            )
+
         # Check for unused configs (top-level configs that weren't applied)
+        ignored_configurations = [
+            config_key for config_key, _ in self.ignored_non_custom_configurations
+        ]
         unused_configs = [
-            x for x in model_config if x not in self.used_configurations and x != "Defaults"
+            x
+            for x in model_config
+            if x not in self.used_configurations
+            and x not in ignored_configurations
+            and x != "Defaults"
         ]
         if len(unused_configs) > 0:
             warnings.warn("\nUnused HW configurations: " + ", ".join(unused_configs))

--- a/src/finn/transformation/general.py
+++ b/src/finn/transformation/general.py
@@ -17,7 +17,7 @@ import warnings
 
 # Protobuf onnx graph node type
 from onnx import AttributeProto, NodeProto, mapping  # noqa
-from qonnx.custom_op.registry import getCustomOp
+from qonnx.custom_op.registry import getCustomOp, is_custom_op
 from qonnx.transformation.base import Transformation
 
 
@@ -69,7 +69,7 @@ class ApplyConfig(Transformation):
             if node_config:
                 self.used_configurations += [config_key]
 
-            try:
+            if is_custom_op(node.domain, node.op_type):
                 inst = getCustomOp(node)
 
                 if "Defaults" in model_config.keys():
@@ -92,9 +92,6 @@ class ApplyConfig(Transformation):
                 # set node attributes from specified configuration
                 for attr_name, value in node_config.items():
                     inst.set_nodeattr(attr_name, value)
-            except Exception:
-                # Node is not a custom op, but it might have subgraphs
-                pass
 
             # Recursively handle nested subgraphs
             for attr in node.attribute:

--- a/tests/util/test_config.py
+++ b/tests/util/test_config.py
@@ -204,3 +204,18 @@ def test_apply_config_reports_invalid_custom_op_attr():
 
     with pytest.raises(Exception):
         model.transform(ApplyConfig({im2col_node.name: {"not_an_im2col_attr": 1}}))
+
+
+@pytest.mark.util
+def test_apply_config_warns_for_non_custom_op_config():
+    """Test explicit configs for standard ONNX nodes are reported."""
+
+    model, _ = make_im2col_test_model()
+    if_node = model.graph.node[1]
+    config = {if_node.name: {"kernel_size": [1, 1]}}
+
+    def node_filter(node):
+        return node.name == if_node.name
+
+    with pytest.warns(UserWarning, match="Configs can only be applied to custom ops"):
+        model.transform(ApplyConfig(config, node_filter=node_filter))

--- a/tests/util/test_config.py
+++ b/tests/util/test_config.py
@@ -193,3 +193,14 @@ def test_roundtrip_export_import():
 
     if os.path.exists(config_json_file):
         os.remove(config_json_file)
+
+
+@pytest.mark.util
+def test_apply_config_reports_invalid_custom_op_attr():
+    """Test invalid custom-op configs fail instead of being silently ignored."""
+
+    model, _ = make_im2col_test_model()
+    im2col_node = model.graph.node[0]
+
+    with pytest.raises(Exception):
+        model.transform(ApplyConfig({im2col_node.name: {"not_an_im2col_attr": 1}}))

--- a/tests/util/test_config.py
+++ b/tests/util/test_config.py
@@ -217,5 +217,10 @@ def test_apply_config_warns_for_non_custom_op_config():
     def node_filter(node):
         return node.name == if_node.name
 
-    with pytest.warns(UserWarning, match="Configs can only be applied to custom ops"):
+    with pytest.warns(UserWarning) as warn_records:
         model.transform(ApplyConfig(config, node_filter=node_filter))
+
+    warning_messages = [str(record.message) for record in warn_records]
+    assert any("Configs can only be applied to custom ops" in msg for msg in warning_messages)
+    assert any("{} ({})".format(if_node.name, if_node.op_type) in msg for msg in warning_messages)
+    assert not any("Unused HW configurations" in msg for msg in warning_messages)


### PR DESCRIPTION
Every exception around getCustomOp(...) and inst.set_nodeattr(...) gets caught in the same section. This means two very different cases look the same:

  1. A normal ONNX node has no FINN custom-op wrapper. That should be skipped.
  2. A FINN custom-op exists, but the config is wrong, for example a misspelled attribute name. That should fail loudly.

The old except Exception: pass hid both. So a bad config could appear to apply successfully while silently leaving the model misconfigured.