### PR TITLE
Fix FINNLoop MVAU MLO memblock paths

### DIFF
--- a/src/finn/custom_op/fpgadataflow/rtl/finn_loop.py
+++ b/src/finn/custom_op/fpgadataflow/rtl/finn_loop.py
@@ -463,9 +463,11 @@ class FINNLoop(HWCustomOp, RTLBackend):
                             for line in infile:
                                 outfile.write(line)
                         os.remove(memblock_file)
-                # Replace the path for the dat files in the ipgen files if Eltwise
+                # Replace the path for the dat files in the ipgen files.
                 # Adapted from transformations.fpgadataflow.replace_verilog_relpaths
-                if param_node.op_type.startswith("Elementwise"):
+                if param_node.op_type.startswith("MVAU") or param_node.op_type.startswith(
+                    "Elementwise"
+                ):
                     param_customop = getCustomOp(param_node)
                     ipgen_path = param_customop.get_nodeattr("code_gen_dir_ipgen")
                     if ipgen_path is not None and os.path.isdir(ipgen_path):


### PR DESCRIPTION
Fixes FINNLoop MVAU MLO memblock path generation.
This keeps generated memblock references correct when MVAU nodes are placed inside rolled loop bodies.
Change type: Python