### PR TITLE
Add pytest sharding core and timing plugin [CI 7/9]

### DIFF
--- a/ci/finn_ci/__init__.py
+++ b/ci/finn_ci/__init__.py
@@ -1,0 +1,16 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""FINN CI helpers.
+
+A small package, importable without the finn package installed, that backs the
+FINN Jenkins CI pipeline and the pytest sharding plugin.
+
+Submodules:
+  config   - the CI board and stage tables and the pure helpers over them
+  sharding - deterministic weight-balanced group-to-shard assignment
+  jsonio   - the JSON read helper shared across the package
+  plugin   - the pytest plugin that selects a shard and captures timings
+"""

--- a/ci/finn_ci/config.py
+++ b/ci/finn_ci/config.py
@@ -1,0 +1,440 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""CI board and stage tables, plus helpers.
+
+The single source of truth for the CI board metadata (BOARDS), the per-row
+build matrix (STAGES), and the derivations the build pipeline needs: row
+validation, the Jenkins stage-choice list, and the per-shard plan. Consumed by
+the pytest plugin (stash names, STAGES) and by the end2end board
+parametrisation (BOARDS/TEST_BOARDS).
+"""
+
+import re
+
+# STAGES row markers are interpolated into the CI pipeline's shell -m
+# argument, so only the "a or b or c" disjunction shape is accepted. This
+# keeps and/not and other shell-unsafe forms out of STAGES.
+MARKER_SAFE_PATTERN = re.compile(r"^[A-Za-z0-9_]+( or [A-Za-z0-9_]+)*$")
+
+# Board setup scripts implemented by the CI HW pipeline's on-board test step.
+VALID_BOARD_SETUP_SCRIPTS = ("alveo", "pynq")
+
+
+# =============================================================================
+# Tables (BOARDS, STAGES)
+# =============================================================================
+# Single source of truth for the HW pipeline's per-board metadata and the
+# build pipeline's per-row matrix. The Jenkinsfile reads these via the
+# hw-config-json and validate-config commands.
+
+# Per-board HW-pipeline metadata. Fields:
+#   agentLabel:    Jenkins label of the board agent
+#   credentialsId: Jenkins credential binding for sudo on the board
+#   restartPrep:   pre-run reboot procedure for Zynq boards
+#   setupScript:   alveo (XRT) or pynq (on-board pynq venv)
+#   marker:        the -m expression the on-board test file runs against
+#   bnnMarker:     the build-side -m token the BNN end2end test file
+#                  parametrises this board under (bnn_<board>)
+#
+# TEST_BOARDS derives from BOARDS and is what tests/end2end
+# parametrises against. Reordering the keys reorders the test matrix.
+BOARDS = {
+    "Pynq-Z1": {
+        "agentLabel": "finn-pynq",
+        "credentialsId": "pynq-z1-credentials",
+        "restartPrep": True,
+        "setupScript": "pynq",
+        "marker": "Pynq",
+        "bnnMarker": "bnn_pynq",
+    },
+    "KV260_SOM": {
+        "agentLabel": "finn-kv260",
+        "credentialsId": "user-ubuntu-credentials",
+        "restartPrep": True,
+        "setupScript": "pynq",
+        "marker": "KV260_SOM",
+        "bnnMarker": "bnn_kv260",
+    },
+    "ZCU104": {
+        "agentLabel": "finn-zcu104",
+        "credentialsId": "pynq-z1-credentials",
+        "restartPrep": True,
+        "setupScript": "pynq",
+        "marker": "ZCU104",
+        "bnnMarker": "bnn_zcu104",
+    },
+    "U250": {
+        "agentLabel": "finn-u250",
+        "credentialsId": None,
+        "restartPrep": False,
+        "setupScript": "alveo",
+        "marker": "U250",
+        "bnnMarker": "bnn_u250",
+    },
+}
+
+# Board iteration order for test parametrisation. Single source of
+# truth: tests/end2end/test_end2end_bnn_pynq.py consumes this tuple.
+TEST_BOARDS = tuple(BOARDS)
+
+
+# Per-test-type human-readable label, surfaced in the Jenkins HW pipeline
+# stage names. Add a row when introducing a new STAGES.zipArtifacts.hwTestType.
+# validate_config() rejects an hwTestType without a label.
+HW_TEST_TYPE_LABELS = {
+    "bnn_build_sanity": "Sanity",
+    "bnn_build_full": "end2end",
+}
+
+
+# Per-row CI matrix. Fields:
+#   param:        Jenkins STAGES choice that activates this row
+#   stage:        human-readable display name
+#   marker:       pytest -m expression (must match MARKER_SAFE_PATTERN in
+#                 the CI pipeline, so only "a or b ...")
+#   shards:       how many parallel shards to split the row into
+#   workers:      pytest-xdist worker count per shard. >1 implies
+#                 --dist loadgroup so xdist_group chains (e.g. tests linked
+#                 by load_test_checkpoint_or_skip) stay on one worker
+#   coverage:     optional, request coverage report
+#   zipArtifacts: optional, {"hwTestType": ..., "boards": [...]} declaring the
+#                 build-to-HW handoff zips this row publishes. hwTestType must
+#                 have a HW_TEST_TYPE_LABELS entry
+STAGES = [
+    {
+        "param": "sanity",
+        "stage": "Sanity - Build Hardware",
+        "marker": "sanity_bnn",
+        "shards": 4,
+        "workers": 1,
+        "zipArtifacts": {
+            "hwTestType": "bnn_build_sanity",
+            "boards": list(TEST_BOARDS),
+        },
+    },
+    {
+        "param": "sanity",
+        "stage": "Sanity - Unit Tests",
+        "marker": "util or brevitas_export or streamline or transform or notebooks",
+        "shards": 1,
+        "workers": 8,
+        "coverage": True,
+    },
+    {
+        "param": "fpgadataflow",
+        "stage": "fpgadataflow",
+        "marker": "fpgadataflow",
+        "shards": 2,
+        "workers": 8,
+        "coverage": True,
+    },
+    {
+        "param": "end2end",
+        "stage": "End2end",
+        "marker": "end2end",
+        "shards": 3,
+        "workers": 6,
+    },
+    {
+        "param": "end2end",
+        "stage": "BNN U250",
+        "marker": "bnn_u250",
+        "shards": 2,
+        "workers": 2,
+        "zipArtifacts": {"hwTestType": "bnn_build_full", "boards": ["U250"]},
+    },
+    {
+        "param": "end2end",
+        "stage": "BNN Pynq-Z1",
+        "marker": "bnn_pynq",
+        "shards": 3,
+        "workers": 2,
+        "zipArtifacts": {"hwTestType": "bnn_build_full", "boards": ["Pynq-Z1"]},
+    },
+    {
+        "param": "end2end",
+        "stage": "BNN ZCU104",
+        "marker": "bnn_zcu104",
+        "shards": 2,
+        "workers": 4,
+        "zipArtifacts": {"hwTestType": "bnn_build_full", "boards": ["ZCU104"]},
+    },
+    {
+        "param": "end2end",
+        "stage": "BNN KV260",
+        "marker": "bnn_kv260",
+        "shards": 2,
+        "workers": 2,
+        "zipArtifacts": {"hwTestType": "bnn_build_full", "boards": ["KV260_SOM"]},
+    },
+]
+
+
+def validate_stage_row(row):
+    """Sanity-check a single STAGES row in isolation.
+
+    Catches a typo in param / marker / shards / workers / coverage at
+    config-load time so a malformed row cannot silently survive into Jenkins
+    or the pytest plugin. A missing or empty param matters most: such a row
+    is skipped by every helper that gates on rowIsActive, with nothing
+    logging why.
+    """
+    stage = row.get("stage", "<unnamed>")
+    param = row.get("param")
+    if not isinstance(param, str) or not param:
+        raise ValueError("STAGES row %r has invalid or missing param=%r" % (stage, param))
+    marker = row.get("marker", "")
+    if not MARKER_SAFE_PATTERN.match(str(marker)):
+        raise ValueError(
+            "STAGES row %r has unsafe marker %r "
+            "(only 'a or b or c ...' is allowed)" % (stage, marker)
+        )
+    shards = row.get("shards")
+    if not isinstance(shards, int) or shards < 1:
+        raise ValueError("STAGES row %r has invalid shards=%r" % (stage, shards))
+    workers = row.get("workers")
+    if not isinstance(workers, int) or workers < 1:
+        raise ValueError("STAGES row %r has invalid workers=%r" % (stage, workers))
+    if "coverage" in row and not isinstance(row["coverage"], bool):
+        raise ValueError(
+            "STAGES row %r has invalid coverage=%r (must be bool)" % (stage, row["coverage"])
+        )
+    zip_art = row.get("zipArtifacts")
+    if zip_art is None:
+        return
+    _validate_zip_artifact(stage, zip_art)
+
+
+def _validate_zip_artifact(stage, zip_art):
+    """Sanity-check the optional "zipArtifacts" block of one STAGES row."""
+    if not isinstance(zip_art, dict):
+        raise ValueError("STAGES row %r has invalid zipArtifacts=%r" % (stage, zip_art))
+    hw_test_type = zip_art.get("hwTestType")
+    if not isinstance(hw_test_type, str) or not hw_test_type:
+        raise ValueError("STAGES row %r has zipArtifacts without a non-empty hwTestType" % stage)
+    boards = zip_art.get("boards")
+    if (
+        not isinstance(boards, list)
+        or not boards
+        or not all(isinstance(b, str) and b for b in boards)
+    ):
+        raise ValueError("STAGES row %r has zipArtifacts without a non-empty boards list" % stage)
+
+
+def validate_board_row(board, row):
+    """Sanity-check one BOARDS row consumed by the CI HW pipeline."""
+    if not isinstance(row, dict):
+        raise ValueError("BOARDS row %r must be a dict, got %r" % (board, row))
+    required = (
+        "agentLabel",
+        "credentialsId",
+        "restartPrep",
+        "setupScript",
+        "marker",
+        "bnnMarker",
+    )
+    missing = [key for key in required if key not in row]
+    if missing:
+        raise ValueError("BOARDS row %r is missing required field(s): %r" % (board, missing))
+    if not isinstance(row["agentLabel"], str) or not row["agentLabel"]:
+        raise ValueError("BOARDS row %r has invalid agentLabel=%r" % (board, row["agentLabel"]))
+    credentials = row["credentialsId"]
+    if credentials is not None and (not isinstance(credentials, str) or not credentials):
+        raise ValueError("BOARDS row %r has invalid credentialsId=%r" % (board, credentials))
+    if not isinstance(row["restartPrep"], bool):
+        raise ValueError("BOARDS row %r has invalid restartPrep=%r" % (board, row["restartPrep"]))
+    if row["restartPrep"] and not credentials:
+        raise ValueError("BOARDS row %r has restartPrep=true but no credentialsId" % board)
+    if row["setupScript"] not in VALID_BOARD_SETUP_SCRIPTS:
+        raise ValueError(
+            "BOARDS row %r has invalid setupScript=%r (allowed: %r)"
+            % (board, row["setupScript"], list(VALID_BOARD_SETUP_SCRIPTS))
+        )
+    if not isinstance(row["marker"], str) or not row["marker"]:
+        raise ValueError("BOARDS row %r has invalid marker=%r" % (board, row["marker"]))
+    if not isinstance(row["bnnMarker"], str) or not row["bnnMarker"]:
+        raise ValueError("BOARDS row %r has invalid bnnMarker=%r" % (board, row["bnnMarker"]))
+
+
+def validate_config(stages=None, boards=None, hw_test_type_labels=None):
+    """Validate every STAGES row and the global BOARDS cross-references.
+
+    Raises ValueError if a STAGES row references a board not in BOARDS, if a
+    row's hwTestType has no HW_TEST_TYPE_LABELS entry, or if any single
+    row is malformed. Called by every CLI subcommand that consumes BOARDS,
+    STAGES, or HW_TEST_TYPE_LABELS (validate-config, hw-config-json)
+    so a bad table fails fast wherever it is first read.
+    """
+    stages = stages if stages is not None else STAGES
+    boards = boards if boards is not None else BOARDS
+    labels = hw_test_type_labels if hw_test_type_labels is not None else HW_TEST_TYPE_LABELS
+    for board, row in boards.items():
+        validate_board_row(board, row)
+    for row in stages:
+        validate_stage_row(row)
+    referenced_boards = set()
+    referenced_test_types = set()
+    for row in stages:
+        zip_art = row.get("zipArtifacts") or {}
+        for b in zip_art.get("boards", []) or []:
+            referenced_boards.add(str(b))
+        hw_test_type = zip_art.get("hwTestType")
+        if hw_test_type:
+            referenced_test_types.add(str(hw_test_type))
+    missing_boards = sorted(referenced_boards - set(boards))
+    if missing_boards:
+        raise ValueError("STAGES references board(s) not declared in BOARDS: %r" % missing_boards)
+    missing_labels = sorted(referenced_test_types - set(labels))
+    if missing_labels:
+        raise ValueError(
+            "STAGES references hwTestType(s) without a HW_TEST_TYPE_LABELS entry: %r"
+            % missing_labels
+        )
+
+
+# =============================================================================
+# Stage choice / job-key helpers
+# =============================================================================
+
+
+def stash_name(stage, shards, shard_id):
+    """Mirror the shard stash naming the CI pipeline relies on."""
+    base = re.sub(r"[^a-z0-9]+", "_", stage.lower()).strip("_")
+    return base if shards <= 1 else "%s_%d" % (base, shard_id + 1)
+
+
+def job_key(job_name):
+    """Sanitise a Jenkins JOB_NAME into a filesystem-safe ci_runs/<key> path component."""
+    # Strip leading/trailing dots so JOB_NAME=".." cannot survive into a
+    # parent-directory traversal under ci_runs/<jobKey>/.
+    out = re.sub(r"[^A-Za-z0-9._-]+", "_", job_name or "job").strip(".")
+    return out or "job"
+
+
+def ci_param_names(stages=None):
+    """Return the distinct STAGES.param values in declaration order."""
+    stages = stages if stages is not None else STAGES
+    seen = []
+    for row in stages:
+        name = row.get("param")
+        if name and name not in seen:
+            seen.append(name)
+    return seen
+
+
+def enabled_params_for_choice(choice, stages=None):
+    """Map the Jenkins STAGES choice to the set of CI params it enables.
+
+    "full" enables every distinct param. A bare param name enables just
+    that one. Unknown choices fail loudly.
+    """
+    stages = stages if stages is not None else STAGES
+    all_params = ci_param_names(stages)
+    if choice == "full":
+        return list(all_params)
+    if choice in all_params:
+        return [choice]
+    raise ValueError(
+        "unknown STAGES choice %r (recognised: full, %s)" % (choice, ", ".join(all_params))
+    )
+
+
+def jenkins_stage_choices(stages=None):
+    """Return the Jenkins UI choices for STAGES in display order.
+
+    "sanity" leads when it exists, then "full"
+    for the nightly matrix, then every other distinct param.
+    """
+    names = list(ci_param_names(stages))
+    head = ["sanity"] if "sanity" in names else []
+    rest = [n for n in names if n != "sanity"]
+    return head + ["full"] + rest
+
+
+# =============================================================================
+# Build-pipeline shard plan
+# =============================================================================
+# The CI pipeline consumes one shard_plan payload instead of re-deriving
+# the active-row/shard/stash matrix in the Jenkinsfile.
+
+
+def shard_stage_name(stage, shards, shard_id):
+    """Mirror the per-shard Jenkins stage display name."""
+    return stage if shards <= 1 else "%s (%d/%d)" % (stage, shard_id + 1, shards)
+
+
+def _shard_entry(row):
+    """Expand one active STAGES row into its per-shard plan entries."""
+    num_shards = int(row["shards"])
+    entries = []
+    for shard_id in range(num_shards):
+        stash = stash_name(row["stage"], num_shards, shard_id)
+        entry = {
+            "stage": shard_stage_name(row["stage"], num_shards, shard_id),
+            "stash": stash,
+            "marker": row["marker"],
+            "workers": int(row["workers"]),
+            "numShards": num_shards,
+            "shardId": shard_id,
+            "coverage": bool(row.get("coverage", False)),
+        }
+        if entry["coverage"]:
+            entry["coverageFile"] = "%s.coverage" % stash
+        zip_art = row.get("zipArtifacts")
+        if zip_art:
+            entry["zipArtifacts"] = zip_art
+        entries.append(entry)
+    return entries
+
+
+def active_stage_rows(choice, stages=None):
+    """Return the STAGES rows enabled by the given Jenkins STAGES choice."""
+    stages = stages if stages is not None else STAGES
+    enabled = set(enabled_params_for_choice(choice, stages))
+    return [row for row in stages if row.get("param") in enabled]
+
+
+def shard_plan(choice, stage_filter="", stages=None):
+    """Build the per-shard plan the build pipeline runs for a STAGES choice.
+
+    Returns a dict with three keys:
+
+      - "shards": the shard branches to run, one entry per shard of each
+        active row. When stage_filter is set, only shards whose display name
+        contains it survive (a substring match).
+      - "candidates": the display name of every active row, unfiltered. Lets
+        the caller report a stage_filter that matched nothing alongside the
+        stage names it could have matched.
+      - "zipArtifacts": one entry per (active row, board) build-to-HW handoff,
+        read straight from the active rows. Not split per shard and ignores
+        stage_filter, so it mirrors the aggregate-time walk.
+    """
+    rows = active_stage_rows(choice, stages)
+    all_shards = []
+    for row in rows:
+        all_shards.extend(_shard_entry(row))
+    if stage_filter:
+        shards = [s for s in all_shards if stage_filter in s["stage"]]
+    else:
+        shards = all_shards
+    zip_artifacts = []
+    for row in rows:
+        zip_art = row.get("zipArtifacts")
+        if not zip_art:
+            continue
+        for board in zip_art.get("boards", []):
+            zip_artifacts.append(
+                {
+                    "stage": row["stage"],
+                    "hwTestType": zip_art["hwTestType"],
+                    "board": board,
+                }
+            )
+    return {
+        "shards": shards,
+        "candidates": [row["stage"] for row in rows],
+        "zipArtifacts": zip_artifacts,
+    }

