### PR TITLE
Isolate per-test scratch for parallel xdist runs [CI 5/9]

### DIFF
--- a/tests/fpgadataflow/test_convert_to_hw_layers_cnv.py
+++ b/tests/fpgadataflow/test_convert_to_hw_layers_cnv.py
@@ -31,7 +31,6 @@ import pytest
 
 import importlib_resources as importlib
 import numpy as np
-import os
 import torch
 from brevitas.export import export_qonnx
 from qonnx.core.modelwrapper import ModelWrapper
@@ -66,9 +65,8 @@ from finn.transformation.qonnx.convert_qonnx_to_finn import ConvertQONNXtoFINN
 from finn.transformation.streamline import Streamline
 from finn.transformation.streamline.reorder import MakeMaxPoolNHWC
 from finn.transformation.streamline.round_thresholds import RoundAndClipThresholds
+from finn.util.basic import make_build_dir, robust_rmtree
 from finn.util.test import get_test_model_trained
-
-export_onnx_path_cnv = "test_convert_to_hw_layers_cnv.onnx"
 
 
 @pytest.mark.fpgadataflow
@@ -76,6 +74,15 @@ export_onnx_path_cnv = "test_convert_to_hw_layers_cnv.onnx"
 # Standalone or fused thresholding-based activation
 @pytest.mark.parametrize("fused_activation", [True, False])
 def test_convert_to_hw_layers_cnv_w1a1(fused_activation):
+    build_dir = make_build_dir(prefix="test_convert_to_hw_layers_cnv_")
+    try:
+        _test_convert_to_hw_layers_cnv_w1a1(fused_activation, build_dir)
+    finally:
+        robust_rmtree(build_dir)
+
+
+def _test_convert_to_hw_layers_cnv_w1a1(fused_activation, build_dir):
+    export_onnx_path_cnv = f"{build_dir}/test_convert_to_hw_layers_cnv.onnx"
     cnv = get_test_model_trained("CNV", 1, 1)
     export_qonnx(cnv, torch.randn(1, 3, 32, 32), export_onnx_path_cnv)
     qonnx_cleanup(export_onnx_path_cnv, out_file=export_onnx_path_cnv)
@@ -167,4 +174,3 @@ def test_convert_to_hw_layers_cnv_w1a1(fused_activation):
     produced = produced_ctx[model.get_first_global_out()]
     assert np.isclose(expected, produced, atol=1e-3).all()
     assert np.argmax(produced) == 3
-    os.remove(export_onnx_path_cnv)

--- a/tests/fpgadataflow/test_convert_to_hw_layers_fc.py
+++ b/tests/fpgadataflow/test_convert_to_hw_layers_fc.py
@@ -32,7 +32,6 @@ import pytest
 import numpy as np
 import onnx
 import onnx.numpy_helper as nph
-import os
 import torch
 from brevitas.export import export_qonnx
 from pkgutil import get_data
@@ -58,14 +57,22 @@ from finn.transformation.fpgadataflow.specialize_layers import SpecializeLayers
 from finn.transformation.qonnx.convert_qonnx_to_finn import ConvertQONNXtoFINN
 from finn.transformation.streamline import Streamline
 from finn.transformation.streamline.round_thresholds import RoundAndClipThresholds
+from finn.util.basic import make_build_dir, robust_rmtree
 from finn.util.test import get_test_model_trained
-
-export_onnx_path = "test_convert_to_hw_layers_fc.onnx"
 
 
 @pytest.mark.fpgadataflow
 @pytest.mark.vivado
 def test_convert_to_hw_layers_tfc_w1a1():
+    build_dir = make_build_dir(prefix="test_convert_to_hw_layers_tfc_w1a1_")
+    try:
+        _test_convert_to_hw_layers_tfc_w1a1(build_dir)
+    finally:
+        robust_rmtree(build_dir)
+
+
+def _test_convert_to_hw_layers_tfc_w1a1(build_dir):
+    export_onnx_path = f"{build_dir}/test_convert_to_hw_layers_fc.onnx"
     tfc = get_test_model_trained("TFC", 1, 1)
     export_qonnx(tfc, torch.randn(1, 1, 28, 28), export_onnx_path)
     qonnx_cleanup(export_onnx_path, out_file=export_onnx_path)
@@ -135,12 +142,20 @@ def test_convert_to_hw_layers_tfc_w1a1():
     # do forward pass in PyTorch/Brevitas
     expected = tfc.forward(input_tensor).detach().numpy()
     assert np.isclose(produced, expected, atol=1e-3).all()
-    os.remove(export_onnx_path)
 
 
 @pytest.mark.fpgadataflow
 @pytest.mark.vivado
 def test_convert_to_hw_layers_tfc_w1a2():
+    build_dir = make_build_dir(prefix="test_convert_to_hw_layers_tfc_w1a2_")
+    try:
+        _test_convert_to_hw_layers_tfc_w1a2(build_dir)
+    finally:
+        robust_rmtree(build_dir)
+
+
+def _test_convert_to_hw_layers_tfc_w1a2(build_dir):
+    export_onnx_path = f"{build_dir}/test_convert_to_hw_layers_fc.onnx"
     tfc = get_test_model_trained("TFC", 1, 2)
     export_qonnx(tfc, torch.randn(1, 1, 28, 28), export_onnx_path)
     qonnx_cleanup(export_onnx_path, out_file=export_onnx_path)
@@ -205,4 +220,3 @@ def test_convert_to_hw_layers_tfc_w1a2():
     golden_output_dict = oxe.execute_onnx(model, input_dict, True)
     expected = golden_output_dict[model.get_first_global_out()]
     assert np.isclose(produced, expected, atol=1e-3).all()
-    os.remove(export_onnx_path)

--- a/tests/fpgadataflow/test_convert_to_hw_layers_synthetic.py
+++ b/tests/fpgadataflow/test_convert_to_hw_layers_synthetic.py
@@ -29,7 +29,6 @@
 import pytest
 
 import numpy as np
