### PR TITLE
dwc wide streams

### DIFF
--- a/src/finn/custom_op/fpgadataflow/hls/streamingdatawidthconverter_hls.py
+++ b/src/finn/custom_op/fpgadataflow/hls/streamingdatawidthconverter_hls.py
@@ -73,9 +73,7 @@ class StreamingDataWidthConverter_hls(StreamingDataWidthConverter, HLSBackend):
                 numMiddleWords % (outWidth // elemWidth) == 0
             ), "Error in DWC element-width split calculation"
             self.code_gen_dict["$DEFINES$"].append("#define IntermediateWidth %d" % elemWidth)
-            self.code_gen_dict["$DEFINES$"].append(
-                "#define NumMiddleWords %d" % numMiddleWords
-            )
+            self.code_gen_dict["$DEFINES$"].append("#define NumMiddleWords %d" % numMiddleWords)
         elif self.needs_lcm():
             lcmWidth = self.get_iowidth_lcm()
             assert numInWords % (lcmWidth / inWidth) == 0, "Error in DWC LCM calculation"
@@ -98,8 +96,7 @@ class StreamingDataWidthConverter_hls(StreamingDataWidthConverter, HLSBackend):
         if self._needs_element_width_split():
             self.code_gen_dict["$DOCOMPUTE$"] = [
                 'hls::stream<ap_uint<IntermediateWidth>> intermediate ("intermediate");',
-                "%s<InWidth, IntermediateWidth, NumInWords>(in0_V, intermediate, numReps);"
-                % op,
+                "%s<InWidth, IntermediateWidth, NumInWords>(in0_V, intermediate, numReps);" % op,
                 "%s<IntermediateWidth, OutWidth, NumMiddleWords>(intermediate, out0_V, numReps);"
                 % op,
             ]

--- a/src/finn/custom_op/fpgadataflow/hls/streamingdatawidthconverter_hls.py
+++ b/src/finn/custom_op/fpgadataflow/hls/streamingdatawidthconverter_hls.py
@@ -41,6 +41,9 @@ class StreamingDataWidthConverter_hls(StreamingDataWidthConverter, HLSBackend):
     """Class that corresponds to finn-hlslib StreamingDataWidthConverter_Batch
     function."""
 
+    def _needs_element_width_split(self):
+        return self.needs_lcm() and self.get_iowidth_lcm() > 8191
+
     def get_nodeattr_types(self):
         my_attrs = {}
         my_attrs.update(StreamingDataWidthConverter.get_nodeattr_types(self))
@@ -61,7 +64,19 @@ class StreamingDataWidthConverter_hls(StreamingDataWidthConverter, HLSBackend):
             "#define NumInWords %d " % numInWords,
             "#define numReps %d" % numReps,
         ]
