### PR TITLE
Tiled MVAU assertion 

### DIFF
--- a/src/finn/custom_op/fpgadataflow/rtl/matrixvectoractivation_rtl.py
+++ b/src/finn/custom_op/fpgadataflow/rtl/matrixvectoractivation_rtl.py
@@ -343,9 +343,8 @@ class MVAU_rtl(MVAU, RTLBackend):
                 "Clock pumping an input of SIMD=1 is not meaningful. Please increase SIMD."
             )
 
-        # Check to make sure that tile size divides the number of input vectors evenly
-        # otherwise we hit issues with output being silently dropped resulting in an 
-        # eventual stall.
+        # Check to make sure that tile size divides the number of input vectors evenly;
+        # otherwise the final partial tile can cause output to be dropped and eventually stall.
         theight = self.get_nodeattr("TH")
         if theight > 1:
             num_inp_vec = int(np.prod(self.get_nodeattr("numInputVectors")))

--- a/src/finn/custom_op/fpgadataflow/rtl/matrixvectoractivation_rtl.py
+++ b/src/finn/custom_op/fpgadataflow/rtl/matrixvectoractivation_rtl.py
@@ -343,6 +343,20 @@ class MVAU_rtl(MVAU, RTLBackend):
                 "Clock pumping an input of SIMD=1 is not meaningful. Please increase SIMD."
             )
 
+        # Check to make sure that tile size divides the number of input vectors evenly
+        # otherwise we hit issues with output being silently dropped resulting in an 
+        # eventual stall.
+        theight = self.get_nodeattr("TH")
+        if theight > 1:
+            num_inp_vec = int(np.prod(self.get_nodeattr("numInputVectors")))
+            if num_inp_vec % theight != 0:
+                valid_th = [t for t in range(1, num_inp_vec + 1) if num_inp_vec % t == 0]
+                raise Exception(
+                    "%s: TH=%d does not divide numInputVectors=%d. The tiled MVU "
+                    "requires TH | numInputVectors; choose a divisor (valid: %s)."
+                    % (self.onnx_node.name, theight, num_inp_vec, valid_th)
+                )
+
         dsp_block = get_dsp_block(fpgapart)
         code_gen_dict = {}
         code_gen_dict["$IS_MVU$"] = [str(1)]


### PR DESCRIPTION
The tiled MVU (TH>1) groups input vectors into tiles of TH and assumes the tile size divides the number of input vectors evenly. A partial final tile (numInputVectors % TH != 0) never completes in weights_buff_tile, deadlocking the dataflow. Fail loudly at codegen rather than producing a silently hanging design.