### PR TITLE
Sim Engine timing issue

### DIFF
--- a/finn_xsi/finn_xsi/sim_engine.py
+++ b/finn_xsi/finn_xsi/sim_engine.py
@@ -28,11 +28,11 @@ class SimEngine:
             clk.set(up).write_back()
             if clk2x is not None:
                 clk2x.set(1).write_back()
-                top.run(25)
+                top.run(2500)
                 clk2x.set(0).write_back()
-                top.run(25)
+                top.run(2500)
             else:
-                top.run(50)
+                top.run(5000)
 
         def cycle(updates):
             half_cycle(1)


### PR DESCRIPTION
Changings to the sim engine timings were causing issues with the DSP58 tests. The initial values returned were corrupted. Restoring it to the original timings restores passing tests. 