-import os
 from onnx import TensorProto, helper
 from qonnx.core.datatype import DataType
 from qonnx.core.modelwrapper import ModelWrapper
@@ -69,9 +68,8 @@ from finn.transformation.streamline.reorder import (
     MoveAddPastMul,
     MoveScalarLinearPastInvariants,
 )
+from finn.util.basic import make_build_dir, robust_rmtree
 from finn.util.test import soft_verify_topk
-
-export_onnx_path = "test_output_synthetic.onnx"
 
 # construct a synthetic graph to test:
 # topk insertion, topk conversion to hw, add conversion to hw
@@ -144,6 +142,15 @@ def make_model(ch, ifmdim):
 @pytest.mark.vivado
 @pytest.mark.slow
 def test_convert_to_hw_layers_synthetic(ch, ifmdim, idt):
+    build_dir = make_build_dir(prefix="test_convert_to_hw_layers_synthetic_")
+    try:
+        _test_convert_to_hw_layers_synthetic(ch, ifmdim, idt, build_dir)
+    finally:
+        robust_rmtree(build_dir)
+
+
+def _test_convert_to_hw_layers_synthetic(ch, ifmdim, idt, build_dir):
+    export_onnx_path = f"{build_dir}/test_output_synthetic.onnx"
     model = make_model(ch, ifmdim)
     model.save(export_onnx_path)
     model = ModelWrapper(export_onnx_path, fix_float64=True)
@@ -250,5 +257,3 @@ def test_convert_to_hw_layers_synthetic(ch, ifmdim, idt):
     produced_topk_hls = output_dict[outp_name]
     topk_input = output_dict[model.graph.node[-1].input[0]]
     assert soft_verify_topk(topk_input, produced_topk_hls, 5)
-
-    os.remove(export_onnx_path)

--- a/tests/fpgadataflow/test_fpgadataflow_lookup.py
+++ b/tests/fpgadataflow/test_fpgadataflow_lookup.py
@@ -53,12 +53,11 @@ from finn.transformation.fpgadataflow.prepare_rtlsim import PrepareRTLSim
 from finn.transformation.fpgadataflow.set_exec_mode import SetExecMode
 from finn.transformation.fpgadataflow.specialize_layers import SpecializeLayers
 from finn.transformation.qonnx.convert_qonnx_to_finn import ConvertQONNXtoFINN
-from finn.util.basic import get_vivado_version
-
-export_onnx_path = "test_lookup.onnx"
+from finn.util.basic import get_vivado_version, make_build_dir, robust_rmtree
 
 
-def make_lookup_model(embeddings, ishape, idt, edt):
+def make_lookup_model(embeddings, ishape, idt, edt, build_dir):
+    export_onnx_path = f"{build_dir}/test_lookup.onnx"
     num_embeddings, embedding_dim = embeddings.shape
 
     class LookupModel(nn.Module):
@@ -111,6 +110,14 @@ def make_lookup_model(embeddings, ishape, idt, edt):
 @pytest.mark.vivado
 @pytest.mark.slow
 def test_fpgadataflow_lookup(edt, embedding_cfg, exec_mode, fpga_part, ram_style):
+    build_dir = make_build_dir(prefix="test_fpgadataflow_lookup_")
+    try:
+        _test_fpgadataflow_lookup(edt, embedding_cfg, exec_mode, fpga_part, ram_style, build_dir)
+    finally:
+        robust_rmtree(build_dir)
+
+
+def _test_fpgadataflow_lookup(edt, embedding_cfg, exec_mode, fpga_part, ram_style, build_dir):
     # Skip URAM on old Vivado versions
     if ram_style == "ultra":
         vivado_version = get_vivado_version()
