### PR TITLE
[Fix] Double-pumped DSP58 rtlsim: apply stimulus after the active clock edge

### DIFF
--- a/finn_xsi/finn_xsi/sim_engine.py
+++ b/finn_xsi/finn_xsi/sim_engine.py
@@ -24,21 +24,35 @@ class SimEngine:
             if p.isInput():
                 p.clear().write_back()
 
-        def half_cycle(up):
-            clk.set(up).write_back()
-            if clk2x is not None:
-                clk2x.set(1).write_back()
-                top.run(2500)
-                clk2x.set(0).write_back()
-                top.run(2500)
-            else:
-                top.run(5000)
+        def half_cycle_2x(run_first):
+            # Complete one slow half-cycle while the fast clock goes high->low.
+            # run_first reserves the stimulus tick after the active edge (2499)
+            # for the leading half; the trailing half uses the full 2500.
+            top.run(run_first)
+            clk2x.set(0).write_back()
+            top.run(2500)
 
         def cycle(updates):
-            half_cycle(1)
+            # Start the cycle on the active (rising) edge.
+            clk.set(1).write_back()
+            if clk2x is not None:
+                clk2x.set(1).write_back()
+            # Apply stimulus one tick after the active edge so inputs are stable
+            # across the whole slow cycle (both fast beats). Required for the
+            # double-pumped DSP58 datapath, which samples on the clk2x rising
+            # edges; mutating stimulus on a clk2x edge corrupts the 2nd beat.
+            top.run(1)
             for port, update in updates.items():
                 port.set_hexstr(update).write_back()
-            half_cycle(0)
+            if clk2x is None:
+                top.run(4999)
+                clk.set(0).write_back()
+                top.run(5000)
+            else:
+                half_cycle_2x(2499)  # finish the clk-high half
+                clk.set(0).write_back()
+                clk2x.set(1).write_back()
+                half_cycle_2x(2500)  # finish the clk-low half
 
         self.top = top
         self.cycle = cycle


### PR DESCRIPTION
Problem
Node-by-node XSI rtlsim produced incorrect results for double-pumped compute (pumpedCompute=True, DSP58). The cycle() driver applied input stimulus between half_cycle(1) and half_cycle(0) — i.e. coincident with a clk2x rising edge.
Mutating inputs on a clk2x edge corrupts the second fast beat of the double-pumped datapath, yielding wrong (non-permuted) outputs. Non-pumped designs were unaffected.

Fix
Restore the previous timing: start the cycle on the active (rising) edge, then apply stimulus one tick later (run(1)) so inputs are stable across the whole slow cycle (both fast beats). The clk/clk2x edge order is unchanged; only the stimulus application point moves.

FIFO sizing / logfile safety
fifo_gauge.sv samples only on posedge(clk), and inputs remain stable from t=1 through the next clk posedge, so the logfile feature is unaffected by this change.
