### PR TITLE
Include nested FINNLoop sources for stitched rtlsim

### DIFF
--- a/src/finn/transformation/fpgadataflow/create_stitched_ip.py
+++ b/src/finn/transformation/fpgadataflow/create_stitched_ip.py
@@ -40,8 +40,62 @@ from shutil import copytree
 from finn.transformation.fpgadataflow.replace_verilog_relpaths import (
     ReplaceVerilogRelPaths,
 )
-from finn.util.basic import make_build_dir, resolve_xilinx_tool
+from finn.util.basic import getHWCustomOp, make_build_dir, resolve_xilinx_tool
 from finn.util.fpgadataflow import is_hls_node, is_rtl_node
+
+
+RTLSIM_SOURCE_EXTENSIONS = {".v", ".sv", ".vh", ".svh", ".vhd"}
+
+
+def append_missing_finnloop_rtlsim_sources(model, v_file_list):
+    """Add nested FINNLoop-generated HDL sources to the top rtlsim source list.
+
+    Vivado's top-level USED_IN_SYNTHESIS query can omit HDL generated under a
+    packaged FINNLoop IP's own block design. The XSI compile then sees the
+    top-level wrapper but misses nested MLO helper modules such as generated
+    FIFOs, DuplicateStreams, and loop-body shuffles. The FINNLoop IP-generation
+    step already exports a complete local rtlsim source list, so merge entries
+    that are not already present in the top source list.
+    """
+
+    if not os.path.isfile(v_file_list):
+        return
+
+    with open(v_file_list) as f:
+        existing_sources = [line.strip() for line in f if line.strip()]
+    existing_paths = set(existing_sources)
+    existing_basenames = {os.path.basename(path) for path in existing_sources}
+    appended_sources = []
+
+    for node in model.graph.node:
+        if node.op_type != "FINNLoop":
+            continue
+        node_inst = getHWCustomOp(node, model)
+        code_gen_dir = node_inst.get_nodeattr("code_gen_dir_ipgen")
+        nested_list = os.path.join(code_gen_dir, "all_verilog_srcs.txt")
+        if not os.path.isfile(nested_list):
+            continue
+        with open(nested_list) as f:
+            candidate_sources = [line.strip() for line in f if line.strip()]
+        for source_path in candidate_sources:
+            _, ext = os.path.splitext(source_path)
+            if ext.lower() not in RTLSIM_SOURCE_EXTENSIONS:
+                continue
+            source_basename = os.path.basename(source_path)
+            if source_path in existing_paths or source_basename in existing_basenames:
+                continue
+            appended_sources.append(source_path)
+            existing_paths.add(source_path)
+            existing_basenames.add(source_basename)
+
+    if appended_sources:
+        with open(v_file_list, "a") as f:
+            for source_path in appended_sources:
+                f.write(source_path + "\n")
+        print(
+            "Added %d nested FINNLoop HDL sources to %s"
+            % (len(appended_sources), v_file_list)
+        )
 
 
 def is_external_input(model, node, i):
@@ -754,6 +808,7 @@ close $ofile
         bash_command = ["bash", make_project_sh]
         process_compile = subprocess.Popen(bash_command, stdout=subprocess.PIPE)
         process_compile.communicate()
+        append_missing_finnloop_rtlsim_sources(model, v_file_list)
         # wrapper may be created in different location depending on Vivado version
         if not os.path.isfile(wrapper_filename):
             # check in alternative location (.gen instead of .srcs)