--- a/ci/finn_ci/jsonio.py
+++ b/ci/finn_ci/jsonio.py
@@ -1,0 +1,27 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""JSON read helper shared across the finn_ci package."""
+
+import json
+import sys
+
+
+def read_json(path, default=None):
+    if not path:
+        return default
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except FileNotFoundError:
+        return default
+    except (OSError, ValueError) as exc:
+        # File present but unreadable or malformed: warn so a corrupt timing
+        # file does not silently degrade sharding to round-robin.
+        print(
+            "finn_ci jsonio read_json: %s: %s: %s" % (path, exc.__class__.__name__, exc),
+            file=sys.stderr,
+        )
+        return default

--- a/ci/finn_ci/plugin.py
+++ b/ci/finn_ci/plugin.py
@@ -1,0 +1,399 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Pytest plugin for Jenkins shard selection and timing capture.
+
+Each Jenkins stage runs pytest with -m <marker> --num-shards N --shard-id I.
+Group assignment is deterministic and weighted by the timings in
+FINN_CI_TIMINGS_FILE. If that file is absent or corrupt,
+assignment falls back to deterministic round-robin over the sorted group
+keys. Tests sharing an @pytest.mark.xdist_group always land in the same
+shard so chained load_test_checkpoint_or_skip steps stay together. Tests
+without an explicit group are grouped by nodeid.
+
+@pytest.mark.shard(N) pins a group to shard N for flaky-test isolation.
+
+The timing state lives on the registered plugin instance rather than a module
+global, so the xdist controller, each worker, and any inline pytester sub-run
+keep their own copy. That also lets pytest_runtest_logreport, which receives
+no config argument, reach the state via self.
+"""
+import pytest
+
+import json
+import os
+import time
+from finn_ci import sharding
+
+SHARD_MARKER_NAME = "shard"
+
+
+def pytest_addoption(parser):
+    group = parser.getgroup("finn-ci-sharding")
+    group.addoption(
+        "--num-shards",
+        type=int,
+        default=0,
+        help="Split the collected test set into N deterministic shards.",
+    )
+    group.addoption(
+        "--shard-id",
+        type=int,
+        default=0,
+        help="Which shard (0-indexed) to run. Requires --num-shards.",
+    )
+    # CI-maintainer tool for tuning a STAGES row's shard count: prints the
+    # predicted shard balance and exits without running anything. the weight_s
+    # column is only meaningful when FINN_CI_TIMINGS_FILE points at a populated
+    # timing master. With no timing data it degrades to a count-balanced view.
+    group.addoption(
+        "--dry-run-shards",
+        action="store_true",
+        default=False,
+        help="CI-maintainer aid: print the predicted shard balance and exit. "
+        "weight_s is meaningful only with a populated FINN_CI_TIMINGS_FILE.",
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "shard(N): pin this test to shard N (use sparingly for flaky-test isolation).",
+    )
+    config.pluginmanager.register(_FinnCiShardingPlugin(), "_finn_ci_sharding")
+
+
+def _is_xdist_worker(config):
+    """True on an xdist worker process.
+
+    Checks for the workerinput attribute that xdist sets on the worker config,
+    rather than the PYTEST_XDIST_WORKER env var. An inline pytester.runpytest
+    sub-run inherits that env var from its parent worker and would be
+    misreported as a worker, whereas the workerinput attribute does not leak
+    into the sub-run.
+    """
+    return hasattr(config, "workerinput")
+
+
+def _group_key(item):
+    """Return item's xdist_group name, or its canonical nodeid as a singleton group."""
+    for mark in item.iter_markers(name="xdist_group"):
+        if mark.args:
+            return str(mark.args[0])
+        name = mark.kwargs.get("name")
+        if name is not None:
+            return str(name)
+    return sharding.canonical_key(item.nodeid)
+
+
+def _pinned_shard(item, num_shards):
+    """Return the @pytest.mark.shard(N) pin for a test item, or None.
+
+    Pins are enforced per xdist_group: every member of a group must agree on
+    a single pin (or none), otherwise chained load_test_checkpoint_or_skip
+    tests would split across shards and silently break the BNN end2end chains.
+    The check that a group's members agree lives in _assignment_details below.
+    """
+    for mark in item.iter_markers(name=SHARD_MARKER_NAME):
+        if not mark.args:
+            continue
+        pinned = mark.args[0]
+        if not isinstance(pinned, int):
+            raise pytest.UsageError(
+                "@pytest.mark.shard expects an int arg, got %r on %s" % (pinned, item.nodeid)
+            )
+        if not 0 <= pinned < num_shards:
+            raise pytest.UsageError(
+                "@pytest.mark.shard(%d) out of range for --num-shards=%d on %s"
+                % (pinned, num_shards, item.nodeid)
+            )
+        return pinned
+    return None
+
+
+def _load_group_weights():
+    return sharding.load_group_weights(os.environ.get("FINN_CI_TIMINGS_FILE"))
+
+
+def _weights_with_fallback():
+    # weight applied to groups with no recorded timing yet: the median of the
+    # recorded weights, or 1.0 when none are recorded.
+    weights_table = _load_group_weights()
+    fallback = sharding.fallback_weight(weights_table)
+    return weights_table, fallback
+
+
+def _assignment_details(groups, num_shards):
+    """Resolve shard pins, then delegate to sharding.assign_groups_to_shards.
+
+    Every xdist_group must agree on a single @pytest.mark.shard(N) value.
+    Otherwise chained checkpoint tests would split across shards.
+    """
+    pins = {}
+    for key, members in groups.items():
+        group_pins = {_pinned_shard(it, num_shards) for it in members}
+        group_pins.discard(None)
+        if len(group_pins) > 1:
+            raise pytest.UsageError(
+                "conflicting @pytest.mark.shard pins within xdist_group %r: %r"
+                % (key, sorted(group_pins))
+            )
+        if group_pins:
+            pins[key] = group_pins.pop()
+    weights_table, fallback = _weights_with_fallback()
+    assignment, source, shard_load, fallback = sharding.assign_groups_to_shards(
+        groups.keys(), num_shards, weights_table, pins
+    )
+    return assignment, source, shard_load, weights_table, fallback
+
+
+def _junit_output_info(config):
+    junitxml = config.getoption("--junitxml") or ""
+    if not junitxml:
+        return None, None, None
+    out_dir = os.path.dirname(junitxml) or "."
+    stash = os.path.splitext(os.path.basename(junitxml))[0]
+    return out_dir, stash, junitxml
+
+
+def _stage_name_from_env():
+    return os.environ.get("FINN_CI_STAGE", "")
+
+
+def _write_shard_map(config, kept, groups, assignment, source, weights_table, fallback):
+    # Under xdist the controller and every worker run collection and would each
+    # write the identical shardmap to the same path, so let only the controller
+    # write it and avoid the concurrent writes.
+    if _is_xdist_worker(config):
+        return
+    out_dir, stash, _ = _junit_output_info(config)
+    if not out_dir or not stash:
+        return
+    num_shards = int(config.getoption("--num-shards"))
+    shard_id = int(config.getoption("--shard-id"))
+    rows = []
+    lines = []
+    for item in sorted(kept, key=lambda it: it.nodeid):
+        group = _group_key(item)
+        weight = weights_table.get(group, fallback)
+        row = {
+            "nodeid": item.nodeid,
+            "stage": _stage_name_from_env(),
+            "stash": stash,
+            "shard_id": shard_id,
+            "num_shards": num_shards,
+            "group": group,
+            "weight_s": round(float(weight), 3),
+            "source": source.get(group, "unknown"),
+        }
+        rows.append(row)
+        lines.append(
+            "nodeid={nodeid} stage={stage} shard={shard_num}/{shard_count} "
+            "stash={stash} group={group} weight_s={weight_s:.3f} source={source}".format(
+                nodeid=row["nodeid"],
+                stage=row["stage"],
+                shard_num=shard_id + 1,
+                shard_count=num_shards,
+                stash=stash,
+                group=group,
+                weight_s=row["weight_s"],
+                source=row["source"],
+            )
+        )
+    try:
+        with open(os.path.join(out_dir, stash + ".shardmap.json"), "w") as f:
+            json.dump(rows, f, indent=2, sort_keys=True)
+            f.write("\n")
+        with open(os.path.join(out_dir, stash + ".shardmap.txt"), "w") as f:
+            for line in lines:
+                f.write(line + "\n")
+    except OSError:
+        pass
+
+
+class _FinnCiShardingPlugin:
+    """Stateful pytest hooks, one instance per process (xdist controller or worker).
+
+    The timing dict is left as None on xdist workers so the per-test reports
+    they forward to the controller are counted once (on the controller) and
+    not double-counted.
+    """
+
+    def __init__(self):
+        self.timings = None
+
+    @pytest.hookimpl(trylast=True)
+    def pytest_collection_modifyitems(self, config, items):
+        # trylast lets pytest's own -m deselection run before we shard.
+        num_shards = config.getoption("--num-shards")
+        dry_run = config.getoption("--dry-run-shards")
+        if num_shards <= 0:
+            return
+        shard_id = config.getoption("--shard-id")
+        if not 0 <= shard_id < num_shards:
+            raise pytest.UsageError(
+                "--shard-id=%d out of range for --num-shards=%d" % (shard_id, num_shards)
+            )
+        if not items:
+            # fail loudly on a stale-marker typo so the stage cannot pass
+            # without running any tests.
+            raise pytest.UsageError(
+                "no tests collected for this marker. CI shard configuration is "
+                "out of sync with the test markers"
+            )
+
+        groups = {}
+        for item in items:
+            groups.setdefault(_group_key(item), []).append(item)
+        assignment, source, _shard_load, weights_table, fallback = _assignment_details(
+            groups, num_shards
+        )
+
+        if dry_run:
+            per_shard = {i: {"items": 0, "groups": [], "seconds": 0.0} for i in range(num_shards)}
+            for key, members in groups.items():
+                s = assignment[key]
+                per_shard[s]["items"] += len(members)
+                per_shard[s]["groups"].append(key)
+                per_shard[s]["seconds"] += weights_table.get(key, fallback)
+            print(
+                "\n--- dry-run-shards (num_shards=%d, groups=%d, items=%d) ---"
+                % (num_shards, len(groups), len(items))
+            )
+            print(
+                "%-8s %-8s %-8s %-10s %s" % ("shard", "items", "groups", "weight_s", "sample_group")
+            )
+            for i in range(num_shards):
+                gs = sorted(per_shard[i]["groups"])
+                sample = gs[0] if gs else "(empty)"
+                print(
+                    "%-8d %-8d %-8d %-10.1f %s"
+                    % (i, per_shard[i]["items"], len(gs), per_shard[i]["seconds"], sample)
+                )
+            config.hook.pytest_deselected(items=list(items))
+            items[:] = []
+            return
+
+        kept = [it for it in items if assignment[_group_key(it)] == shard_id]
+        _write_shard_map(config, kept, groups, assignment, source, weights_table, fallback)
+        my_groups = sorted(k for k, s in assignment.items() if s == shard_id)
+        print(
+            "[finn-sharding] shard %d/%d: %d item(s) across %d group(s)"
+            % (shard_id, num_shards, len(kept), len(my_groups))
+        )
+        if my_groups:
+            sample = my_groups[:5]
+            ellipsis = " ..." if len(my_groups) > 5 else ""
+            print("[finn-sharding] groups: %s%s" % (sample, ellipsis))
+        items[:] = kept
+
+    def pytest_sessionstart(self, session):
+        self.timings = None
+        if session.config.getoption("--num-shards") <= 0:
+            return
+        if _is_xdist_worker(session.config):
+            return
+        self.timings = {
+            "per_test_seconds": {},
+            "nodeid_to_group": {},
+            "start_monotonic": time.monotonic(),
+        }
+
+    def pytest_collection_finish(self, session):
+        if self.timings is None:
+            return
+        for item in session.items:
+            for mark in item.iter_markers(name="xdist_group"):
+                if mark.args:
+                    self.timings["nodeid_to_group"][item.nodeid] = str(mark.args[0])
+                    break
+                name = mark.kwargs.get("name")
+                if name is not None:
+                    self.timings["nodeid_to_group"][item.nodeid] = str(name)
+                    break
+
+    def pytest_runtest_logreport(self, report):
+        if self.timings is None:
+            return
+        # sum setup+call+teardown per nodeid. xdist forwards worker reports here.
+        duration = float(getattr(report, "duration", 0.0) or 0.0)
+        self.timings["per_test_seconds"][report.nodeid] = (
+            self.timings["per_test_seconds"].get(report.nodeid, 0.0) + duration
+        )
+
+    def pytest_sessionfinish(self, session, exitstatus):
+        # --dry-run-shards deselects everything by design, so exit 5 ("no tests
+        # collected") is benign. For a real sharded run, exit 5 can also happen
+        # when this shard's slice is empty after group assignment. Remap it to
+        # 0, but print a warning so an unbalanced split is visible.
+        num_shards = session.config.getoption("--num-shards")
+        if exitstatus == 5:
+            if session.config.getoption("--dry-run-shards"):
+                session.exitstatus = 0
+            elif num_shards > 0:
+                shard_id = session.config.getoption("--shard-id")
+                # Sidecar lets a build-level aggregator detect the empty shard
+                # without grepping stdout. Best-effort: an OSError here must not
+                # change exit status.
+                out_dir, stash, _ = _junit_output_info(session.config)
+                # only the controller writes the sidecar: workers share out_dir,
+                # and a worker that drew 0 of the shard's groups is not the shard
+                # itself being empty.
+                if out_dir and stash and not _is_xdist_worker(session.config):
+                    try:
+                        with open(os.path.join(out_dir, stash + ".empty-shard"), "w") as f:
+                            f.write("shard %d/%d collected 0 items\n" % (shard_id, num_shards))
+                    except OSError:
+                        pass
+                print(
+                    "[finn-sharding] WARNING: shard %d/%d collected 0 items after assignment"
+                    % (shard_id, num_shards)
+                )
+                session.exitstatus = 0
+        if self.timings is None:
+            return
+        # an interrupted/aborted shard has truncated timings, so skip the
+        # sidecar: a killed or timed-out run must not feed the persistent
+        # master. a plain test failure (exit 1) still has real durations.
+        if session.exitstatus in (
+            pytest.ExitCode.INTERRUPTED,
+            pytest.ExitCode.INTERNAL_ERROR,
+            pytest.ExitCode.USAGE_ERROR,
+        ):
+            return
+        out_dir, stash, junitxml = _junit_output_info(session.config)
+        if not junitxml:
+            return
+        out_path = os.path.join(out_dir, stash + ".timings.json")
+        groups = {}
+        for nodeid, duration in self.timings["per_test_seconds"].items():
+            # under --dist loadgroup the forwarded report nodeid gains an
+            # "@<group>" suffix, so it misses the plain-nodeid keys in
+            # nodeid_to_group. canonical_key recovers the group from the suffix
+            # so a group's members sum together per shard, not as singletons.
+            group = self.timings["nodeid_to_group"].get(nodeid) or sharding.canonical_key(nodeid)
+            entry = groups.setdefault(group, {"name": group, "count": 0, "seconds": 0.0})
+            entry["count"] += 1
+            entry["seconds"] += duration
+        payload = {
+            "stash": stash,
+            "shard": {
+                "num": session.config.getoption("--num-shards"),
+                "id": session.config.getoption("--shard-id"),
+            },
+            "metadata": {
+                "job": os.environ.get("FINN_CI_JOB_NAME"),
+                "build": os.environ.get("FINN_CI_BUILD_NUMBER"),
+                "stage": os.environ.get("FINN_CI_STAGE"),
+                "timings_file": os.environ.get("FINN_CI_TIMINGS_FILE"),
+            },
+            "wall_seconds": time.monotonic() - self.timings["start_monotonic"],
+            "groups": sorted(groups.values(), key=lambda g: -g["seconds"]),
+        }
+        try:
+            with open(out_path, "w") as f:
+                json.dump(payload, f, indent=2)
+        except OSError:
+            pass

