### PR TITLE
[Tests] Tolerate extra robust_rmtree retry from real NFS removal

### DIFF
--- a/tests/util/test_robust_rmtree.py
+++ b/tests/util/test_robust_rmtree.py
@@ -56,7 +56,7 @@ def test_robust_rmtree_retries_on_transient_then_succeeds(monkeypatch, transient
 
     robust_rmtree(target, retries=5)
 
-    assert state["calls"] == 3
+    assert state["calls"] >= 3
     assert not os.path.exists(target)
 
 


### PR DESCRIPTION
A robust_rmtree test is very rarely flaky because it stubs a failed tree removal due to ENOTEMPTY (NFS race) twice, then calls a real shutil.rmtree and asserts that "calls == 3". But that third call might fail with a real ENOTEMPTY. This patch changes the assertion to >= 3 calls to remove this transient issue.