### PR TITLE
Generalise rtlsim package ordering and route xelab via resolver [CI 3/9]

### DIFF
--- a/finn_xsi/finn_xsi/adapter.py
+++ b/finn_xsi/finn_xsi/adapter.py
@@ -13,9 +13,10 @@ import os
 import os.path
 import re
 from finn_xsi.sim_engine import SimEngine
+from finn_xsi.srcutil import order_pkg_first
 from typing import Optional
 
-from finn.util.basic import launch_process_helper
+from finn.util.basic import launch_process_helper, resolve_xilinx_tool
 
 
 def locate_glbl() -> Optional[str]:
@@ -45,12 +46,8 @@ def compile_sim_obj(top_module_name, source_list, sim_out_dir, debug=False, beha
         }
         verilog_header_incl_str = " ".join(["--include " + x for x in verilog_headers])
 
-        # sort src list so that packages are loaded first
-        # these packages must be compiled before modules that depend on them
-        pkg_patterns = ["swg_pkg", "mvu_pkg"]
-        srcs_list = sorted(
-            source_list, key=lambda s: (not any(pkg in s for pkg in pkg_patterns), s)
-        )
+        # packages must come before the modules that import them
+        srcs_list = order_pkg_first(source_list)
         for src_line in srcs_list:
             if src_line.endswith(".v"):
                 f.write(f"verilog work {verilog_header_incl_str} {src_line}\n")