--- a/ci/finn_ci/sharding.py
+++ b/ci/finn_ci/sharding.py
@@ -1,0 +1,147 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Deterministic weight-balanced group-to-shard assignment.
+
+Reads per-group weights from a timing state file (written by the timing
+master) and packs groups into shards by longest-processing-time-first greedy
+bin packing, degrading to round-robin when there is no timing signal.
+"""
+
+import os
+import re
+from finn_ci import jsonio
+
+# Internal regexes for canonical_key. The group suffix is the "@<group>" that
+# xdist's loadgroup appends to a forwarded nodeid. Anchor on a token that stops
+# at a "]" or whitespace so a parametrised id such as test[user@host] is not
+# mistaken for a group suffix.
+GROUP_SUFFIX_RE = re.compile(r"@([^\]\s]+)$")
+NOTEBOOK_PARAM_RE = re.compile(r"\[(/[^\]]+\.ipynb)\]")
+
+
+def canonical_key(name):
+    """Normalise timing group names across xdist and workspace-specific paths."""
+    m = GROUP_SUFFIX_RE.search(name)
+    if m:
+        return m.group(1)
+    m2 = NOTEBOOK_PARAM_RE.search(name)
+    if m2:
+        path = m2.group(1)
+        return name.replace(m2.group(0), "[%s]" % os.path.basename(path))
+    return name
+
+
+def _samples_from_entry(entry):
+    """Return the samples list from a master entry (empty if absent or malformed)."""
+    if not isinstance(entry, dict):
+        return []
+    samples = entry.get("samples")
+    if not isinstance(samples, list):
+        return []
+    return [float(s) for s in samples if s is not None]
+
+
+def _window_weight(values):
+    """Max of the positive values: the conservative per-group weight.
+
+    Returns 0.0 on an empty input.
+    """
+    return max((v for v in values if v > 0.0), default=0.0)
+
+
+def _entry_weight_seconds(entry):
+    """Extract the weight (window max) from a master/snapshot group entry."""
+    return _window_weight(_samples_from_entry(entry))
+
+
+def load_group_weights(path):
+    """Return {group_name: seconds} from a timing state file."""
+    data = jsonio.read_json(path, default={})
+    groups = data.get("groups") if isinstance(data, dict) else None
+    if not isinstance(groups, dict):
+        return {}
+    weights = {}
+    for key, val in groups.items():
+        seconds = _entry_weight_seconds(val)
+        if seconds > 0.0:
+            weights[str(key)] = seconds
+    return weights
+
+
+def fallback_weight(weights):
+    # weight used for groups with no timing data: the median of the known
+    # group weights, or 1.0 at cold-start so a brand-new master still
+    # produces a reproducible round-robin assignment.
+    known = sorted(w for w in weights.values() if w > 0.0)
+    return known[len(known) // 2] if known else 1.0
+
+
+def assign_groups_to_shards(group_keys, num_shards, weights=None, pins=None):
+    """Assign group keys to shard ids.
+
+    Pinned groups are placed first. Unpinned groups are packed by
+    longest-processing-time-first greedy bin packing when timing data is
+    available, otherwise by round-robin over the sorted group keys so the
+    fallback placement is reproducible and balanced by group count.
+
+    Raises ValueError for num_shards < 1 or any pin outside [0, num_shards).
+    """
+    num_shards = int(num_shards)
+    if num_shards < 1:
+        raise ValueError("num_shards must be >= 1, got %r" % (num_shards,))
+    pins = pins or {}
+    for key, shard in pins.items():
+        try:
+            shard_int = int(shard)
+        except (TypeError, ValueError):
+            raise ValueError("pin for %r must be an int, got %r" % (key, shard))
+        if not 0 <= shard_int < num_shards:
+            raise ValueError(
+                "pin for %r out of range: %d not in [0, %d)" % (key, shard_int, num_shards)
+            )
+    group_keys = sorted(str(k) for k in group_keys)
+    weights = weights or {}
+    assignment = {}
+    source = {}
+    shard_load = [0.0] * num_shards
+    fallback = fallback_weight(weights)
+
+    for key in group_keys:
+        if key in pins:
+            shard = int(pins[key])
+            assignment[key] = shard
+            source[key] = "pinned"
+            shard_load[shard] += weights.get(key, fallback)
+
+    if num_shards <= 1:
+        for key in group_keys:
+            assignment.setdefault(key, 0)
+            source.setdefault(key, "single")
+        return assignment, source, shard_load, fallback
+
+    unpinned = [k for k in group_keys if k not in assignment]
+    has_signal = any(weights.get(k, 0.0) > 0.0 for k in unpinned)
+
+    if not has_signal:
+        # No timing signal: balance by group count, but seed from any pinned
+        # load so pins are respected. Placing each group on the least-loaded
+        # shard (ties broken by index) stays deterministic and matches plain
+        # round-robin when there are no pins.
+        for key in unpinned:
+            shard = min(range(num_shards), key=lambda s: (shard_load[s], s))
+            assignment[key] = shard
+            source[key] = "round_robin"
+            shard_load[shard] += 1.0
+        return assignment, source, shard_load, fallback
+
+    unpinned.sort(key=lambda k: (-weights.get(k, fallback), k))
+    for key in unpinned:
+        weight = weights.get(key, fallback)
+        shard = min(range(num_shards), key=lambda s: (shard_load[s], s))
+        assignment[key] = shard
+        source[key] = "known" if key in weights else "fallback"
+        shard_load[shard] += weight
+    return assignment, source, shard_load, fallback

--- a/ci/scripts/print_pytest_failures.py
+++ b/ci/scripts/print_pytest_failures.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Print a tail of every failed/errored testcase in a JUnit XML.
+
+Used by Jenkins to surface per-test failure context when there is no tool
+log to tail (notebook timeouts, asserts, fixture errors). Pure stdlib so
+it runs on any agent.
+
+Usage: print_pytest_failures.py <junit_xml> <stash> <lines_per_failure> <max_failures>
+"""
+import re
+import sys
+import xml.etree.ElementTree as ET
+
+
+def main(argv):
+    if len(argv) != 5:
+        print(
+            "Usage: print_pytest_failures.py <junit_xml> <stash> "
+            "<lines_per_failure> <max_failures>",
+            file=sys.stderr,
+        )
+        return 2
+    xml_path = argv[1]
+    stash = argv[2]
+    lines_per = int(argv[3])
+    max_fails = int(argv[4])
+    tag = "[pytest-failures %s]" % stash
+    try:
+        root = ET.parse(xml_path).getroot()
+    except Exception as exc:
+        print("%s failed to parse %s: %s" % (tag, xml_path, exc))
+        return 0
+
+    ansi = re.compile(r"\x1b\[[0-9;]*m")
+    fails = []
+    for tc in root.iter("testcase"):
+        classname = tc.get("classname", "?")
+        name = tc.get("name", "?")
+        for kind in ("failure", "error"):
+            node = tc.find(kind)
+            if node is None:
+                continue
+            msg = node.get("message") or ""
+            body = node.text or ""
+            fails.append((kind, classname, name, msg, body))
+            break
+
+    if not fails:
+        print("%s no test failures recorded in %s" % (tag, xml_path))
+        return 0
+
+    print("%s %d test failure(s):" % (tag, len(fails)))
+    shown = 0
+    for kind, classname, name, msg, body in fails:
+        if shown >= max_fails:
+            print()
+            print(
+                "... and %d more failure(s) elided, see %s.xml in artifacts."
+                % (len(fails) - shown, stash)
+            )
+            break
+        shown += 1
+        print()
+        print("=== %s: %s::%s" % (kind.upper(), classname, name))
+        if msg:
+            msg_lines = msg.splitlines()
+            if msg_lines:
+                print("  %s" % msg_lines[0])
+        body_text = ansi.sub("", body).rstrip()
+        body_lines = body_text.splitlines()
+        if len(body_lines) > lines_per:
+            omitted = len(body_lines) - lines_per
+            body_lines = [
+                "... (%d earlier lines elided, see %s.xml in artifacts)" % (omitted, stash)
+            ] + body_lines[-lines_per:]
+        for ln in body_lines:
+            print("  %s" % ln)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/docker/quicktest.sh
+++ b/docker/quicktest.sh
@@ -5,8 +5,8 @@
 cd $FINN_ROOT
 # check if command line argument is empty or not present
 if [ -z $1 ]; then