@@ -122,7 +129,7 @@ def test_fpgadataflow_lookup(edt, embedding_cfg, exec_mode, fpga_part, ram_style
     eshape = (num_embeddings, embedding_dim)
     exp_oshape = tuple(list(ishape) + [embedding_dim])
     embeddings = gen_finn_dt_tensor(edt, eshape)
-    model = make_lookup_model(embeddings, ishape, idt, edt)
+    model = make_lookup_model(embeddings, ishape, idt, edt, build_dir)
     assert len(model.graph.node) == 1
     assert model.graph.node[0].op_type == "Gather"
     iname = model.get_first_global_in()
@@ -171,6 +178,14 @@ def test_fpgadataflow_lookup(edt, embedding_cfg, exec_mode, fpga_part, ram_style
 @pytest.mark.vivado
 @pytest.mark.slow
 def test_fpgadataflow_lookup_external():
+    build_dir = make_build_dir(prefix="test_fpgadataflow_lookup_external_")
+    try:
+        _test_fpgadataflow_lookup_external(build_dir)
+    finally:
+        robust_rmtree(build_dir)
+
+
+def _test_fpgadataflow_lookup_external(build_dir):
     fpga_part = "xczu3eg-sbva484-1-e"
     edt = DataType["INT8"]
     embedding_cfg = (200000, DataType["UINT32"], 300)
@@ -179,7 +194,7 @@ def test_fpgadataflow_lookup_external():
     eshape = (num_embeddings, embedding_dim)
     exp_oshape = tuple(list(ishape) + [embedding_dim])
     embeddings = gen_finn_dt_tensor(edt, eshape)
-    model = make_lookup_model(embeddings, ishape, idt, edt)
+    model = make_lookup_model(embeddings, ishape, idt, edt, build_dir)
     assert len(model.graph.node) == 1
     assert model.graph.node[0].op_type == "Gather"
     iname = model.get_first_global_in()

--- a/tests/fpgadataflow/test_fpgadataflow_softmax.py
+++ b/tests/fpgadataflow/test_fpgadataflow_softmax.py
@@ -28,10 +28,10 @@ from finn.transformation.fpgadataflow.prepare_ip import PrepareIP
 from finn.transformation.fpgadataflow.prepare_rtlsim import PrepareRTLSim
 from finn.transformation.fpgadataflow.set_exec_mode import SetExecMode
 from finn.transformation.fpgadataflow.specialize_layers import SpecializeLayers
+from finn.util.basic import make_build_dir, robust_rmtree
 
 test_fpga_part: str = "xczu7ev-ffvc1156-2-e"
 target_clk_ns = 5
-export_onnx_path = "pytest_softmax_dut.onnx"
 
 
 class SoftMaxSimple(nn.Module):
@@ -44,7 +44,8 @@ class SoftMaxSimple(nn.Module):
         return x
 
 
-def create_softmax_model(io_shape, idt):
+def create_softmax_model(io_shape, idt, build_dir):
+    export_onnx_path = f"{build_dir}/pytest_softmax_dut.onnx"
     dut = SoftMaxSimple()
     input = torch.rand(io_shape)
     export_qonnx(dut, input, export_onnx_path, opset_version=11)
@@ -61,11 +62,19 @@ def create_softmax_model(io_shape, idt):
 @pytest.mark.fpgadataflow
 @pytest.mark.vivado
 def test_fpgadataflow_hwsoftmax(simd, idt, exec_mode, ifm_dim):
+    build_dir = make_build_dir(prefix="test_fpgadataflow_hwsoftmax_")
+    try:
+        _test_fpgadataflow_hwsoftmax(simd, idt, exec_mode, ifm_dim, build_dir)
+    finally:
+        robust_rmtree(build_dir)
+
+
+def _test_fpgadataflow_hwsoftmax(simd, idt, exec_mode, ifm_dim, build_dir):
     idt = DataType[idt]
     io_shape = ifm_dim
     tollerance = 1e-5
 
-    model = create_softmax_model(io_shape, idt)
+    model = create_softmax_model(io_shape, idt, build_dir)
 
     input = gen_finn_dt_tensor(idt, io_shape)
     in_name = model.graph.input[0].name

--- a/tests/transformation/streamline/test_sign_to_thres.py
+++ b/tests/transformation/streamline/test_sign_to_thres.py
@@ -30,7 +30,6 @@ import pytest
 
 import onnx
 import onnx.numpy_helper as nph
-import os
 import torch
 from brevitas.export import export_qonnx
 from pkgutil import get_data
@@ -42,25 +41,28 @@ from qonnx.util.cleanup import cleanup as qonnx_cleanup
 import finn.core.onnx_exec as oxe
 from finn.transformation.qonnx.convert_qonnx_to_finn import ConvertQONNXtoFINN
 from finn.transformation.streamline import ConvertSignToThres
+from finn.util.basic import make_build_dir, robust_rmtree
 from finn.util.test import get_test_model_trained
-
-export_onnx_path = "test_sign_to_thres.onnx"
 
 
 @pytest.mark.streamline
 def test_sign_to_thres():
-    lfc = get_test_model_trained("LFC", 1, 1)
-    export_qonnx(lfc, torch.randn(1, 1, 28, 28), export_onnx_path)
-    qonnx_cleanup(export_onnx_path, out_file=export_onnx_path)
-    model = ModelWrapper(export_onnx_path)
-    model = model.transform(ConvertQONNXtoFINN())
-    model = model.transform(InferShapes())
-    model = model.transform(FoldConstants())
-    new_model = model.transform(ConvertSignToThres())
-    assert new_model.graph.node[3].op_type == "MultiThreshold"
-    # load one of the test vectors
-    raw_i = get_data("qonnx.data", "onnx/mnist-conv/test_data_set_0/input_0.pb")
-    input_tensor = onnx.load_tensor_from_string(raw_i)
-    input_dict = {model.get_first_global_in(): nph.to_array(input_tensor)}
-    assert oxe.compare_execution(model, new_model, input_dict)
-    os.remove(export_onnx_path)
+    build_dir = make_build_dir(prefix="test_sign_to_thres_")
+    try:
+        export_onnx_path = f"{build_dir}/test_sign_to_thres.onnx"
+        lfc = get_test_model_trained("LFC", 1, 1)
+        export_qonnx(lfc, torch.randn(1, 1, 28, 28), export_onnx_path)
+        qonnx_cleanup(export_onnx_path, out_file=export_onnx_path)
+        model = ModelWrapper(export_onnx_path)
+        model = model.transform(ConvertQONNXtoFINN())
+        model = model.transform(InferShapes())
+        model = model.transform(FoldConstants())
+        new_model = model.transform(ConvertSignToThres())
+        assert new_model.graph.node[3].op_type == "MultiThreshold"
+        # load one of the test vectors
+        raw_i = get_data("qonnx.data", "onnx/mnist-conv/test_data_set_0/input_0.pb")
+        input_tensor = onnx.load_tensor_from_string(raw_i)
+        input_dict = {model.get_first_global_in(): nph.to_array(input_tensor)}
+        assert oxe.compare_execution(model, new_model, input_dict)
+    finally:
+        robust_rmtree(build_dir)

--- a/tests/transformation/test_batchnorm_to_affine_bnn_pynq.py
+++ b/tests/transformation/test_batchnorm_to_affine_bnn_pynq.py
@@ -32,7 +32,6 @@ import importlib_resources as importlib
 import numpy as np
 import onnx
 import onnx.numpy_helper as nph
-import os
 import torch
 from brevitas.export import export_qonnx
 from pkgutil import get_data
@@ -44,52 +43,59 @@ from qonnx.util.cleanup import cleanup as qonnx_cleanup
 
 import finn.core.onnx_exec as oxe
 from finn.transformation.qonnx.convert_qonnx_to_finn import ConvertQONNXtoFINN
+from finn.util.basic import make_build_dir, robust_rmtree
 from finn.util.test import get_test_model_trained
-
-export_onnx_path = "test_output_bn2affine.onnx"
 
 
 @pytest.mark.transform
 def test_batchnorm_to_affine_cnv_w1a1():
-    lfc = get_test_model_trained("CNV", 1, 1)
-    export_qonnx(lfc, torch.randn(1, 3, 32, 32), export_onnx_path)
-    qonnx_cleanup(export_onnx_path, out_file=export_onnx_path)
-    model = ModelWrapper(export_onnx_path)
-    model = model.transform(ConvertQONNXtoFINN())
-    model = model.transform(InferShapes())
-    model = model.transform(FoldConstants())
-    ref = importlib.files("finn.qnn-data") / "cifar10/cifar10-test-data-class3.npz"
-    with importlib.as_file(ref) as fn:
-        input_tensor = np.load(fn)["arr_0"].astype(np.float32)
-    input_tensor = input_tensor / 255
-    assert input_tensor.shape == (1, 3, 32, 32)
-    input_dict = {model.get_first_global_in(): input_tensor}
-    output_dict = oxe.execute_onnx(model, input_dict)
-    expected = output_dict[list(output_dict.keys())[0]]
-    new_model = model.transform(BatchNormToAffine())
-    # check that there are no BN nodes left
-    op_types = list(map(lambda x: x.op_type, new_model.graph.node))
-    assert "BatchNormalization" not in op_types
-    output_dict_p = oxe.execute_onnx(new_model, input_dict)
-    produced = output_dict_p[list(output_dict_p.keys())[0]]
-    assert np.isclose(expected, produced).all()
-    assert np.argmax(produced) == 3
-    os.remove(export_onnx_path)
+    build_dir = make_build_dir(prefix="test_batchnorm_to_affine_cnv_")
+    try:
+        export_onnx_path = f"{build_dir}/test_output_bn2affine.onnx"
+        lfc = get_test_model_trained("CNV", 1, 1)
+        export_qonnx(lfc, torch.randn(1, 3, 32, 32), export_onnx_path)
+        qonnx_cleanup(export_onnx_path, out_file=export_onnx_path)
+        model = ModelWrapper(export_onnx_path)
+        model = model.transform(ConvertQONNXtoFINN())
+        model = model.transform(InferShapes())
+        model = model.transform(FoldConstants())
+        ref = importlib.files("finn.qnn-data") / "cifar10/cifar10-test-data-class3.npz"
+        with importlib.as_file(ref) as fn:
+            input_tensor = np.load(fn)["arr_0"].astype(np.float32)
+        input_tensor = input_tensor / 255
+        assert input_tensor.shape == (1, 3, 32, 32)
+        input_dict = {model.get_first_global_in(): input_tensor}
+        output_dict = oxe.execute_onnx(model, input_dict)
+        expected = output_dict[list(output_dict.keys())[0]]
+        new_model = model.transform(BatchNormToAffine())
+        # check that there are no BN nodes left
+        op_types = list(map(lambda x: x.op_type, new_model.graph.node))
+        assert "BatchNormalization" not in op_types
+        output_dict_p = oxe.execute_onnx(new_model, input_dict)
+        produced = output_dict_p[list(output_dict_p.keys())[0]]
+        assert np.isclose(expected, produced).all()
+        assert np.argmax(produced) == 3
+    finally:
+        robust_rmtree(build_dir)
 
 
 @pytest.mark.transform
 def test_batchnorm_to_affine_lfc_w1a1():
-    lfc = get_test_model_trained("LFC", 1, 1)
-    export_qonnx(lfc, torch.randn(1, 1, 28, 28), export_onnx_path)
-    qonnx_cleanup(export_onnx_path, out_file=export_onnx_path)
-    model = ModelWrapper(export_onnx_path)
-    model = model.transform(ConvertQONNXtoFINN())
-    model = model.transform(InferShapes())
-    model = model.transform(FoldConstants())
-    new_model = model.transform(BatchNormToAffine())
-    # load one of the test vectors
-    raw_i = get_data("qonnx.data", "onnx/mnist-conv/test_data_set_0/input_0.pb")
-    input_tensor = onnx.load_tensor_from_string(raw_i)
-    input_dict = {model.get_first_global_in(): nph.to_array(input_tensor)}
-    assert oxe.compare_execution(model, new_model, input_dict)
-    os.remove(export_onnx_path)
+    build_dir = make_build_dir(prefix="test_batchnorm_to_affine_lfc_")
+    try:
+        export_onnx_path = f"{build_dir}/test_output_bn2affine.onnx"
+        lfc = get_test_model_trained("LFC", 1, 1)
+        export_qonnx(lfc, torch.randn(1, 1, 28, 28), export_onnx_path)
+        qonnx_cleanup(export_onnx_path, out_file=export_onnx_path)
+        model = ModelWrapper(export_onnx_path)
+        model = model.transform(ConvertQONNXtoFINN())
+        model = model.transform(InferShapes())
+        model = model.transform(FoldConstants())
+        new_model = model.transform(BatchNormToAffine())
+        # load one of the test vectors
+        raw_i = get_data("qonnx.data", "onnx/mnist-conv/test_data_set_0/input_0.pb")
+        input_tensor = onnx.load_tensor_from_string(raw_i)
+        input_dict = {model.get_first_global_in(): nph.to_array(input_tensor)}
+        assert oxe.compare_execution(model, new_model, input_dict)
+    finally:
+        robust_rmtree(build_dir)

--- a/tests/transformation/test_infer_data_layouts_cnv.py
+++ b/tests/transformation/test_infer_data_layouts_cnv.py
@@ -29,7 +29,6 @@
 
 import pytest
 
-import os
 import qonnx.core.data_layout as DataLayout
 import torch
 from brevitas.export import export_qonnx
@@ -51,74 +50,76 @@ import finn.transformation.streamline.absorb as absorb
 from finn.transformation.qonnx.convert_qonnx_to_finn import ConvertQONNXtoFINN
 from finn.transformation.streamline import Streamline
 from finn.transformation.streamline.reorder import MakeMaxPoolNHWC
+from finn.util.basic import make_build_dir, robust_rmtree
 from finn.util.test import get_test_model_trained
-
-export_onnx_path_cnv = "test_infer_data_layouts.onnx"
 
 
 @pytest.mark.transform
 @pytest.mark.xfail
 def test_infer_data_layouts_cnv():
-    cnv = get_test_model_trained("CNV", 1, 1)
-    export_qonnx(cnv, torch.randn(1, 3, 32, 32), export_onnx_path_cnv)
-    qonnx_cleanup(export_onnx_path_cnv, out_file=export_onnx_path_cnv)
-    model = ModelWrapper(export_onnx_path_cnv)
-    model = model.transform(ConvertQONNXtoFINN())
-    model = model.transform(InferShapes())
-    model = model.transform(FoldConstants())
-    model = model.transform(GiveUniqueNodeNames())
-    model = model.transform(GiveUniqueParameterTensors())
-    model = model.transform(GiveReadableTensorNames())
-    model = model.transform(Streamline())
-    model = model.transform(InferDataLayouts())
+    build_dir = make_build_dir(prefix="test_infer_data_layouts_cnv_")
+    try:
+        export_onnx_path_cnv = f"{build_dir}/test_infer_data_layouts.onnx"
+        cnv = get_test_model_trained("CNV", 1, 1)
+        export_qonnx(cnv, torch.randn(1, 3, 32, 32), export_onnx_path_cnv)
+        qonnx_cleanup(export_onnx_path_cnv, out_file=export_onnx_path_cnv)
+        model = ModelWrapper(export_onnx_path_cnv)
+        model = model.transform(ConvertQONNXtoFINN())
+        model = model.transform(InferShapes())
+        model = model.transform(FoldConstants())
+        model = model.transform(GiveUniqueNodeNames())
+        model = model.transform(GiveUniqueParameterTensors())
+        model = model.transform(GiveReadableTensorNames())
+        model = model.transform(Streamline())
+        model = model.transform(InferDataLayouts())
 
-    assert model.get_tensor_layout("global_in") == DataLayout.NCHW
-    assert model.get_tensor_layout("Conv_0_out0") == DataLayout.NCHW
-    assert model.get_tensor_layout("MaxPool_0_out0") == DataLayout.NCHW
-    assert model.get_tensor_layout("MultiThreshold_6_out0") == DataLayout.NCHW
-    assert model.get_tensor_layout("Reshape_0_out0") == DataLayout.NC
-    assert model.get_tensor_layout("MatMul_0_out0") == DataLayout.NC
-    assert model.get_tensor_layout("global_out") == DataLayout.NC
+        assert model.get_tensor_layout("global_in") == DataLayout.NCHW
+        assert model.get_tensor_layout("Conv_0_out0") == DataLayout.NCHW
+        assert model.get_tensor_layout("MaxPool_0_out0") == DataLayout.NCHW
+        assert model.get_tensor_layout("MultiThreshold_6_out0") == DataLayout.NCHW
+        assert model.get_tensor_layout("Reshape_0_out0") == DataLayout.NC
+        assert model.get_tensor_layout("MatMul_0_out0") == DataLayout.NC
+        assert model.get_tensor_layout("global_out") == DataLayout.NC
 
-    model = model.transform(LowerConvsToMatMul())
-    model = model.transform(MakeMaxPoolNHWC())
-    model = model.transform(GiveUniqueNodeNames())
-    model = model.transform(GiveReadableTensorNames())
-    model = model.transform(InferDataLayouts())
+        model = model.transform(LowerConvsToMatMul())
+        model = model.transform(MakeMaxPoolNHWC())
+        model = model.transform(GiveUniqueNodeNames())
+        model = model.transform(GiveReadableTensorNames())
+        model = model.transform(InferDataLayouts())
 
-    assert model.get_tensor_layout("global_in") == DataLayout.NCHW
-    assert model.get_tensor_layout("Transpose_0_out0") == DataLayout.NHWC
-    assert model.get_tensor_layout("Im2Col_0_out0") == DataLayout.NHWC
-    # note: im2col output isn't really NHWC or any other common layout
-    # since the concept of channels changes with lowering... but it is
-    # conceptually close to NHWC since the innermost dim gets multiplied
-    assert model.get_tensor_layout("MatMul_0_out0") == DataLayout.NHWC
-    assert model.get_tensor_layout("Transpose_1_out0") == DataLayout.NCHW
-    assert model.get_tensor_layout("Transpose_2_out0") == DataLayout.NHWC
-    assert model.get_tensor_layout("MaxPoolNHWC_0_out0") == DataLayout.NHWC
-    assert model.get_tensor_layout("Reshape_0_out0") == DataLayout.NC
-    assert model.get_tensor_layout("global_out") == DataLayout.NC
+        assert model.get_tensor_layout("global_in") == DataLayout.NCHW
+        assert model.get_tensor_layout("Transpose_0_out0") == DataLayout.NHWC
+        assert model.get_tensor_layout("Im2Col_0_out0") == DataLayout.NHWC
+        # note: im2col output isn't really NHWC or any other common layout
+        # since the concept of channels changes with lowering... but it is
+        # conceptually close to NHWC since the innermost dim gets multiplied
+        assert model.get_tensor_layout("MatMul_0_out0") == DataLayout.NHWC
+        assert model.get_tensor_layout("Transpose_1_out0") == DataLayout.NCHW
+        assert model.get_tensor_layout("Transpose_2_out0") == DataLayout.NHWC
+        assert model.get_tensor_layout("MaxPoolNHWC_0_out0") == DataLayout.NHWC
+        assert model.get_tensor_layout("Reshape_0_out0") == DataLayout.NC
+        assert model.get_tensor_layout("global_out") == DataLayout.NC
 
-    model = model.transform(absorb.AbsorbTransposeIntoMultiThreshold())
-    model = model.transform(ConvertBipolarMatMulToXnorPopcount())
-    model = model.transform(Streamline())
-    model = model.transform(to_hw.InferBinaryMatrixVectorActivation())
-    model = model.transform(to_hw.InferQuantizedMatrixVectorActivation())
-    model = model.transform(to_hw.InferConvInpGen())
-    model = model.transform(to_hw.InferPool())
-    model = model.transform(GiveUniqueNodeNames())
-    model = model.transform(GiveReadableTensorNames())
-    model = model.transform(InferDataLayouts())
+        model = model.transform(absorb.AbsorbTransposeIntoMultiThreshold())
+        model = model.transform(ConvertBipolarMatMulToXnorPopcount())
+        model = model.transform(Streamline())
+        model = model.transform(to_hw.InferBinaryMatrixVectorActivation())
+        model = model.transform(to_hw.InferQuantizedMatrixVectorActivation())
+        model = model.transform(to_hw.InferConvInpGen())
+        model = model.transform(to_hw.InferPool())
+        model = model.transform(GiveUniqueNodeNames())
+        model = model.transform(GiveReadableTensorNames())
+        model = model.transform(InferDataLayouts())
 
-    assert model.get_tensor_layout("global_in") == DataLayout.NCHW
-    assert model.get_tensor_layout("Transpose_0_out0") == DataLayout.NHWC
-    # note: im2col output isn't really NHWC or any other common layout
-    # since the concept of channels changes with lowering... but it is
-    # conceptually close to NHWC since the innermost dim gets multiplied
-    assert model.get_tensor_layout("ConvolutionInputGenerator_0_out0") == DataLayout.NHWC
-    assert model.get_tensor_layout("MVAU_3_out0") == DataLayout.NHWC
-    assert model.get_tensor_layout("Reshape_0_out0") == DataLayout.NC
-    assert model.get_tensor_layout("MVAU_6_out0") == DataLayout.NC
-    assert model.get_tensor_layout("global_out") == DataLayout.NC
-
-    os.remove(export_onnx_path_cnv)
+        assert model.get_tensor_layout("global_in") == DataLayout.NCHW
+        assert model.get_tensor_layout("Transpose_0_out0") == DataLayout.NHWC
+        # note: im2col output isn't really NHWC or any other common layout
+        # since the concept of channels changes with lowering... but it is
+        # conceptually close to NHWC since the innermost dim gets multiplied
+        assert model.get_tensor_layout("ConvolutionInputGenerator_0_out0") == DataLayout.NHWC
+        assert model.get_tensor_layout("MVAU_3_out0") == DataLayout.NHWC
+        assert model.get_tensor_layout("Reshape_0_out0") == DataLayout.NC
+        assert model.get_tensor_layout("MVAU_6_out0") == DataLayout.NC
+        assert model.get_tensor_layout("global_out") == DataLayout.NC
+    finally:
+        robust_rmtree(build_dir)

--- a/tests/transformation/test_infer_datatypes_lfc.py
+++ b/tests/transformation/test_infer_datatypes_lfc.py
@@ -28,7 +28,6 @@
 
 import pytest
 
-import os
 import torch
 from brevitas.export import export_qonnx
 from qonnx.core.datatype import DataType
@@ -40,29 +39,32 @@ from qonnx.transformation.infer_shapes import InferShapes
 from qonnx.util.cleanup import cleanup as qonnx_cleanup
 
 from finn.transformation.qonnx.convert_qonnx_to_finn import ConvertQONNXtoFINN
+from finn.util.basic import make_build_dir, robust_rmtree
 from finn.util.test import get_test_model_trained
-
-export_onnx_path = "test_infer_datatypes.onnx"
 
 
 @pytest.mark.transform
 def test_infer_datatypes_lfc():
-    lfc = get_test_model_trained("LFC", 1, 1)
-    export_qonnx(lfc, torch.randn(1, 1, 28, 28), export_onnx_path)
-    qonnx_cleanup(export_onnx_path, out_file=export_onnx_path)
-    model = ModelWrapper(export_onnx_path)
-    model = model.transform(ConvertQONNXtoFINN())
-    model = model.transform(InferShapes())
-    model = model.transform(FoldConstants())
-    model = model.transform(GiveUniqueNodeNames())
-    model = model.transform(GiveReadableTensorNames())
-    model = model.transform(InferDataTypes())
-    assert model.get_tensor_datatype("MatMul_0_out0") == DataType["INT32"]
-    assert model.get_tensor_datatype("MatMul_1_out0") == DataType["INT32"]
-    assert model.get_tensor_datatype("MatMul_2_out0") == DataType["INT32"]
-    assert model.get_tensor_datatype("MatMul_3_out0") == DataType["INT32"]
-    assert model.get_tensor_datatype("MultiThreshold_0_out0") == DataType["BIPOLAR"]
-    assert model.get_tensor_datatype("MultiThreshold_1_out0") == DataType["BIPOLAR"]
-    assert model.get_tensor_datatype("MultiThreshold_2_out0") == DataType["BIPOLAR"]
-    assert model.get_tensor_datatype("MultiThreshold_3_out0") == DataType["BIPOLAR"]
-    os.remove(export_onnx_path)
+    build_dir = make_build_dir(prefix="test_infer_datatypes_lfc_")
+    try:
+        export_onnx_path = f"{build_dir}/test_infer_datatypes.onnx"
+        lfc = get_test_model_trained("LFC", 1, 1)
+        export_qonnx(lfc, torch.randn(1, 1, 28, 28), export_onnx_path)
+        qonnx_cleanup(export_onnx_path, out_file=export_onnx_path)
+        model = ModelWrapper(export_onnx_path)
+        model = model.transform(ConvertQONNXtoFINN())
+        model = model.transform(InferShapes())
+        model = model.transform(FoldConstants())
+        model = model.transform(GiveUniqueNodeNames())
+        model = model.transform(GiveReadableTensorNames())
+        model = model.transform(InferDataTypes())
+        assert model.get_tensor_datatype("MatMul_0_out0") == DataType["INT32"]
+        assert model.get_tensor_datatype("MatMul_1_out0") == DataType["INT32"]
+        assert model.get_tensor_datatype("MatMul_2_out0") == DataType["INT32"]
+        assert model.get_tensor_datatype("MatMul_3_out0") == DataType["INT32"]
+        assert model.get_tensor_datatype("MultiThreshold_0_out0") == DataType["BIPOLAR"]
+        assert model.get_tensor_datatype("MultiThreshold_1_out0") == DataType["BIPOLAR"]
+        assert model.get_tensor_datatype("MultiThreshold_2_out0") == DataType["BIPOLAR"]
+        assert model.get_tensor_datatype("MultiThreshold_3_out0") == DataType["BIPOLAR"]
+    finally:
+        robust_rmtree(build_dir)

--- a/tests/transformation/test_loop_rolling.py
+++ b/tests/transformation/test_loop_rolling.py
@@ -3,11 +3,11 @@ import pytest
 import brevitas.onnx as bo
 import numpy as np
 import onnx
-import os
 import qonnx.util.basic as util
 import torch
 from brevitas.nn import QuantLinear
 from brevitas.quant import Int8ActPerTensorFloat, Int8WeightPerTensorFloat
+from pathlib import Path
 from qonnx.core.datatype import DataType
 from qonnx.core.modelwrapper import ModelWrapper
 from qonnx.transformation.general import (
@@ -35,6 +35,7 @@ from finn.transformation.streamline.reorder import (
     MoveScalarAddPastMatMul,
     MoveScalarMulPastMatMul,
 )
+from finn.util.basic import make_build_dir, robust_rmtree
 
 
 class SimpleSubModule(torch.nn.Module):
@@ -77,7 +78,7 @@ class SimpleModule(torch.nn.Module):
 
 
 # export the model to ONNX format using dynamo
-def export_model_to_qonnx(input_size=10, hidden_size=20, num_layers=4, output_size=None):
+def export_model_to_qonnx(out_dir, input_size=10, hidden_size=20, num_layers=4, output_size=None):
     model = SimpleModule(
         input_size=input_size,
         hidden_size=hidden_size,
@@ -89,8 +90,8 @@ def export_model_to_qonnx(input_size=10, hidden_size=20, num_layers=4, output_si
     model(x)  # Initialise scale factors
     model.eval()
 
-    # Export the model to ONNX format
-    onnx_path = os.environ["FINN_BUILD_DIR"] + f"/simple_module_{num_layers}layers.onnx"
+    # per-test out_dir so concurrent workers never share this export path
+    onnx_path = str(out_dir / f"simple_module_{num_layers}layers.onnx")
     with torch.no_grad():
         bo.export_qonnx(
             model,
@@ -122,10 +123,18 @@ def check_tensor_shape(model_wrapper, name, expected_shape):
 # num_layers
 @pytest.mark.parametrize("num_layers", [6, 12, 24])
 @pytest.mark.transform
-def test_finn_loop(input_size, num_layers):
+def test_finn_loop(input_size, num_layers, monkeypatch):
+    out_dir = Path(make_build_dir(prefix="test_finn_loop_"))
+    # LoopExtraction saves and reloads a fixed-name loop-body-template.onnx in
+    # the cwd, so run each case in its own build dir (kept on failure for
+    # debugging) to stop concurrent workers racing on that file
+    monkeypatch.chdir(out_dir)
+    # fixed seed so the deep quantised configs stay within tolerance run to run
+    torch.manual_seed(0)
+    np.random.seed(0)
     hidden_size = input_size
 
-    onnx_path, model = export_model_to_qonnx(input_size, hidden_size, num_layers)
+    onnx_path, model = export_model_to_qonnx(out_dir, input_size, hidden_size, num_layers)
 
     qonnx_cleanup(onnx_path, out_file=onnx_path)
     model_wrapper = ModelWrapper(onnx_path)
@@ -229,12 +238,15 @@ def test_finn_loop(input_size, num_layers):
         produced, expected, rtol=rtol, atol=atol
     ), "Results do not match within tolerance!"
 
-    # when run successfully, delete temp onnx files
-    os.remove(onnx_path)
+    # on success drop the per-test scratch dir, kept on failure for debugging
+    robust_rmtree(out_dir)
 
 
 @pytest.mark.transform
-def test_inconsistent_initializer_shape():
+def test_inconsistent_initializer_shape(monkeypatch):
+    out_dir = Path(make_build_dir(prefix="test_inconsistent_initializer_"))
+    # isolate LoopExtraction's fixed-name cwd file per test, see test_finn_loop
+    monkeypatch.chdir(out_dir)
     # test that if the initializer shape is inconsistent with the value info
     # shape, the transformation fails
     input_size = 20
@@ -242,7 +254,9 @@ def test_inconsistent_initializer_shape():
     num_layers = 6
     output_size = None
 
-    onnx_path, model = export_model_to_qonnx(input_size, hidden_size, num_layers, output_size)
+    onnx_path, model = export_model_to_qonnx(
+        out_dir, input_size, hidden_size, num_layers, output_size
+    )
 
     qonnx_cleanup(onnx_path, out_file=onnx_path)
     model_wrapper = ModelWrapper(onnx_path)
@@ -263,3 +277,6 @@ def test_inconsistent_initializer_shape():
         ),
     ):
         model_wrapper = model_wrapper.transform(LoopRolling(loop_extraction.loop_body_template))
+
+    # on success (the expected raise fired) drop the scratch dir, kept otherwise
+    robust_rmtree(out_dir)

--- a/tests/util/test_data_packing.py
+++ b/tests/util/test_data_packing.py
@@ -30,12 +30,11 @@ import pytest
 
 import numpy as np
 import os
-import shutil
 import subprocess
 from qonnx.core.datatype import DataType
 from qonnx.util.basic import gen_finn_dt_tensor
 
-from finn.util.basic import make_build_dir
+from finn.util.basic import make_build_dir, robust_rmtree
 from finn.util.data_packing import (
     finnpy_to_packed_bytearray,
     npy_to_rtlsim_input,
@@ -110,20 +109,14 @@ g++ -o test_npy2apintstream test.cpp $FINN_ROOT/src/finn/qnn-data/cpp/cnpy.cpp \
     )
     with open(test_dir + "/compile.sh", "w") as f:
         f.write(cmd_compile)
-    compile = subprocess.Popen(["sh", "compile.sh"], stdout=subprocess.PIPE, cwd=test_dir)
-    (stdout, stderr) = compile.communicate()
+    subprocess.check_call(["sh", "compile.sh"], cwd=test_dir)
     # make copy before saving the array
     ndarray = ndarray.copy()
     np.save(npy_in, ndarray)
-    execute = subprocess.Popen("./test_npy2apintstream", stdout=subprocess.PIPE, cwd=test_dir)
-    (stdout, stderr) = execute.communicate()
+    subprocess.check_call(["./test_npy2apintstream"], cwd=test_dir)
     produced = np.load(npy_out)
-    success = (produced == ndarray).all()
-    # only delete generated code if test has passed
-    # useful for debug otherwise
-    if success:
-        shutil.rmtree(test_dir)
-    assert success
+    assert (produced == ndarray).all()
+    robust_rmtree(test_dir)
 
 
 @pytest.mark.util

--- a/tests/util/test_hls_vector.py
+++ b/tests/util/test_hls_vector.py
@@ -29,12 +29,11 @@ import pytest
 
 import numpy as np
 import os
-import shutil
 import subprocess
 from qonnx.core.datatype import DataType
 from qonnx.util.basic import gen_finn_dt_tensor
 
-from finn.util.basic import make_build_dir
+from finn.util.basic import make_build_dir, robust_rmtree
 
 
 @pytest.mark.util
@@ -101,17 +100,11 @@ g++ -o test_npy2vectorstream test.cpp $FINN_ROOT/src/finn/qnn-data/cpp/cnpy.cpp 
     )
     with open(test_dir + "/compile.sh", "w") as f:
         f.write(cmd_compile)
-    compile = subprocess.Popen(["sh", "compile.sh"], stdout=subprocess.PIPE, cwd=test_dir)
-    (stdout, stderr) = compile.communicate()
+    subprocess.check_call(["sh", "compile.sh"], cwd=test_dir)
     # make copy before saving the array
     ndarray = ndarray.copy()
     np.save(npy_in, ndarray)
-    execute = subprocess.Popen("./test_npy2vectorstream", stdout=subprocess.PIPE, cwd=test_dir)
-    (stdout, stderr) = execute.communicate()
+    subprocess.check_call(["./test_npy2vectorstream"], cwd=test_dir)
     produced = np.load(npy_out)
-    success = (produced == ndarray).all()
-    # only delete generated code if test has passed
-    # useful for debug otherwise
-    if success:
-        shutil.rmtree(test_dir)
-    assert success
+    assert (produced == ndarray).all()
+    robust_rmtree(test_dir)


### PR DESCRIPTION
This is PR 5 of 9 in a series to make CI faster and more robust.

This patch makes concurrency hygiene improvements to tests, making them safe to run under `pytest-xdist` by giving each test and each parametrisation its own scratch path. Several tests wrote a fixed scratch filename and so collided on the same path when two workers ran them at once. A few others did not race but left a stray file in the repository root on failure.

### Changes

Grouped by type:

- **`tmp_path` for tests that reused one fixed export name.** `test_batchnorm_to_affine_bnn_pynq` (two functions shared one ONNX path), `test_convert_to_hw_layers_{cnv,fc,synthetic}`, `test_fpgadataflow_lookup` and `test_fpgadataflow_softmax` each reused one fixed export path across parametrisations or sibling tests. Each now writes under its own `tmp_path`, so no two workers share a path and pytest owns the cleanup.
- **`tmp_path` for cleanup hygiene.** `test_infer_datatypes_lfc`, `test_infer_data_layouts_cnv` and `test_sign_to_thres` are single tests with unique filenames, so they did not race, but they wrote into the working directory and left the file behind on failure (the `xfail`ing `test_infer_data_layouts_cnv` left it on every run). Moving them to `tmp_path` keeps the repo root clean and hands cleanup to pytest.
- **`test_loop_rolling`.** The export went to a shared `FINN_BUILD_DIR` and, separately, `LoopExtraction` saves and reloads a fixed-name `loop-body-template.onnx` in the current working directory. Each case now gets its own `make_build_dir` and `chdir`s into it, so both the export and that cwd template are per test. The directory is removed with `robust_rmtree` on success and kept on failure.
- **`test_npy2apintstream` / `test_npy2vectorstream`.** These already used a unique `make_build_dir`, but these specific tests sometimes hit `ENOTEMPTY` on NFS (see #1595), so teardown now uses `robust_rmtree`. They also swap `subprocess.Popen` plus `communicate` (which discards the return code) for `subprocess.check_call`, so a failed compile or run fails at the point of failure.

### Review notes / judgement calls

#### Intended pattern

Going forward, the intended pattern is as follows:

1. Use pytest's tmp_path when you don't intend to keep any test artifacts, it keeps scratch on the local fs and let's pytest handle cleanup.
2. Use `make_build_dir` with `robust_rmtree` if you intend to keep artifacts in FINN_BUILD_DIR on failure.
3. Don't write tests that write or consume artifacts without isolating them.

#### Seeding change

This PR now seeds numpy/pytorch in the loop rolling test (while we're already changing it). A random seed would occasionally fail numerical tolerance in a small percentage of cases which is unhelpful for CI. Opinion on this is welcome.

#### Completeness

This PR addresses observed issues, but the problematic patterns/races addressed may silently exist elsewhere. Follow-on work needed, out of scope for this PR.