-        if self.needs_lcm():
+        if self._needs_element_width_split():
+            elemWidth = self.get_input_datatype().bitwidth()
+            assert inWidth % elemWidth == 0, "DWC input width must be element-aligned"
+            assert outWidth % elemWidth == 0, "DWC output width must be element-aligned"
+            numMiddleWords = numInWords * (inWidth // elemWidth)
+            assert (
+                numMiddleWords % (outWidth // elemWidth) == 0
+            ), "Error in DWC element-width split calculation"
+            self.code_gen_dict["$DEFINES$"].append("#define IntermediateWidth %d" % elemWidth)
+            self.code_gen_dict["$DEFINES$"].append(
+                "#define NumMiddleWords %d" % numMiddleWords
+            )
+        elif self.needs_lcm():
             lcmWidth = self.get_iowidth_lcm()
             assert numInWords % (lcmWidth / inWidth) == 0, "Error in DWC LCM calculation"
             numLCMToOut = numInWords // (lcmWidth / inWidth)
@@ -80,7 +95,15 @@ class StreamingDataWidthConverter_hls(StreamingDataWidthConverter, HLSBackend):
     def docompute(self):
         # TODO continue with fxns below, they are copy-pasted
         op = "StreamingDataWidthConverter_Batch"
-        if self.needs_lcm():
+        if self._needs_element_width_split():
+            self.code_gen_dict["$DOCOMPUTE$"] = [
+                'hls::stream<ap_uint<IntermediateWidth>> intermediate ("intermediate");',
+                "%s<InWidth, IntermediateWidth, NumInWords>(in0_V, intermediate, numReps);"
+                % op,
+                "%s<IntermediateWidth, OutWidth, NumMiddleWords>(intermediate, out0_V, numReps);"
+                % op,
+            ]
+        elif self.needs_lcm():
             self.code_gen_dict["$DOCOMPUTE$"] = [
                 'hls::stream<ap_uint<{}>> intermediate ("intermediate");'.format(
                     self.get_iowidth_lcm()

--- a/src/finn/custom_op/fpgadataflow/streamingdatawidthconverter.py
+++ b/src/finn/custom_op/fpgadataflow/streamingdatawidthconverter.py
@@ -97,10 +97,9 @@ class StreamingDataWidthConverter(HWCustomOp):
             return tuple(shape[:-1] + [int(channels // elems), elems])
 
         total_elems = int(np.prod(shape))
-        assert total_elems % elems == 0, (
-            "DWC stream width with %d elements does not divide tensor shape %s"
-            % (elems, str(shape))
-        )
+        assert (
+            total_elems % elems == 0
+        ), "DWC stream width with %d elements does not divide tensor shape %s" % (elems, str(shape))
         return (int(total_elems // elems), elems)
 
     def get_folded_input_shape(self, ind=0):

--- a/src/finn/custom_op/fpgadataflow/streamingdatawidthconverter.py
+++ b/src/finn/custom_op/fpgadataflow/streamingdatawidthconverter.py
@@ -84,46 +84,34 @@ class StreamingDataWidthConverter(HWCustomOp):
     def check_divisible_iowidths(self):
         pass
 
+    def _folded_shape_for_width(self, width):
+        shape = self.get_normal_input_shape()
+        bits = self.get_input_datatype().bitwidth()
+        assert (
+            width % bits == 0
+        ), """DWC stream width must be divisible by
+        input element bitwidth"""
+        elems = int(width // bits)
+        channels = shape[-1]
+        if channels % elems == 0:
+            return tuple(shape[:-1] + [int(channels // elems), elems])
+
+        total_elems = int(np.prod(shape))
+        assert total_elems % elems == 0, (
+            "DWC stream width with %d elements does not divide tensor shape %s"
+            % (elems, str(shape))
+        )
+        return (int(total_elems // elems), elems)
+
     def get_folded_input_shape(self, ind=0):
         self.check_divisible_iowidths()
         iwidth = self.get_nodeattr("inWidth")
-        ishape = self.get_normal_input_shape()
-        dummy_t = np.random.randn(*ishape)
-        ibits = self.get_input_datatype().bitwidth()
-        assert (
-            iwidth % ibits == 0
-        ), """DWC input width must be divisible by
-        input element bitwidth"""
-        ielems = int(iwidth // ibits)
-        ichannels = ishape[-1]
-        new_shape = []
-        for i in ishape[:-1]:
-            new_shape.append(i)
-        new_shape.append(int(ichannels // ielems))
-        new_shape.append(ielems)
-        dummy_t = dummy_t.reshape(new_shape)
-        return dummy_t.shape
+        return self._folded_shape_for_width(iwidth)
 
     def get_folded_output_shape(self, ind=0):
         self.check_divisible_iowidths()
         owidth = self.get_nodeattr("outWidth")
-        oshape = self.get_normal_output_shape()
-        dummy_t = np.random.randn(*oshape)
-        obits = self.get_output_datatype().bitwidth()
-        assert (
-            owidth % obits == 0
-        ), """DWC output width must be divisible by
-        input element bitwidth"""
-        oelems = int(owidth // obits)
-        ochannels = oshape[-1]
-        new_shape = []
-        for i in oshape[:-1]:
-            new_shape.append(i)
-        new_shape.append(int(ochannels // oelems))
-        new_shape.append(oelems)
-        dummy_t = dummy_t.reshape(new_shape)
-
-        return dummy_t.shape
+        return self._folded_shape_for_width(owidth)
 
     def get_instream_width(self, ind=0):
         in_width = self.get_nodeattr("inWidth")

--- a/tests/fpgadataflow/test_fpgadataflow_dwc.py
+++ b/tests/fpgadataflow/test_fpgadataflow_dwc.py
@@ -90,6 +90,13 @@ def prepare_inputs(input_tensor, dt):
         ([1, 4], 4, 2, DataType["INT2"]),
         ([1, 2, 8], 4, 4, DataType["INT2"]),
         ([1, 2, 8], 8, 16, DataType["INT2"]),
+        # A 32-bit word holds 16 INT2 elements and spans both 8-channel rows.
+        pytest.param(([1, 2, 8], 32, 16, DataType["INT2"]), id="wide-input-stream"),
+        # lcm(128, 130) = 8320, which exercises HLS element-width splitting.
+        pytest.param(
+            ([1, 65, 128], 128, 130, DataType["BINARY"]),
+            id="wide-output-stream-oversized-lcm",
+        ),
     ],
 )
 @pytest.mark.parametrize("exec_mode", ["cppsim", "rtlsim"])


### PR DESCRIPTION
Allows flattened DWC folding for wide stream cases.
Groups the Python-side data-width-converter change separately from later HLS splitting work.
Change type: Python