-  echo "Running quicktest: not (vivado or slow or board) with pytest-xdist"
-  pytest -m 'not (vivado or slow or vitis or board or notebooks or bnn_pynq)' --dist=loadfile -n $PYTEST_PARALLEL
+  echo "Running quicktest: not (vivado or slow or board or bnn) with pytest-xdist"
+  pytest -m 'not (vivado or slow or vitis or board or notebooks or sanity_bnn or bnn_pynq or bnn_zcu104 or bnn_kv260 or bnn_u250)' --dist=loadfile -n $PYTEST_PARALLEL
 elif [ $1 = "verify" ]; then
   echo "Running verification tests (minimal install verification with Vivado)"
   $FINN_ROOT/scripts/quicktest-local.sh vivado

--- a/src/finn/util/basic.py
+++ b/src/finn/util/basic.py
@@ -41,9 +41,6 @@ from typing import Dict, Optional, Tuple
 
 from finn.util.data_packing import finnpy_to_packed_bytearray
 
-# test boards used for bnn pynq tests
-test_board_map = ["Pynq-Z1", "KV260_SOM", "ZCU104", "U250"]
-
 # mapping from PYNQ board names to FPGA part names
 pynq_part_map = dict()
 pynq_part_map["Ultra96"] = "xczu3eg-sbva484-1-e"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2020, Xilinx
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -26,13 +27,16 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-# -*- coding: utf-8 -*-
-"""
-    Dummy conftest.py for finn.
+# The Jenkins CI sharding + timing plugin lives in the top-level ci/ dir, out
+# of the shipped finn package. Put ci/ on sys.path so the finn_ci package and
+# the end2end board parametrisation can import it by bare name. Local pytest
+# collection is unaffected unless the --num-shards / --dry-run-shards options
+# are passed.
+import os
+import sys
 
-    If you don't know what this is for, just leave it empty.
-    Read more about conftest.py under:
-    https://pytest.org/latest/plugins.html
-"""
+_CI_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "ci")
+if _CI_DIR not in sys.path:
+    sys.path.insert(0, _CI_DIR)
 
-# import pytest
+pytest_plugins = ["finn_ci.plugin"]

--- a/tests/end2end/test_end2end_bnn_pynq.py
+++ b/tests/end2end/test_end2end_bnn_pynq.py
@@ -40,6 +40,7 @@ import torch
 import warnings
 from brevitas.export import export_qonnx
 from dataset_loading import cifar, mnist
+from finn_ci.config import BOARDS, TEST_BOARDS
 from qonnx.core.datatype import DataType
 from qonnx.core.modelwrapper import ModelWrapper
 from qonnx.custom_op.registry import getCustomOp
@@ -95,7 +96,7 @@ from finn.transformation.streamline.reorder import (
     MoveScalarLinearPastInvariants,
 )
 from finn.transformation.streamline.round_thresholds import RoundAndClipThresholds