@@ -91,7 +88,7 @@ def compile_sim_obj(top_module_name, source_list, sim_out_dir, debug=False, beha
     ]
 
     cmd_xelab = [
-        "xelab",
+        resolve_xilinx_tool("xelab"),
         "work." + top_module_name,
         "-relax",
         "-prj",
@@ -100,11 +97,9 @@ def compile_sim_obj(top_module_name, source_list, sim_out_dir, debug=False, beha
         "-s",
         top_module_name,
     ]
-    # Add debug flag if debug is enabled
     if debug:
         cmd_xelab.append("-debug")
         cmd_xelab.append("all")
-    # Add behavioural simulation flag if behav is enabled
     if behav:
         cmd_xelab.append("-define")
         cmd_xelab.append("FINN_SIMULATION")
@@ -115,7 +110,8 @@ def compile_sim_obj(top_module_name, source_list, sim_out_dir, debug=False, beha
     if locate_glbl() is not None:
         cmd_xelab.insert(1, "work.glbl")
 
-    launch_process_helper(cmd_xelab, cwd=sim_out_dir)
+    # check=True so an xelab failure is raised here, not later as a missing xsimk.so
+    launch_process_helper(cmd_xelab, cwd=sim_out_dir, check=True)
     out_so_relative_path = "xsim.dir/%s/xsimk.so" % top_module_name
     out_so_full_path = sim_out_dir + "/" + out_so_relative_path
 

--- a/finn_xsi/finn_xsi/srcutil.py
+++ b/finn_xsi/finn_xsi/srcutil.py
@@ -1,0 +1,37 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import os.path
+
+# these helpers live in a separate module from adapter.py so they can be
+# imported without the xsi C-extension (pulled in via sim_engine), keeping them
+# unit-testable in a checkout where finn_xsi has not been built yet
+
+
+def is_pkg_src(path: str) -> bool:
+    """Return True for ``*_pkg.{sv,v}`` files (SystemVerilog/Verilog packages).
+
+    ``compile_sim_obj`` uses this to move packages ahead of the modules that
+    import them, which xelab requires. Matching the ``_pkg`` basename suffix is
+    just a useful heuristic that may catch new finn-rtllib packages without
+    manually editing a whitelist.
+    """
+    base = os.path.basename(path)
+    return base.endswith("_pkg.sv") or base.endswith("_pkg.v")
+
+
+def order_pkg_first(source_list):
+    """Return ``source_list`` reordered so ``*_pkg.{sv,v}`` files come first.
+
+    The partition is stable, so files keep their original relative order within
+    each group. This only guarantees packages before modules. A package that
+    imports another package still depends on ``source_list`` already listing
+    them in dependency order.
+    """
+    pkg_srcs = []
+    other_srcs = []
+    for src in source_list:
+        (pkg_srcs if is_pkg_src(src) else other_srcs).append(src)
+    return pkg_srcs + other_srcs

--- a/src/finn/util/basic.py
+++ b/src/finn/util/basic.py
@@ -243,22 +243,36 @@ class CppBuilder:
         process_compile.communicate()
 
 
-def launch_process_helper(args, proc_env=None, cwd=None):
-    """Helper function to launch a process in a way that facilitates logging
-    stdout/stderr with Python loggers.
-    Returns (cmd_out, cmd_err)."""
+def launch_process_helper(args, proc_env=None, cwd=None, check=False):
+    """Launch a process and capture its output for logging with Python loggers.
+
+    Returns ``(cmd_out, cmd_err)`` as UTF-8 strings, with undecodable bytes in
+    tool output replaced rather than raised. Both streams are also written
+    through to ``sys.stdout``/``sys.stderr``.
+
+    When ``check`` is True and the process exits non-zero, raises
+    ``subprocess.CalledProcessError`` with ``output`` and ``stderr`` set to the
+    captured strings. The write-through happens before the raise, so the tool
+    log is still visible on failure. That is why the return code is checked by
+    hand rather than relying on ``subprocess.run(check=True)``.
+    """
     if proc_env is None:
         proc_env = os.environ.copy()
-    with subprocess.Popen(
-        args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=proc_env, cwd=cwd
-    ) as proc:
-        (cmd_out, cmd_err) = proc.communicate()
-    if cmd_out is not None:
-        cmd_out = cmd_out.decode("utf-8")
-        sys.stdout.write(cmd_out)
-    if cmd_err is not None:
-        cmd_err = cmd_err.decode("utf-8")
-        sys.stderr.write(cmd_err)
+    proc = subprocess.run(
+        args,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=proc_env,
+        cwd=cwd,
+        encoding="utf-8",
+        errors="replace",
+    )
+    cmd_out = proc.stdout
+    cmd_err = proc.stderr
+    sys.stdout.write(cmd_out)
+    sys.stderr.write(cmd_err)
+    if check and proc.returncode != 0:
+        raise subprocess.CalledProcessError(proc.returncode, args, cmd_out, cmd_err)
     return (cmd_out, cmd_err)
 
 
@@ -287,14 +301,15 @@ _XILINX_TOOL_DIR_ENV = "FINN_TOOL_DIR_OVERRIDE"
 
 
 def resolve_xilinx_tool(tool_name):
-    """Return the Xilinx-tool command to embed in generated bash scripts. Update
-    the following list if new tools use this resolver.
+    """Resolve the command used to invoke a Xilinx tool. Update the following
+    list if new tools use this resolver.
 
     Default names:
     - vivado
     - vitis_hls
     - vitis-run
     - v++
+    - xelab
 
     With FINN_TOOL_DIR_OVERRIDE set, the command resolves to
     <override>/<tool_name>, otherwise the bare tool_name is used.

--- a/tests/util/test_xsi_pkg_ordering.py
+++ b/tests/util/test_xsi_pkg_ordering.py
@@ -1,0 +1,75 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+
+import pytest
+
+import os
+import sys
+
+# finn_xsi is not pip-installed (only src/ is packaged), and finn.xsi adds this
+# dir to sys.path at runtime. srcutil has no xsi C-extension import, so we can
+# add the dir and import it even in a checkout where finn_xsi is not built yet
+# (finn_xsi.adapter could not, since it imports sim_engine).
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+_XSI_ROOT = os.path.join(os.environ.get("FINN_ROOT", _REPO_ROOT), "finn_xsi")
+if _XSI_ROOT not in sys.path:
+    sys.path.insert(0, _XSI_ROOT)
+
+from finn_xsi.srcutil import is_pkg_src, order_pkg_first  # noqa: E402
+
+
+@pytest.mark.util
+@pytest.mark.parametrize(
+    "path",
+    [
+        # a generic *_pkg suffix should catch any new finn-rtllib
+        # package without manually editing a whitelist
+        "/path/to/swg_pkg.sv",
+        "/path/to/mvu_pkg.v",
+        "/path/to/some_other_pkg.sv",
+        "foo_pkg.sv",
+    ],
+)
+def test_is_pkg_src_matches_pkg_basenames(path):
+    assert is_pkg_src(path)
+
+
+@pytest.mark.util
+def test_is_pkg_src_does_not_match_non_pkg_or_header_files():
+    # compile_sim_obj skips header files (.svh / .vh) when writing the .prj, so
+    # the predicate must not pull them into the package group either
+    assert not is_pkg_src("/path/to/foo.sv")
+    assert not is_pkg_src("/path/to/foo.v")
+    assert not is_pkg_src("/path/to/foo.vhd")
+    assert not is_pkg_src("/path/to/swg_pkg.svh")
+    assert not is_pkg_src("/path/to/swg_pkg_top.sv")
+    assert not is_pkg_src("/path/to/_pkg.svh")
+
+
+@pytest.mark.util
+def test_order_pkg_first_floats_packages_and_is_stable():
+    # packages must come before modules, and order within each group (including
+    # the interleaved headers) must be preserved so dependency order survives
+    source_list = [
+        "/path/to/top.sv",
+        "/path/to/swg_pkg.sv",
+        "/path/to/foo.vh",
+        "/path/to/mvu_pkg.v",
+        "/path/to/bar.v",
+    ]
+    assert order_pkg_first(source_list) == [
+        "/path/to/swg_pkg.sv",
+        "/path/to/mvu_pkg.v",
+        "/path/to/top.sv",
+        "/path/to/foo.vh",
+        "/path/to/bar.v",
+    ]
+
+
+@pytest.mark.util
+def test_order_pkg_first_preserves_list_with_no_packages():
+    source_list = ["/path/to/top.sv", "/path/to/bar.v"]
+    assert order_pkg_first(source_list) == source_list


### PR DESCRIPTION
This is PR 3 of 9 of a series intended to make CI faster and more robust.

This patch hardens the FINN XSI rtlsim compile path and completes the xelab handling through the resolver (introduced in #1600). 

xelab aborts if a SystemVerilog package is analysed after a module that imports it, so the compile step floats packages ahead of their importers. To date its been done with a hardcoded whitelist which needs to grow reactively. ca70a7876 ("Sort list of hdl sources to make sure configs come first") floated `swg_pkg`, then 240dd536c ("Add mvu_pkg to be loaded first") added `mvu_pkg`. Each new package is an expensive red CI run and a manual whitelist add, which doesn't scale well as finn-rtllib grows. I've replaced the whitelist with a simple heuristic (*_pkg.{sv,v}). While doing so, the xelab call is now routed through the tool resolver so it can be delegated like the other heavy tools, and a xelab failure now fails fast with the real error instead of a missing output `.so` file.

### Changes

- float any `*_pkg.{sv,v}` source ahead of regular modules by basename, instead of matching a fixed set of names. The ordering is a stable partition, so the caller's relative order within each group is preserved.
- moved the ordering helpers into a small finn_xsi/srcutil.py that doesn't import the `xsi` C-extension so they are unit-testable without finn-xsi built.
- route the xelab call through resolve_xilinx_tool so it can be delegated to HPC/LSF clusters
- add a "check" flag to `launch_process_helper` so a non-zero exit raises immediately. Previously a failed xelab returned quietly and surfaced later with a FileNotFoundError on the missing `.so` file.
- unit tests for reordering

### Testing

Reproduced the failure directly with xelab, a package listed after its importer fails with `VRFC 10-2989`, while floating it first fixes it. Confirmed that a realistic new source will break the old whitelist method. Many functional rtlsim validation runs in Jenkins.