--- a/src/finn/transformation/fpgadataflow/create_stitched_ip.py
+++ b/src/finn/transformation/fpgadataflow/create_stitched_ip.py
@@ -43,7 +43,6 @@ from finn.transformation.fpgadataflow.replace_verilog_relpaths import (
 from finn.util.basic import getHWCustomOp, make_build_dir, resolve_xilinx_tool
 from finn.util.fpgadataflow import is_hls_node, is_rtl_node
 
-
 RTLSIM_SOURCE_EXTENSIONS = {".v", ".sv", ".vh", ".svh", ".vhd"}
 
 
@@ -92,10 +91,7 @@ def append_missing_finnloop_rtlsim_sources(model, v_file_list):
         with open(v_file_list, "a") as f:
             for source_path in appended_sources:
                 f.write(source_path + "\n")
-        print(
-            "Added %d nested FINNLoop HDL sources to %s"
-            % (len(appended_sources), v_file_list)
-        )
+        print("Added %d nested FINNLoop HDL sources to %s" % (len(appended_sources), v_file_list))
 
 
 def is_external_input(model, node, i):

--- a/tests/fpgadataflow/test_fpgadataflow_ipstitch.py
+++ b/tests/fpgadataflow/test_fpgadataflow_ipstitch.py
@@ -44,7 +44,11 @@ from finn.transformation.fpgadataflow.alveo_build import PrepareForLinking, Viti
 from finn.transformation.fpgadataflow.create_dataflow_partition import (
     CreateDataflowPartition,
 )
-from finn.transformation.fpgadataflow.create_stitched_ip import CreateStitchedIP
+from finn.transformation.fpgadataflow import create_stitched_ip
+from finn.transformation.fpgadataflow.create_stitched_ip import (
+    CreateStitchedIP,
+    append_missing_finnloop_rtlsim_sources,
+)
 from finn.transformation.fpgadataflow.floorplan import Floorplan
 from finn.transformation.fpgadataflow.hlssynth_ip import HLSSynthIP
 from finn.transformation.fpgadataflow.insert_iodma import InsertIODMA
@@ -59,6 +63,105 @@ test_pynq_board = "Pynq-Z1"
 test_fpga_part = pynq_part_map[test_pynq_board]
 
 ip_stitch_model_dir = os.environ["FINN_BUILD_DIR"]
+
+
+class FakeHWCustomOp:
+    def __init__(self, code_gen_dir):
+        self.code_gen_dir = code_gen_dir
+
+    def get_nodeattr(self, name):
+        assert name == "code_gen_dir_ipgen"
+        return self.code_gen_dir
+
+
+class FakeNode:
+    def __init__(self, op_type, code_gen_dir=None):
+        self.op_type = op_type
+        self.code_gen_dir = code_gen_dir
+
+
+class FakeGraph:
+    def __init__(self, nodes):
+        self.node = nodes
+
+
+class FakeModel:
+    def __init__(self, nodes):
+        self.graph = FakeGraph(nodes)
+
+
+@pytest.mark.fpgadataflow
+def test_ipstitch_appends_missing_finnloop_rtlsim_sources(tmp_path, monkeypatch):
+    top_list = tmp_path / "all_verilog_srcs.txt"
+    existing_top = tmp_path / "top_existing.v"
+    existing_duplicate_basename = tmp_path / "same_name.sv"
+    existing_top.write_text("// top\n")
+    existing_duplicate_basename.write_text("// duplicate basename\n")
+    top_list.write_text(str(existing_top) + "\n" + str(existing_duplicate_basename) + "\n")
+
+    loop_a = tmp_path / "loop_a"
+    loop_b = tmp_path / "loop_b"
+    loop_a.mkdir()
+    loop_b.mkdir()
+
+    loop_a_new_v = loop_a / "nested_a.v"
+    loop_a_new_sv = loop_a / "nested_a_extra.SV"
+    loop_a_skip_txt = loop_a / "ignore.txt"
+    loop_a_dup_basename = loop_a / "same_name.sv"
+    for source_path in [
+        loop_a_new_v,
+        loop_a_new_sv,
+        loop_a_skip_txt,
+        loop_a_dup_basename,
+    ]:
+        source_path.write_text("// loop a\n")
+    (loop_a / "all_verilog_srcs.txt").write_text(
+        "\n".join(
+            map(
+                str,
+                [
+                    loop_a_new_v,
+                    loop_a_new_sv,
+                    loop_a_skip_txt,
+                    loop_a_dup_basename,
+                ],
+            )
+        )
+        + "\n"
+    )
+
+    loop_b_new_vhd = loop_b / "nested_b.vhd"
+    loop_b_dup_basename = loop_b / "nested_a.v"
+    for source_path in [loop_b_new_vhd, loop_b_dup_basename]:
+        source_path.write_text("// loop b\n")
+    (loop_b / "all_verilog_srcs.txt").write_text(
+        "\n".join(map(str, [loop_b_new_vhd, loop_b_dup_basename])) + "\n"
+    )
+
+    model = FakeModel(
+        [
+            FakeNode("MVAU_rtl", str(loop_a)),
+            FakeNode("FINNLoop", str(loop_a)),
+            FakeNode("FINNLoop", str(loop_b)),
+            FakeNode("FINNLoop", str(tmp_path / "missing_loop")),
+        ]
+    )
+    monkeypatch.setattr(
+        create_stitched_ip,
+        "getHWCustomOp",
+        lambda node, model: FakeHWCustomOp(node.code_gen_dir),
+    )
+
+    append_missing_finnloop_rtlsim_sources(model, str(top_list))
+    assert top_list.read_text().splitlines() == [
+        str(existing_top),
+        str(existing_duplicate_basename),
+        str(loop_a_new_v),
+        str(loop_a_new_sv),
+        str(loop_b_new_vhd),
+    ]
+
+    append_missing_finnloop_rtlsim_sources(model, str(tmp_path / "missing_top.txt"))
 
 
 def create_one_fc_model(mem_mode="internal_embedded"):

--- a/tests/fpgadataflow/test_fpgadataflow_ipstitch.py
+++ b/tests/fpgadataflow/test_fpgadataflow_ipstitch.py
@@ -40,11 +40,11 @@ from qonnx.transformation.infer_data_layouts import InferDataLayouts
 from qonnx.util.basic import gen_finn_dt_tensor, qonnx_make_model
 
 from finn.core.onnx_exec import execute_onnx
+from finn.transformation.fpgadataflow import create_stitched_ip
 from finn.transformation.fpgadataflow.alveo_build import PrepareForLinking, VitisLink
 from finn.transformation.fpgadataflow.create_dataflow_partition import (
     CreateDataflowPartition,
 )
-from finn.transformation.fpgadataflow import create_stitched_ip
 from finn.transformation.fpgadataflow.create_stitched_ip import (
     CreateStitchedIP,
     append_missing_finnloop_rtlsim_sources,


### PR DESCRIPTION
Adds missing nested FINNLoop HDL sources to the stitched-IP rtlsim source list.
Includes the source-list helper and its focused IP-stitch regression test.
Change type: Python