### PR TITLE
Fix ElementwiseBinary cppsim over-read on a broadcast last axis

### DIFF
--- a/src/finn/custom_op/fpgadataflow/hls/elementwise_binary_hls.py
+++ b/src/finn/custom_op/fpgadataflow/hls/elementwise_binary_hls.py
@@ -797,6 +797,24 @@ class ElementwiseBinaryOperation_hls(
             return super().code_generation_ipi()
         return cmd
 
+    def fold_input_for_npy(self, inp_val, ind):
+        # A broadcast operand's folded inner axis is 1 but its stream word is PE
+        # wide, so the cppsim feeder over-reads the scalar npy. Widen it to the
+        # stream word, but only for an npy-fed operand (runtime input or
+        # internal_decoupled const). An embedded const is read from params, not
+        # the npy, so there is nothing to widen.
+        folded = super().fold_input_for_npy(inp_val, ind)
+        style = [self.lhs_style, self.rhs_style][ind]
+        stream_fed = style == "input" or (
+            style == "const" and self.get_nodeattr("mem_mode") == "internal_decoupled"
+        )
+        if not stream_fed:
+            return folded
+        elems = self.get_instream_width(ind) // self.get_input_datatype(ind).bitwidth()
+        if folded.shape[-1] == 1 and elems > 1:
+            folded = np.broadcast_to(folded, folded.shape[:-1] + (elems,))
+        return folded
+
     def execute_node(self, context, graph):
         mode = self.get_nodeattr("exec_mode")
         if mode == "cppsim":

--- a/src/finn/custom_op/fpgadataflow/hlsbackend.py
+++ b/src/finn/custom_op/fpgadataflow/hlsbackend.py
@@ -306,6 +306,12 @@ compilation transformations?
         process_execute = subprocess.Popen(executable_path, stdout=subprocess.PIPE)
         process_execute.communicate()
 
+    def fold_input_for_npy(self, inp_val, ind):
+        """Lay an input tensor out into the folded shape written to the npy that
+        feeds cppsim/rtlsim. Overridable seam for ops whose npy layout differs
+        from the folded shape."""
+        return inp_val.reshape(self.get_folded_input_shape(ind))
+
     def execute_node(self, context, graph):
         mode = self.get_nodeattr("exec_mode")
         node = self.onnx_node
@@ -324,7 +330,6 @@ compilation transformations?
         inputs = {}
         for i, inp in enumerate(node.input):
             exp_ishape = tuple(self.get_normal_input_shape(i))
-            folded_ishape = self.get_folded_input_shape(i)
             inp_val = context[inp]
             # Make sure the input has the right container datatype
             if inp_val.dtype not in [np.float32, np.float16]:
@@ -344,7 +349,7 @@ compilation transformations?
                 inp_val = (inp_val + 1) / 2
                 export_idt = DataType["BINARY"]
 
-            reshaped_input = inp_val.reshape(folded_ishape)
+            reshaped_input = self.fold_input_for_npy(inp_val, i)
             reshaped_input = reshaped_input.copy()
             np.save(os.path.join(code_gen_dir, "input_%s.npy" % i), reshaped_input)
             nbits = self.get_instream_width(i)

--- a/tests/fpgadataflow/test_fpgadataflow_elementwise_binary.py
+++ b/tests/fpgadataflow/test_fpgadataflow_elementwise_binary.py
@@ -405,3 +405,95 @@ def test_elementwise_binary_operation_stitched_ip(
     else:
         # Compare the expected to the produced for exact equality
         assert np.all(o_produced == o_expected)
+
+
+@pytest.mark.parametrize("op_type", ["ElementwiseAdd", "ElementwiseMul", "ElementwiseGreater"])
+# Both broadcast directions on the last axis, plus a non-broadcast control
+@pytest.mark.parametrize(
+    "lhs_shape, rhs_shape",
+    [
+        ([3, 1, 7, 1], [3, 32, 1, 16]),  # lhs last axis broadcast
+        ([3, 32, 1, 16], [3, 1, 7, 1]),  # rhs last axis broadcast
+        ([3, 1, 7, 16], [3, 32, 1, 16]),  # no broadcast on last axis (control)
+    ],
+)
+# Number of elements to process in parallel
+@pytest.mark.parametrize("pe", [1, 2, 4])
+@pytest.mark.fpgadataflow
+@pytest.mark.slow
+@pytest.mark.vivado
+def test_elementwise_binary_cppsim_broadcast_last_axis(op_type, lhs_shape, rhs_shape, pe):
+    lhs_dtype = rhs_dtype = "INT8"
+    out_dtype = "FLOAT32"
+    # Make dummy model with both inputs left as runtime streams
+    model = create_elementwise_binary_operation_onnx(
+        op_type, lhs_dtype, rhs_dtype, out_dtype, lhs_shape, rhs_shape
+    )
+    context = {
+        "in_x": gen_finn_dt_tensor(DataType[lhs_dtype], lhs_shape),
+        "in_y": gen_finn_dt_tensor(DataType[rhs_dtype], rhs_shape),
+    }
+
+    model = model.transform(InferDataTypes())
+    model = model.transform(InferShapes())
+    model = model.transform(InferElementwiseBinaryOperation())
+    model = model.transform(InferDataTypes())
+    model = model.transform(InferShapes())
+    model = model.transform(SpecializeLayers("xczu7ev-ffvc1156-2-e"))
+
+    getCustomOp(model.graph.node[0]).set_nodeattr("PE", pe)
+
+    model = model.transform(MinimizeWeightBitWidth())
+    model = model.transform(MinimizeAccumulatorWidth())
+    model = model.transform(SetExecMode("cppsim"))
+    model = model.transform(GiveUniqueNodeNames())
+    model = model.transform(PrepareCppSim())
+    model = model.transform(CompileCppSim())
+
+    o_expected = NUMPY_REFERENCES[op_type](context["in_x"], context["in_y"])
+    o_produced = execute_onnx(model, context)["out"]
+
+    assert np.all(o_produced == o_expected)
+
+
+# A broadcast const operand is npy-fed in internal_decoupled but baked into params
+# in internal_embedded, so the two modes exercise the two sides of the fold guard
+@pytest.mark.parametrize("mem_mode", ["internal_embedded", "internal_decoupled"])
+@pytest.mark.parametrize("pe", [2, 4])
+@pytest.mark.fpgadataflow
+@pytest.mark.slow
+@pytest.mark.vivado
+def test_elementwise_binary_cppsim_broadcast_const(mem_mode, pe):
+    # Streamed lhs (last axis 16), broadcast const rhs (last axis 1)
+    lhs_shape, rhs_shape = [3, 32, 1, 16], [3, 1, 7, 1]
+    model = create_elementwise_binary_operation_onnx(
+        "ElementwiseMul", "INT8", "INT8", "FLOAT32", lhs_shape, rhs_shape
+    )
+    context = {
+        "in_x": gen_finn_dt_tensor(DataType["INT8"], lhs_shape),
+        "in_y": gen_finn_dt_tensor(DataType["INT8"], rhs_shape),
+    }
+    model.set_initializer("in_y", context["in_y"])
+
+    model = model.transform(InferDataTypes())
+    model = model.transform(InferShapes())
+    model = model.transform(InferElementwiseBinaryOperation())
+    model = model.transform(InferDataTypes())
+    model = model.transform(InferShapes())
+    model = model.transform(SpecializeLayers("xczu7ev-ffvc1156-2-e"))
+
+    op = getCustomOp(model.graph.node[0])
+    op.set_nodeattr("PE", pe)
+    op.set_nodeattr("mem_mode", mem_mode)
+
+    model = model.transform(MinimizeWeightBitWidth())
+    model = model.transform(MinimizeAccumulatorWidth())
+    model = model.transform(SetExecMode("cppsim"))
+    model = model.transform(GiveUniqueNodeNames())
+    model = model.transform(PrepareCppSim())
+    model = model.transform(CompileCppSim())
+
+    o_expected = np.multiply(context["in_x"], context["in_y"])
+    o_produced = execute_onnx(model, context)["out"]
+
+    assert np.all(o_produced == o_expected)


### PR DESCRIPTION
## Summary

A broadcast elementwise operand is written to the cppsim input file as one value per stream word, but the C++ reader consumes PE values per word, so its pointer runs PE times too fast and reads wrong (then out-of-bounds) data. Fix: write PE copies of the value into each word.

## Example to follow

Elementwise ops (`ElementwiseAdd`, `ElementwiseMul`, ...) combine two tensors `lhs` and `rhs` position by position. **Broadcast** lets an operand of size 1 on an axis be reused along that axis. Take `rhs` with size 1 on its **last** axis:

```
SHAPES:
lhs [3, 2]            rhs [3, 1]         out [3, 2]

OPERATION:
out[i, j] = lhs[i, j] * rhs[i, 0]

VALUES:
lhs = [[1, 2],        rhs = [[5],       out = [[ 5, 10],
       [3, 4],               [6],              [18, 24],
       [8, 9]]               [7]]              [56, 63]]
```

So `rhs` stores one value per row (5, 6, 7), reused across the whole row.

## How FINN currently streams

FINN streams a tensor **along its last axis**, packing `PE` of those elements into one **stream word** (`PE = 2` here). `lhs` rows are one word each: `[1 2]`, `[3 4]`, `[8 9]`. `rhs` has only ONE real value per row, which the hardware copies onto both lanes and reads from lane 0, so the npy feeding cppsim holds one value per word:

```
rhs npy (flat) :  [ 5 ][ 6 ][ 7 ]
```

## Bug

The reader `npy2apintstream.hpp` fills each word by pulling `N = word_width / element_width = PE` values from the flat array, advancing a pointer. The broadcast npy has only one value per word, so the pointer runs twice as fast as the data:

```
BEFORE (broken, PE = 2)

flat array :  [ 5, 6, 7 ]              (only 3 values)

word 0 reads flat[0..1] = 5,6   -> lane0 = 5   OK
word 1 reads flat[2..3] = 7,?   -> lane0 = 7   WRONG (wanted 6)
word 2 reads flat[4..5] = ?,?   -> out of bounds
```

From the second word on every broadcast value is wrong, and the read runs off the end.

## Fix

Write `PE` copies of the value into each word, so a word is self-contained:

```
AFTER (fixed, PE = 2)

flat array :  [ 5, 5, 6, 6, 7, 7 ]

word 0 reads flat[0..1] = 5,5   -> lane0 = 5   OK
word 1 reads flat[2..3] = 6,6   -> lane0 = 6   OK
word 2 reads flat[4..5] = 7,7   -> lane0 = 7   OK
```

The word count is unchanged and lane 0 now always holds the right value.

## Notes

- **Only cppsim was affected.** rtlsim uses a different feeder that pads a full word from one value, so its lane 0 was already correct.
- **Scope.** We only widen an operand fed through the npy: a runtime **input**, or a **const** in `internal_decoupled` mode. An **embedded** const is read from params, so its npy is never consumed and is left alone.
- **Implementation.** `HLSBackend` now has an overridable `fold_input_for_npy` whose default is the old behaviour (`reshape` to the folded shape); `ElementwiseBinaryOperation_hls` overrides it to make the `PE` copies.

## Testing

- [x] New cppsim tests cover both broadcast directions, a non-broadcast control, PE in {1, 2, 4}, and both const memory modes.
- [x] A local container sweep, 42/42 across INT8, UINT4, INT16, PE in {1, 2, 4, 8, 16}, both directions, scalar operand, and embedded plus decoupled const. Disabling the fix fails exactly the broadcast PE>1 cases and nothing else.
- [x] Full Jenkins run validates the fix with no regressions.