-from finn.util.basic import get_finn_root, make_build_dir, test_board_map
+from finn.util.basic import get_finn_root, make_build_dir
 from finn.util.pytorch import ToTensor
 from finn.util.test import (
     execute_parent,
@@ -368,114 +369,75 @@ def deploy_based_on_board(model, model_title, topology, wbits, abits, board):
         model.set_metadata_prop("cpp_deploy_dir", deployment_dir)
 
 
-# parameters that make up inputs to test case(s)
-def get_full_parameterized_test_list(marker, wbits_list, abits_list, topology_list, board_list):
-    test_cases = [
-        (
-            f"{marker}_w{param1}_a{param2}_{param3}_{param4}",
-            {
-                "wbits": param1,
-                "abits": param2,
-                "topology": param3,
-                "board": param4,
-            },
+# Each scenario carries a selection marker so pytest -m <marker> picks it up.
+# Sanity is a fixed set of four scenarios, one per board. -m bnn_<board>
+# selects the twelve-scenario matrix (wbits x abits x topology) for one board.
+_SANITY_BNN_CONFIGS = [
+    (1, 1, "lfc", "Pynq-Z1"),
+    (1, 2, "cnv", "KV260_SOM"),
+    (2, 2, "tfc", "ZCU104"),
+    (2, 2, "cnv", "U250"),
+]
+
+# these values feed the xdist_group names below, so changing one renames its
+# group and loses that group's history in the timing master.
+_BNN_WBITS = [1, 2]
+_BNN_ABITS = [1, 2]
+_BNN_TOPOLOGY = ["lfc", "tfc", "cnv"]
+
+
+def _bnn_scenarios():
+    """Return a list of (id, kwargs, marks) tuples, one per test scenario.
+
+    Each scenario's xdist_group name is built from its parameter values, not a
+    list index, so adding or removing a value leaves the other groups (and
+    their timing-master history) unchanged.
+    """
+    scenarios = []
+    for w, a, top, board in _SANITY_BNN_CONFIGS:
+        # fail loudly on a sanity board not declared in BOARDS rather than
+        # silently mis-sharding a mistyped board name
+        if board not in BOARDS:
+            raise ValueError(
+                "_SANITY_BNN_CONFIGS board %r is not a key in finn_ci.config.BOARDS" % board
+            )
+        scenarios.append(
+            (
+                f"sanity_bnn_w{w}_a{a}_{top}_{board}",
+                {"wbits": w, "abits": a, "topology": top, "board": board},
+                [
+                    pytest.mark.sanity_bnn,
+                    pytest.mark.xdist_group(name=f"sanity_bnn_w{w}_a{a}_{top}_{board}"),
+                ],
+            )
         )
-        for param1, param2, param3, param4 in itertools.product(
-            wbits_list,
-            abits_list,
-            topology_list,
-            board_list,
-        )
-    ]
-    return test_cases
+    for board in TEST_BOARDS:
+        marker_name = BOARDS[board]["bnnMarker"]
+        marker = getattr(pytest.mark, marker_name)
+        for w, a, top in itertools.product(_BNN_WBITS, _BNN_ABITS, _BNN_TOPOLOGY):
+            scenarios.append(
+                (
+                    f"bnn_w{w}_a{a}_{top}_{board}",
+                    {"wbits": w, "abits": a, "topology": top, "board": board},
+                    [
+                        marker,
+                        pytest.mark.xdist_group(name=f"{marker_name}_w{w}_a{a}_{top}_{board}"),
+                    ],
+                )
+            )
+    return scenarios
 
 
 def pytest_generate_tests(metafunc):
-    idlist = []
-    argvalues = []
-    scenarios = []
-
-    # Full set of test parameters
-    wbits = [1, 2]
-    abits = [1, 2]
-    topology = ["lfc", "tfc", "cnv"]
-
-    # Separate the full list of markers used on command line.
-    # This allows a user to select multiple markers
-    all_markers_used = metafunc.config.getoption("-m").split(" ")
-
-    for marker in all_markers_used:
-        if "sanity_bnn" in marker:
-            # Define a set of sanity tests that target each of
-            # the supported boards with fixed parameters
-            scenarios.extend(
-                get_full_parameterized_test_list(
-                    "sanity_bnn",
-                    wbits_list=[1],
-                    abits_list=[1],
-                    topology_list=["lfc"],
-                    board_list=[test_board_map[0]],
-                )
-            )
-            scenarios.extend(
-                get_full_parameterized_test_list(
-                    "sanity_bnn",
-                    wbits_list=[1],
-                    abits_list=[2],
-                    topology_list=["cnv"],
-                    board_list=[test_board_map[1]],
-                )
-            )
-            scenarios.extend(
-                get_full_parameterized_test_list(
-                    "sanity_bnn",
-                    wbits_list=[2],
-                    abits_list=[2],
-                    topology_list=["tfc"],
-                    board_list=[test_board_map[2]],
-                )
-            )
-            scenarios.extend(
-                get_full_parameterized_test_list(
-                    "sanity_bnn",
-                    wbits_list=[2],
-                    abits_list=[2],
-                    topology_list=["cnv"],
-                    board_list=[test_board_map[3]],
-                )
-            )
-
-        if "bnn_" in marker:
-            # Target the full set of parameters for a single board
-            # Extract the board name from the marker used, as it is in the form of 'bnn_<board>'
-            bnn_board = next(
-                (element for element in test_board_map if marker.split("_")[1] in element.lower()),
-                None,
-            )
-            test_cases = get_full_parameterized_test_list(
-                "bnn", wbits, abits, topology, [bnn_board]
-            )
-            scenarios.extend(test_cases)
-
-    if len(scenarios) > 0:
-        for i, scenario in enumerate(scenarios):
-            idlist.append(scenario[0])
-            items = scenario[1].items()
-            argnames = [x[0] for x in items]
-            argvalues_scenario = [x[1] for x in items]
-            argvalues.append(
-                pytest.param(
-                    *argvalues_scenario, marks=pytest.mark.xdist_group(name="bnn_pynq_%d" % i)
-                )
-            )
-        metafunc.parametrize(argnames, argvalues, ids=idlist, scope="class")
+    scenarios = _bnn_scenarios()
+    if not scenarios:
+        return
+    argnames = ["wbits", "abits", "topology", "board"]
+    idlist = [s[0] for s in scenarios]
+    argvalues = [pytest.param(*(s[1][k] for k in argnames), marks=s[2]) for s in scenarios]
+    metafunc.parametrize(argnames, argvalues, ids=idlist, scope="class")
 
 
-@pytest.mark.sanity_bnn
-@pytest.mark.bnn_pynq
-@pytest.mark.bnn_zcu104
-@pytest.mark.bnn_kv260
-@pytest.mark.bnn_u250
 class TestEnd2End:
     def test_export(self, topology, wbits, abits, board):
         if wbits > abits:

--- a/tests/fpgadataflow/test_fpgadataflow_ipstitch.py
+++ b/tests/fpgadataflow/test_fpgadataflow_ipstitch.py
@@ -194,7 +194,18 @@ def create_two_fc_model(mem_mode="internal_decoupled"):
     return model
 
 
-@pytest.mark.parametrize("mem_mode", ["internal_embedded", "internal_decoupled"])
+# gen_model -> do_stitch -> rtlsim hand a checkpoint between separate tests via
+# load_test_checkpoint_or_skip. grouping each mem_mode chain keeps it in one
+# shard (and, with workers > 1, loadgroup keeps it on one worker), so each
+# step's output is on disk before the next test reads it. the shared table
+# below keeps the three tests' group names in lockstep.
+MEM_MODE_PARAMS = [
+    pytest.param(m, marks=pytest.mark.xdist_group(name=f"ipstitch_{m}"))
+    for m in ("internal_embedded", "internal_decoupled")
+]
+
+
+@pytest.mark.parametrize("mem_mode", MEM_MODE_PARAMS)
 @pytest.mark.fpgadataflow
 @pytest.mark.vivado
 def test_fpgadataflow_ipstitch_gen_model(mem_mode):
@@ -213,7 +224,7 @@ def test_fpgadataflow_ipstitch_gen_model(mem_mode):
     model.save(ip_stitch_model_dir + "/test_fpgadataflow_ipstitch_gen_model_%s.onnx" % mem_mode)
 
 
-@pytest.mark.parametrize("mem_mode", ["internal_embedded", "internal_decoupled"])
+@pytest.mark.parametrize("mem_mode", MEM_MODE_PARAMS)
 @pytest.mark.fpgadataflow
 @pytest.mark.vivado
 @pytest.mark.slow
@@ -249,7 +260,7 @@ def test_fpgadataflow_ipstitch_do_stitch(mem_mode):
     model.save(ip_stitch_model_dir + "/test_fpgadataflow_ip_stitch_%s.onnx" % mem_mode)
 
 
-@pytest.mark.parametrize("mem_mode", ["internal_embedded", "internal_decoupled"])
+@pytest.mark.parametrize("mem_mode", MEM_MODE_PARAMS)
 @pytest.mark.fpgadataflow
 @pytest.mark.vivado
 def test_fpgadataflow_ipstitch_rtlsim(mem_mode):

--- a/tests/util/test_finn_ci_config.py
+++ b/tests/util/test_finn_ci_config.py
@@ -1,0 +1,353 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import pytest
+
+from finn_ci import config
+
+pytestmark = pytest.mark.util
+
+
+def test_enabled_params_sanity_runs_only_sanity_rows():
+    assert config.enabled_params_for_choice("sanity") == ["sanity"]
+
+
+def test_enabled_params_bare_name_returns_that_one():
+    assert config.enabled_params_for_choice("fpgadataflow") == ["fpgadataflow"]
+    assert config.enabled_params_for_choice("end2end") == ["end2end"]
+
+
+# ----------------------------------------------------------------------------
+# shard_plan
+# ----------------------------------------------------------------------------
+
+_PLAN_STAGES = [
+    {"param": "sanity", "stage": "Sanity Build", "marker": "sanity_bnn", "shards": 1, "workers": 1},
+    {
+        "param": "end2end",
+        "stage": "BNN U250",
+        "marker": "bnn_u250",
+        "shards": 2,
+        "workers": 2,
+        "coverage": True,
+        "zipArtifacts": {"hwTestType": "bnn_build_full", "boards": ["U250", "ZCU104"]},
+    },
+]
+
+
+def test_shard_plan_expands_rows_into_per_shard_entries():
+    plan = config.shard_plan("full", stages=_PLAN_STAGES)
+    stages = [s["stage"] for s in plan["shards"]]
+    assert stages == ["Sanity Build", "BNN U250 (1/2)", "BNN U250 (2/2)"]
+    # single-shard row keeps the bare display name and stash
+    sanity = plan["shards"][0]
+    assert sanity["stash"] == "sanity_build"
+    assert "coverageFile" not in sanity
+    # multi-shard row carries shardId, coverageFile, zipArtifacts
+    u250_b = plan["shards"][2]
+    assert u250_b["shardId"] == 1
+    assert u250_b["numShards"] == 2
+    assert u250_b["stash"] == "bnn_u250_2"
+    assert u250_b["coverageFile"] == "bnn_u250_2.coverage"
+    assert u250_b["zipArtifacts"]["hwTestType"] == "bnn_build_full"
+
+
+def test_shard_plan_filters_by_substring_but_keeps_candidates():
+    plan = config.shard_plan("full", stage_filter="U250", stages=_PLAN_STAGES)
+    assert [s["stage"] for s in plan["shards"]] == ["BNN U250 (1/2)", "BNN U250 (2/2)"]
+    # candidates is the unfiltered active-row display list for the error path
+    assert plan["candidates"] == ["Sanity Build", "BNN U250"]
+
+
+def test_shard_plan_filter_miss_yields_empty_shards_with_candidates():
+    plan = config.shard_plan("full", stage_filter="does-not-match", stages=_PLAN_STAGES)
+    assert plan["shards"] == []
+    assert plan["candidates"] == ["Sanity Build", "BNN U250"]
+
+
+def test_shard_plan_zip_artifacts_flatten_per_row_per_board_not_per_shard():
+    plan = config.shard_plan("full", stages=_PLAN_STAGES)
+    # one entry per (active row, board), so the 2-shard row contributes once
+    # per board, not once per shard
+    assert plan["zipArtifacts"] == [
+        {"stage": "BNN U250", "hwTestType": "bnn_build_full", "board": "U250"},
+        {"stage": "BNN U250", "hwTestType": "bnn_build_full", "board": "ZCU104"},
+    ]
+
+
+def test_shard_plan_only_includes_active_rows():
+    plan = config.shard_plan("sanity", stages=_PLAN_STAGES)
+    assert [s["stage"] for s in plan["shards"]] == ["Sanity Build"]
+
+
+def test_shard_plan_matches_live_stages_stash_names():
+    # shard_plan stash names must equal stash_name() so the conftest plugin
+    # sidecars and the aggregate-time unstash agree.
+    plan = config.shard_plan("full")
+    for entry in plan["shards"]:
+        expected = config.stash_name(
+            entry["stage"].split(" (")[0], entry["numShards"], entry["shardId"]
+        )
+        assert entry["stash"] == expected
+
+
+def test_marker_safe_pattern_accepts_live_markers_and_rejects_foot_guns():
+    # MARKER_SAFE_PATTERN has one home (finn_ci.config) and marker safety is
+    # enforced in validate_config during Validate, so the Jenkinsfile carries no
+    # duplicate regex. The marker is interpolated into the CI pipeline's shell
+    # -m argument, so the pattern must forbid and/not and the double-space shape
+    # (empty token) that would be unsafe or ambiguous there.
+    pattern = config.MARKER_SAFE_PATTERN
+    for row in config.STAGES:
+        assert pattern.match(row["marker"]), (
+            "MARKER_SAFE_PATTERN rejects STAGES marker %r" % row["marker"]
+        )
+    for bad in ("foo and bar", "not slow", "foo  or bar", "foo or", "or foo"):
+        assert not pattern.match(bad), "MARKER_SAFE_PATTERN should reject %r" % bad
+
+
+def test_enabled_params_rejects_unknown_choice_loudly():
+    with pytest.raises(ValueError, match="unknown STAGES choice"):
+        config.enabled_params_for_choice("notarealchoice")
+
+
+def test_enabled_params_full_on_synthetic_stages_picks_up_new_params():
+    # A new CI param (no edits to enabled_params_for_choice required) flows
+    # through the "full" choice automatically because the function reads
+    # ci_param_names.
+    custom_stages = [
+        {"param": "sanity", "stage": "S", "marker": "s", "shards": 1, "workers": 1},
+        {"param": "newthing", "stage": "N", "marker": "n", "shards": 1, "workers": 1},
+    ]
+    assert config.enabled_params_for_choice("full", stages=custom_stages) == [
+        "sanity",
+        "newthing",
+    ]
+    assert config.enabled_params_for_choice("newthing", stages=custom_stages) == ["newthing"]
+    assert config.jenkins_stage_choices(stages=custom_stages) == [
+        "sanity",
+        "full",
+        "newthing",
+    ]
+
+
+def test_jenkins_stage_choices_omits_sanity_head_when_param_absent():
+    # If a future STAGES has no sanity rows at all, jenkins_stage_choices()
+    # must not synthesise a "sanity" choice the dropdown cannot deliver.
+    no_sanity = [
+        {"param": "fpgadataflow", "stage": "F", "marker": "f", "shards": 1, "workers": 1},
+        {"param": "end2end", "stage": "E", "marker": "e", "shards": 1, "workers": 1},
+    ]
+    assert config.jenkins_stage_choices(stages=no_sanity) == [
+        "full",
+        "fpgadataflow",
+        "end2end",
+    ]
+
+
+@pytest.mark.parametrize(
+    "board,row,match",
+    [
+        ("B", {}, "missing required"),
+        (
+            "B",
+            {
+                "agentLabel": "",
+                "credentialsId": None,
+                "restartPrep": False,
+                "setupScript": "pynq",
+                "marker": "B",
+                "bnnMarker": "bnn_b",
+            },
+            "invalid agentLabel",
+        ),
+        (
+            "B",
+            {
+                "agentLabel": "finn-b",
+                "credentialsId": "",
+                "restartPrep": False,
+                "setupScript": "pynq",
+                "marker": "B",
+                "bnnMarker": "bnn_b",
+            },
+            "invalid credentialsId",
+        ),
+        (
+            "B",
+            {
+                "agentLabel": "finn-b",
+                "credentialsId": None,
+                "restartPrep": True,
+                "setupScript": "pynq",
+                "marker": "B",
+                "bnnMarker": "bnn_b",
+            },
+            "restartPrep=true but no credentialsId",
+        ),
+        (
+            "B",
+            {
+                "agentLabel": "finn-b",
+                "credentialsId": None,
+                "restartPrep": False,
+                "setupScript": "bogus",
+                "marker": "B",
+                "bnnMarker": "bnn_b",
+            },
+            "invalid setupScript",
+        ),
+        (
+            "B",
+            {
+                "agentLabel": "finn-b",
+                "credentialsId": None,
+                "restartPrep": False,
+                "setupScript": "pynq",
+                "marker": "B",
+                "bnnMarker": "",
+            },
+            "invalid bnnMarker",
+        ),
+    ],
+)
+def test_validate_board_row_rejects_bad_input(board, row, match):
+    with pytest.raises(ValueError, match=match):
+        config.validate_board_row(board, row)
+
+
+def test_validate_config_rejects_orphan_zipartifact_board_via_helper():
+    custom_stages = [
+        {
+            "param": "p",
+            "stage": "X",
+            "marker": "x",
+            "shards": 1,
+            "workers": 1,
+            "zipArtifacts": {"hwTestType": "t", "boards": ["FakeBoard"]},
+        },
+    ]
+    with pytest.raises(ValueError, match="FakeBoard"):
+        config.validate_config(stages=custom_stages, boards={})
+
+
+@pytest.mark.parametrize(
+    "zip_art,match",
+    [
+        ({}, "non-empty hwTestType"),
+        ({"hwTestType": "", "boards": ["U250"]}, "non-empty hwTestType"),
+        ({"hwTestType": "t"}, "non-empty boards list"),
+        ({"hwTestType": "t", "boards": []}, "non-empty boards list"),
+        ({"hwTestType": "t", "boards": [""]}, "non-empty boards list"),
+    ],
+)
+def test_validate_stage_row_rejects_bad_zip_artifacts(zip_art, match):
+    row = {
+        "param": "p",
+        "stage": "X",
+        "marker": "x",
+        "shards": 1,
+        "workers": 1,
+        "zipArtifacts": zip_art,
+    }
+    with pytest.raises(ValueError, match=match):
+        config.validate_stage_row(row)
+
+
+def test_job_key_strips_dot_traversal():
+    # the per-build prune paths are os.path.join(parent, job_key(...)/...) so
+    # JOB_NAME=".." or all-dot inputs must not survive the sanitiser
+    assert config.job_key("..") == "job"
+    assert config.job_key(".") == "job"
+    assert config.job_key("...") == "job"
+    assert config.job_key("") == "job"
+    assert config.job_key(None) == "job"
+    # leading-/trailing-dot inputs lose just the offending dots
+    assert config.job_key(".foo") == "foo"
+    assert config.job_key("foo.") == "foo"
+    # legitimate names with internal dots survive
+    assert config.job_key("finn.dev") == "finn.dev"
+    # the path-separator class still gets replaced with '_' as before
+    assert config.job_key("../etc") == "_etc"
+
+
+def test_validate_config_rejects_hw_test_type_without_label(monkeypatch):
+    bad_stages = list(config.STAGES) + [
+        {
+            "param": "sanity",
+            "stage": "Bad",
+            "marker": "sanity_bnn",
+            "shards": 1,
+            "workers": 1,
+            "zipArtifacts": {"hwTestType": "bnn_build_unlabelled", "boards": ["U250"]},
+        }
+    ]
+    monkeypatch.setattr(config, "STAGES", bad_stages)
+    with pytest.raises(ValueError, match="bnn_build_unlabelled"):
+        config.validate_config()
+
+
+def test_validate_stage_row_accepts_each_live_row():
+    for row in config.STAGES:
+        config.validate_stage_row(row)
+
+
+@pytest.mark.parametrize(
+    "bad,match",
+    [
+        (
+            {"stage": "X", "marker": "a", "shards": 1, "workers": 1},
+            "missing param",
+        ),
+        (
+            {"stage": "X", "param": "", "marker": "a", "shards": 1, "workers": 1},
+            "missing param",
+        ),
+        (
+            {"stage": "X", "param": 7, "marker": "a", "shards": 1, "workers": 1},
+            "missing param",
+        ),
+        (
+            {"stage": "X", "param": "p", "marker": "a and b", "shards": 1, "workers": 1},
+            "unsafe marker",
+        ),
+        (
+            {"stage": "X", "param": "p", "marker": "a", "shards": 0, "workers": 1},
+            "invalid shards",
+        ),
+        (
+            {"stage": "X", "param": "p", "marker": "a", "shards": 1, "workers": 0},
+            "invalid workers",
+        ),
+        (
+            {
+                "stage": "X",
+                "param": "p",
+                "marker": "a",
+                "shards": 1,
+                "workers": 1,
+                "coverage": "yes",
+            },
+            "invalid coverage",
+        ),
+    ],
+)
+def test_validate_stage_row_rejects_bad_input(bad, match):
+    with pytest.raises(ValueError, match=match):
+        config.validate_stage_row(bad)
+
+
+def test_validate_stage_row_accepts_explicit_coverage_bool():
+    row = {
+        "param": "p",
+        "stage": "X",
+        "marker": "a",
+        "shards": 1,
+        "workers": 1,
+        "coverage": True,
+    }
+    config.validate_stage_row(row)
+    row["coverage"] = False
+    config.validate_stage_row(row)

--- a/tests/util/test_finn_ci_jsonio.py
+++ b/tests/util/test_finn_ci_jsonio.py
@@ -1,0 +1,32 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import pytest
+
+from finn_ci import jsonio
+
+pytestmark = pytest.mark.util
+
+
+def test_read_json_warns_on_corrupt_file(tmp_path, capsys):
+    corrupt = tmp_path / "corrupt.json"
+    corrupt.write_text("{")
+
+    assert jsonio.read_json(str(corrupt), default={"fallback": True}) == {"fallback": True}
+
+    captured = capsys.readouterr()
+    # FileNotFoundError stays silent (idle state), corrupt files warn loudly
+    # so a broken master state doesn't silently degrade sharding to round-robin.
+    assert "finn_ci jsonio read_json" in captured.err
+    assert str(corrupt) in captured.err
+
+
+def test_read_json_missing_file_is_silent(tmp_path, capsys):
+    missing = tmp_path / "absent.json"
+
+    assert jsonio.read_json(str(missing), default=None) is None
+
+    captured = capsys.readouterr()
+    assert captured.err == ""

--- a/tests/util/test_finn_ci_plugin.py
+++ b/tests/util/test_finn_ci_plugin.py
@@ -1,0 +1,303 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import pytest
+
+import json
+import os
+import time
+from finn_ci import plugin, sharding
+
+pytestmark = pytest.mark.util
+pytest_plugins = ["pytester"]
+
+
+class _StubItem:
+    # minimal stand-in for a pytest Item: _group_key only needs nodeid and an
+    # (empty) xdist_group marker iterator.
+    def __init__(self, nodeid):
+        self.nodeid = nodeid
+
+    def iter_markers(self, name):
+        return iter(())
+
+
+def test_group_key_canonicalises_ungrouped_notebook_nodeid():
+    # the timing master stores canonical group names (notebook paths reduced to
+    # basename), so the sharding read path must canonicalise an ungrouped nodeid
+    # the same way or a recorded notebook weight could never be matched.
+    nodeid = "tests/notebooks/test_x.py::test_run[/ws/abs/foo.ipynb]"
+    group = plugin._group_key(_StubItem(nodeid))
+    assert group == "tests/notebooks/test_x.py::test_run[foo.ipynb]"
+    assert group == sharding.canonical_key(nodeid)
+    # a plain nodeid is returned unchanged (canonical_key is a no-op there)
+    plain = "tests/util/test_x.py::test_y[1-2]"
+    assert plugin._group_key(_StubItem(plain)) == plain
+
+
+def _install_finn_ci_plugin(pytester):
+    """Wire the real plugin into a pytester sandbox via pytest_plugins.
+
+    The plugin is a normal importable module (finn_ci.plugin on sys.path), so the
+    sandbox conftest only has to name it. Worker detection in the plugin keys
+    off the inner config's workerinput attribute rather than the inherited
+    PYTEST_XDIST_WORKER env var, so an inline sub-run is correctly seen as a
+    non-worker and no env scrubbing is needed.
+    """
+    pytester.makeconftest('pytest_plugins = ["finn_ci.plugin"]')
+
+
+def test_pytest_plugin_writes_timings_for_successful_sharded_run(pytester):
+    _install_finn_ci_plugin(pytester)
+    pytester.makepyfile(
+        test_sample="""
+def test_ok():
+    assert True
+"""
+    )
+
+    result = pytester.runpytest(
+        "--num-shards=1",
+        "--shard-id=0",
+        "--junitxml=stage.xml",
+        "-q",
+    )
+
+    result.assert_outcomes(passed=1)
+    data = json.loads((pytester.path / "stage.timings.json").read_text())
+    assert data["stash"] == "stage"
+    assert data["shard"] == {"num": 1, "id": 0}
+    assert data["groups"][0]["name"].endswith("test_sample.py::test_ok")
+
+
+def test_pytest_plugin_writes_empty_shard_sidecar_when_slice_collected_zero(pytester):
+    # Two single-test groups round-robin onto shards 0 and 1 (sorted by
+    # nodeid). Shard 1 therefore gets one item, shard 0 gets the other.
+    # If we then ask for shard 0 with a marker that only matches the
+    # second test, the slice is empty and the plugin must:
+    #  - remap exit 5 to 0 so the build does not fail spuriously
+    #  - drop a <stash>.empty-shard sidecar so the aggregator can tell
+    #    "shard had no work" apart from "shard crashed".
+    _install_finn_ci_plugin(pytester)
+    pytester.makepyfile(
+        test_sample="""
+import pytest
+
+@pytest.mark.fpgadataflow
+def test_a():
+    assert True
+
+@pytest.mark.end2end
+def test_b():
+    assert True
+"""
+    )
+
+    result = pytester.runpytest(
+        "-m",
+        "fpgadataflow",
+        "--num-shards=2",
+        "--shard-id=1",
+        "--junitxml=stage.xml",
+        "-q",
+    )
+
+    assert result.ret == 0
+    sidecar = pytester.path / "stage.empty-shard"
+    assert sidecar.exists()
+    assert "0 items" in sidecar.read_text()
+
+
+def test_pytest_plugin_rejects_conflicting_shard_pins_within_xdist_group(pytester):
+    # Two tests share an xdist_group and disagree on @pytest.mark.shard(N).
+    # _assignment_details must surface this as a UsageError rather than
+    # silently splitting a chained checkpoint sequence across shards.
+    _install_finn_ci_plugin(pytester)
+    pytester.makepyfile(
+        test_sample="""
+import pytest
+
+@pytest.mark.xdist_group(name="chain")
+@pytest.mark.shard(0)
+def test_first():
+    assert True
+
+@pytest.mark.xdist_group(name="chain")
+@pytest.mark.shard(1)
+def test_second():
+    assert True
+"""
+    )
+
+    result = pytester.runpytest(
+        "--num-shards=2",
+        "--shard-id=0",
+        "--junitxml=stage.xml",
+        "-q",
+    )
+
+    assert result.ret != 0
+    combined = "\n".join(result.outlines + result.errlines)
+    assert "conflicting" in combined
+    assert "chain" in combined
+
+
+def test_pytest_plugin_dry_run_prints_per_shard_table_and_exits_zero(pytester):
+    # --dry-run-shards must print the header row and exit 0 without running
+    # any test. We deselect everything by design so exit 5 is benign.
+    _install_finn_ci_plugin(pytester)
+    pytester.makepyfile(
+        test_sample="""
+def test_a():
+    assert True
+
+def test_b():
+    assert True
+"""
+    )
+
+    result = pytester.runpytest(
+        "--num-shards=2",
+        "--shard-id=0",
+        "--dry-run-shards",
+        "--junitxml=stage.xml",
+        "-q",
+    )
+
+    assert result.ret == 0
+    out = "\n".join(result.outlines)
+    assert "dry-run-shards" in out
+    assert "shard" in out and "items" in out and "groups" in out
+    # No tests should have actually run.
+    result.assert_outcomes()
+
+
+def test_pytest_plugin_no_double_count_under_xdist(pytester):
+    # Each CI shard runs under xdist, so the controller must aggregate every
+    # worker's forwarded reports into one timings.json while workers keep
+    # self.timings=None and never write a partial one. Under --dist loadgroup
+    # the forwarded nodeids carry an @<group> suffix, so the plugin folds them
+    # back onto the xdist_group via canonical_key: each group must appear once,
+    # its members counted once each AND their seconds summed (not maxed), which
+    # is the weight the timing master keys on downstream.
+    pytest.importorskip("xdist")
+    # runpytest_subprocess is a fresh interpreter, so the ci/ dir that the repo
+    # conftest puts on sys.path at runtime is not visible to it. Make the
+    # sandbox conftest add ci/ itself before naming the plugin.
+    ci_dir = os.path.dirname(os.path.dirname(os.path.abspath(sharding.__file__)))
+    pytester.makeconftest(
+        "import sys\n" "sys.path.insert(0, %r)\n" "pytest_plugins = ['finn_ci.plugin']\n" % ci_dir
+    )
+    # grpA's members sleep unequally (0.30 + 0.05) so the summed group weight
+    # sits well above the 0.30 slowest single member: a max-per-test regression
+    # would record ~0.30 and fail the seconds assertion below.
+    pytester.makepyfile(
+        test_sample="""
+import time
+import pytest
+
+@pytest.mark.xdist_group(name="grpA")
+def test_a():
+    time.sleep(0.30)
+
+@pytest.mark.xdist_group(name="grpA")
+def test_b():
+    time.sleep(0.05)
+
+@pytest.mark.xdist_group(name="grpB")
+def test_c():
+    time.sleep(0.05)
+
+@pytest.mark.xdist_group(name="grpB")
+def test_d():
+    time.sleep(0.05)
+"""
+    )
+
+    result = pytester.runpytest_subprocess(
+        "-n",
+        "2",
+        "--dist",
+        "loadgroup",
+        "--num-shards=1",
+        "--shard-id=0",
+        "--junitxml=stage.xml",
+        "-q",
+    )
+
+    result.assert_outcomes(passed=4)
+    data = json.loads((pytester.path / "stage.timings.json").read_text())
+    by_group = {}
+    for g in data["groups"]:
+        key = sharding.canonical_key(g["name"])
+        entry = by_group.setdefault(key, {"count": 0, "seconds": 0.0})
+        entry["count"] += g["count"]
+        entry["seconds"] += g["seconds"]
+    assert {k: v["count"] for k, v in by_group.items()} == {"grpA": 2, "grpB": 2}
+    assert by_group["grpA"]["seconds"] > 0.33
+
+
+class _FakeConfig:
+    def __init__(self, options):
+        self._options = options
+
+    def getoption(self, name):
+        return self._options.get(name)
+
+
+class _FakeSession:
+    def __init__(self, config, exitstatus):
+        self.config = config
+        self.exitstatus = exitstatus
+
+
+def _drive_sessionfinish(tmp_path, exitstatus):
+    # exercise the per-shard trust guard via a stub session, without spinning up
+    # a full pytest run just to reach pytest_sessionfinish.
+    instance = plugin._FinnCiShardingPlugin()
+    instance.timings = {
+        "per_test_seconds": {"tests/foo.py::test_a": 1.0},
+        "nodeid_to_group": {},
+        "start_monotonic": time.monotonic(),
+    }
+    config = _FakeConfig(
+        {
+            "--num-shards": 1,
+            "--shard-id": 0,
+            "--dry-run-shards": False,
+            "--junitxml": str(tmp_path / "stage.xml"),
+        }
+    )
+    instance.pytest_sessionfinish(_FakeSession(config, exitstatus), exitstatus)
+    return tmp_path / "stage.timings.json"
+
+
+def test_plugin_skips_timings_sidecar_on_interrupted_session(tmp_path):
+    # an aborted/interrupted shard has truncated timings and must not feed the
+    # master, so no sidecar is written.
+    assert not _drive_sessionfinish(tmp_path, pytest.ExitCode.INTERRUPTED).exists()
+
+
+def test_pytest_plugin_writes_timings_sidecar_on_test_failure(pytester):
+    # a plain test failure (exit 1) still has real durations, so the sidecar is
+    # written and can feed the master. only interrupted/aborted runs skip it.
+    _install_finn_ci_plugin(pytester)
+    pytester.makepyfile(
+        test_sample="""
+def test_fails():
+    assert False
+"""
+    )
+
+    result = pytester.runpytest(
+        "--num-shards=1",
+        "--shard-id=0",
+        "--junitxml=stage.xml",
+        "-q",
+    )
+
+    result.assert_outcomes(failed=1)
+    data = json.loads((pytester.path / "stage.timings.json").read_text())
+    assert data["groups"][0]["name"].endswith("test_sample.py::test_fails")

--- a/tests/util/test_finn_ci_sharding.py
+++ b/tests/util/test_finn_ci_sharding.py
@@ -1,0 +1,106 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import pytest
+
+import json
+from finn_ci import sharding
+
+pytestmark = pytest.mark.util
+
+
+def write_json(path, payload):
+    path.write_text(json.dumps(payload))
+
+
+def test_load_group_weights_ignores_missing_and_corrupt(tmp_path):
+    missing = tmp_path / "missing.json"
+    corrupt = tmp_path / "corrupt.json"
+    corrupt.write_text("{")
+
+    assert sharding.load_group_weights(str(missing)) == {}
+    assert sharding.load_group_weights(str(corrupt)) == {}
+
+
+def test_load_group_weights_returns_max_of_samples(tmp_path):
+    master = tmp_path / "master.json"
+    write_json(master, {"groups": {"g": {"samples": [10.0, 20.0, 30.0]}}})
+    weights = sharding.load_group_weights(str(master))
+    assert weights["g"] == 30.0
+
+
+def test_assign_groups_round_robin_without_timing_signal():
+    assignment, source, shard_load, fallback = sharding.assign_groups_to_shards(
+        ["b", "a", "c"], 2, weights={}
+    )
+
+    assert assignment == {"a": 0, "b": 1, "c": 0}
+    assert source == {"a": "round_robin", "b": "round_robin", "c": "round_robin"}
+    assert shard_load == [2.0, 1.0]
+    assert fallback == 1.0
+
+
+def test_assign_groups_pins_override_timing_weights():
+    assignment, source, shard_load, fallback = sharding.assign_groups_to_shards(
+        ["slow", "pinned"], 2, weights={"slow": 100.0, "pinned": 1.0}, pins={"pinned": 0}
+    )
+
+    assert assignment["pinned"] == 0
+    assert assignment["slow"] == 1
+    assert source["pinned"] == "pinned"
+    assert source["slow"] == "known"
+    assert fallback == 100.0
+
+
+def test_assign_groups_unknown_pins_use_fallback_weight():
+    assignment, source, shard_load, fallback = sharding.assign_groups_to_shards(
+        ["known", "pinned"], 2, weights={"known": 9.0}, pins={"pinned": 0}
+    )
+
+    assert assignment["pinned"] == 0
+    assert source["pinned"] == "pinned"
+    assert fallback == 9.0
+    assert shard_load[0] == 9.0
+
+
+def test_assign_groups_rejects_zero_or_negative_num_shards():
+    # Defence-in-depth: a future direct caller (off the plugin path that
+    # validates separately) must get a loud error rather than an IndexError
+    # when shard_load[shard] is written.
+    with pytest.raises(ValueError, match="num_shards must be >= 1"):
+        sharding.assign_groups_to_shards(["a"], 0)
+    with pytest.raises(ValueError, match="num_shards must be >= 1"):
+        sharding.assign_groups_to_shards(["a"], -1)
+
+
+def test_assign_groups_rejects_out_of_range_pin():
+    with pytest.raises(ValueError, match=r"pin for 'k' out of range"):
+        sharding.assign_groups_to_shards(["k"], 2, pins={"k": 2})
+    with pytest.raises(ValueError, match=r"pin for 'k' out of range"):
+        sharding.assign_groups_to_shards(["k"], 2, pins={"k": -1})
+
+
+def test_assign_groups_rejects_non_int_pin():
+    with pytest.raises(ValueError, match="must be an int"):
+        sharding.assign_groups_to_shards(["k"], 2, pins={"k": "zero"})
+
+
+def test_canonical_key_strips_xdist_group_suffix():
+    # xdist's loadgroup forwards a nodeid with an "@<group>" suffix; canonical_key
+    # recovers the bare group name so its members sum together, not as singletons.
+    assert sharding.canonical_key("tests/x.py::test_a@grpA") == "grpA"
+
+
+def test_canonical_key_ignores_param_at_sign():
+    # an "@" inside a parametrize id (e.g. an email-like value) must not be
+    # mistaken for an xdist loadgroup "@<group>" suffix, which would collapse
+    # unrelated tests into one group and one shared timing weight.
+    nodeid = "tests/x.py::test_a[user@host]"
+    assert sharding.canonical_key(nodeid) == nodeid
+
+
+def test_canonical_key_reduces_notebook_path_to_basename():
+    nodeid = "tests/notebooks/test_x.py::test_run[/ws/abs/foo.ipynb]"
+    assert sharding.canonical_key(nodeid) == "tests/notebooks/test_x.py::test_run[foo.ipynb]"

--- a/tests/util/test_print_pytest_failures.py
+++ b/tests/util/test_print_pytest_failures.py
@@ -1,0 +1,119 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import pytest
+
+import os
+import subprocess
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+SCRIPT = os.path.join(REPO_ROOT, "ci", "scripts", "print_pytest_failures.py")
+
+
+JUNIT_WITH_FAILURES = """\
+<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+  <testsuite name="suite" tests="3" failures="1" errors="1" skipped="0">
+    <testcase classname="pkg.mod" name="test_passes" time="0.01"/>
+    <testcase classname="pkg.mod" name="test_fails" time="0.02">
+      <failure message="assert 1 == 2">stack line 1
+stack line 2
+stack line 3</failure>
+    </testcase>
+    <testcase classname="pkg.mod" name="test_errors" time="0.03">
+      <error message="boom">trace line 1
+trace line 2</error>
+    </testcase>
+  </testsuite>
+</testsuites>
+"""
+
+
+def _run(xml_path, stash, lines_per, max_fails):
+    return subprocess.run(
+        [sys.executable, SCRIPT, str(xml_path), stash, str(lines_per), str(max_fails)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+@pytest.mark.util
+def test_print_pytest_failures_emits_per_failure_blocks(tmp_path):
+    xml = tmp_path / "stage.xml"
+    xml.write_text(JUNIT_WITH_FAILURES)
+
+    result = _run(xml, "stage", lines_per=10, max_fails=10)
+
+    out = result.stdout
+    assert "[pytest-failures stage] 2 test failure(s)" in out
+    assert "FAILURE: pkg.mod::test_fails" in out
+    assert "assert 1 == 2" in out
+    assert "stack line 3" in out
+    assert "ERROR: pkg.mod::test_errors" in out
+    assert "trace line 2" in out
+
+
+@pytest.mark.util
+def test_print_pytest_failures_truncates_long_bodies(tmp_path):
+    body_lines = "\n".join("line %02d" % i for i in range(50))
+    xml = tmp_path / "stage.xml"
+    xml.write_text(
+        "<?xml version='1.0'?>\n"
+        "<testsuites><testsuite name='s' tests='1' failures='1'>\n"
+        "<testcase classname='c' name='t'>\n"
+        "<failure message='m'>%s</failure>\n"
+        "</testcase></testsuite></testsuites>\n" % body_lines
+    )
+
+    result = _run(xml, "stage", lines_per=5, max_fails=10)
+
+    assert "earlier lines elided" in result.stdout
+    assert "line 49" in result.stdout
+    assert "line 04" not in result.stdout
+
+
+@pytest.mark.util
+def test_print_pytest_failures_caps_to_max_failures(tmp_path):
+    cases = "\n".join(
+        "<testcase classname='c' name='t%d'><failure message='m'>x</failure></testcase>" % i
+        for i in range(5)
+    )
+    xml = tmp_path / "stage.xml"
+    xml.write_text(
+        "<?xml version='1.0'?>\n"
+        "<testsuites><testsuite name='s' tests='5' failures='5'>\n"
+        "%s\n</testsuite></testsuites>\n" % cases
+    )
+
+    result = _run(xml, "stage", lines_per=10, max_fails=2)
+
+    assert "5 test failure(s)" in result.stdout
+    assert "and 3 more failure(s) elided" in result.stdout
+
+
+@pytest.mark.util
+def test_print_pytest_failures_handles_no_failures(tmp_path):
+    xml = tmp_path / "stage.xml"
+    xml.write_text(
+        "<?xml version='1.0'?>\n"
+        "<testsuites><testsuite name='s' tests='1' failures='0'>\n"
+        "<testcase classname='c' name='t'/></testsuite></testsuites>\n"
+    )
+
+    result = _run(xml, "stage", lines_per=10, max_fails=10)
+
+    assert "no test failures recorded" in result.stdout
+
+
+@pytest.mark.util
+def test_print_pytest_failures_handles_unparseable_xml(tmp_path):
+    xml = tmp_path / "stage.xml"
+    xml.write_text("not actually xml")
+
+    result = _run(xml, "stage", lines_per=10, max_fails=10)
+
+    assert "failed to parse" in result.stdout


### PR DESCRIPTION
This is PR 7 of 9 of a series intended to make CI faster and more robust.

This PR adds a new `ci/` subdirectory and a `finn_ci` Python package inside it. This package is designed to let any marker stage be easily split into time-balanced shards. Note that PRs 8 and 9 wire the Jenkinsfiles into this package, so some of the package's surface won't be consumed until then (to keep this PR reviewable). This PR is safe to merge on its own because it does not affect the existing Jenkins pipeline and test changes do not change actual behaviour (only the way they are generated).

Currently, FINN's Jenkins pipeline is a handful of long marker stages, and the best way to improve wall clock time is to split those stages between more workers (i.e. sharding). Doing that reliably requires:

**A)** a definition of the board and stage matrix that both the tests and the build pipeline agree on
**B)** a way to assign tests to shards that is deterministic across every worker (so xdist collections match)
**C)** a way for per-test timing data to feed the next run so that shards are balanced

### A - Consolidated config

The "finn_ci" package now owns the CI board and stage tables and any derivations over such, eliminating duplication between pytest and Jenkinsfiles. These configurations are now validated directly by the tests themselves.

### B & C - Sharding and timing

There were several approaches available for this. For instance, the simplest is round-robin allocation, but that produces uneven shards and longer overall wall-clock times. Another approach is to record the durations of tests manually, store those durations somewhere, and have your CI consume that file. The problem with this is that it goes stale quickly as tests are added, and someone needs to refresh the timings file.

There exist off-the-shelf options, but none were exactly what the problem needed. For instance, pytest-shard can't balance by durations/weights, and pytest-split doesn't have awareness of xidst_group, so it splits checkpoint chains that need to stay together.

I ended up going with writing a simple pytest sharding plugin that does the following:

**1. Grouping:** Before assigning, tests are bucketed into groups. Tests marked with the same `xdist_group` form one group, because they hand files to each other and must stay together.
**2. Selection:** Every shard's pytest collects the same full set of tests for that marker. The plugin checks the config tables and a master timings file, and decides what tests _this_ shard should keep, and throws away the rest. Each shard uses exactly the same calculation, so the assignment is deterministic.
**3. Updating:** Each group takes a certain amount of time. After a shard finishes, the plugin writes a small sidecar file next to the JUnit XML recording how long each group took. A full build later merges those into a persistent timing master file, which feeds step 2.

This is a self-healing system which rebalances as new tests are added, keeps grouped tests together, and falls back to simple round-robin on a cold start. The pytest plugin does nothing if the sharding flag isn't passed, so regular contributors won't experience any changes to local testing.

### Other changes

- `test_end2end_bnn_pynq.py` generated its test matrix in a fragile way, duplicating the board list in `basic.py`, and the per-board markers were a third copy. In addition, because a group was named by its position `i` in the generated list, inserting or removing a scenario would renumber every group after it (which would invalidate the new timing strategy). The board metadata now lives in `finn_ci.config.BOARDS`, and the test generates its matrix from that table.
- `print_pytest_failures.py` is a new simple script that parses JUnit XML that has already been produced and prints a tail of test failures into the CI log, for observability. Never crashes a run.
- Use `@pytest.mark.shard(N)` to pin a test to a particular shard.
- Unit tests for all the above