### PR TITLE
Update the SLASH_ALVEO flow for SLASH's renamed slashkit linker

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -263,6 +263,6 @@ A site that offloads the heavy Xilinx tools to a compute farm (see "Running tool
 
 | Env var                  | What it sets                                                                                                                                        |
 | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `FINN_TOOL_DIR_OVERRIDE` | Shim directory. `finn.util.basic.resolve_xilinx_tool()` resolves `vivado`/`v++`/`vitis_hls`/`vitis-run`/`xelab` to `<dir>/<tool>` when set.        |
+| `FINN_TOOL_DIR_OVERRIDE` | Shim directory. `finn.util.basic.resolve_xilinx_tool()` resolves `vivado`/`v++`/`vitis_hls`/`vitis-run`/`xelab`/`slashkit` to `<dir>/<tool>` when set.        |
 
 The wrapper's own variables are deployment-specific.

--- a/docker/Dockerfile.finn
+++ b/docker/Dockerfile.finn
@@ -88,7 +88,7 @@ RUN locale-gen "en_US.UTF-8"
 # Install v80++. If the package isn't provided, this is a no-op
 # The wildcard pattern ensures COPY doesn't fail if the file doesn't exist
 COPY v80pp.de[b] /tmp/
-RUN if [ -f /tmp/v80pp.deb ]; then apt-get install -y /tmp/v80pp.deb && rm /tmp/v80pp.deb; fi
+RUN if [ -f /tmp/v80pp.deb ]; then apt-get update && apt-get install -y /tmp/v80pp.deb && rm /tmp/v80pp.deb; fi
 
 # install XRT
 RUN if [ -z "$LOCAL_XRT" ] && [ -z "$SKIP_XRT" ];then \

--- a/docker/Dockerfile.finn
+++ b/docker/Dockerfile.finn
@@ -166,6 +166,6 @@ COPY docker/finn_entrypoint.sh /usr/local/bin/
 COPY docker/quicktest.sh /usr/local/bin/
 RUN chmod 755 /usr/local/bin/finn_entrypoint.sh
 RUN chmod 755 /usr/local/bin/quicktest.sh
-USER USERNAME
+USER $USERNAME
 ENTRYPOINT ["finn_entrypoint.sh"]
 CMD ["bash"]

--- a/docker/Dockerfile.finn
+++ b/docker/Dockerfile.finn
@@ -33,7 +33,7 @@ LABEL maintainer="Jakoba Petri-Koenig <jakoba.petri-koenig@amd.com>, Yaman Umuro
 ARG XRT_DEB_VERSION="xrt_202220.2.14.354_22.04-amd64-xrt"
 ARG SKIP_XRT
 ARG LOCAL_XRT
-ARG V80PP_DEB_PACKAGE
+ARG SLASHKIT_DEB_PACKAGE
 
 WORKDIR /workspace
 
@@ -85,10 +85,10 @@ RUN apt-get update && \
 RUN echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config
 RUN locale-gen "en_US.UTF-8"
 
-# Install v80++. If the package isn't provided, this is a no-op
+# Install slashkit. If the package isn't provided, this is a no-op
 # The wildcard pattern ensures COPY doesn't fail if the file doesn't exist
-COPY v80pp.de[b] /tmp/
-RUN if [ -f /tmp/v80pp.deb ]; then apt-get update && apt-get install -y /tmp/v80pp.deb && rm /tmp/v80pp.deb; fi
+COPY slashkit.de[b] /tmp/
+RUN if [ -f /tmp/slashkit.deb ]; then apt-get update && apt-get install -y /tmp/slashkit.deb && rm /tmp/slashkit.deb; fi
 
 # install XRT
 RUN if [ -z "$LOCAL_XRT" ] && [ -z "$SKIP_XRT" ];then \

--- a/docs/finn/getting_started.rst
+++ b/docs/finn/getting_started.rst
@@ -100,7 +100,7 @@ The most relevant are summarized below:
 * (required) ``FINN_XILINX_VERSION`` sets the Xilinx tools version to be used (e.g. ``2022.2``)
 * (required for Vitis) ``PLATFORM_REPO_PATHS`` points to the Vitis platform files (DSA).
 * (required for Vitis) ``XRT_DEB_VERSION`` specifies the .deb to be installed for XRT inside the container (see default value in ``run-docker.sh``).
-* (required for Slash) ``V80PP_DEB_PACKAGE`` specifies the .deb to be installed for Slash's v80++ linker.
+* (required for Slash) ``SLASHKIT_DEB_PACKAGE`` specifies the .deb to be installed for Slash's slashkit linker. This replaces the former ``V80PP_DEB_PACKAGE`` variable, there is no backwards compatibility.
 * (optional) ``NUM_DEFAULT_WORKERS`` (default 4) specifies the degree of parallelization for the transformations that can be run in parallel, potentially reducing build time
 * (optional) ``FINN_XELAB_MT`` overrides the number of threads used by ``xelab`` when building XSI simulations. Defaults to ``NUM_DEFAULT_WORKERS`` or 8 if unset. Set to 1 to disable xelab multithreading.
 * (optional) ``FINN_HOST_BUILD_DIR`` specifies which directory on the host will be used as the build directory. Defaults to ``/tmp/finn_dev_<username>``
@@ -258,7 +258,7 @@ card is installed. These two can be the same PC, or connected over the network.
 Prior to first usage, you need to build the Slash packages from source and set up both
 the host and the target. Please refer to the `Slash GitHub repository
 <https://github.com/Xilinx/slash>`_ for instructions on how to build all Slash packages,
-including the ``v80++`` linker package.
+including the ``slashkit`` linker package.
 
 On the target side:
 
@@ -268,10 +268,10 @@ On the target side:
 
 On the host side:
 
-1. Build the ``v80++`` Debian package from the `Slash GitHub repository
+1. Build the ``slashkit`` Debian package from the `Slash GitHub repository
    <https://github.com/Xilinx/slash>`_ and copy it to a location accessible on the host.
-2. Set the ``V80PP_DEB_PACKAGE`` environment variable to the path of the ``v80++``
-   Debian package (e.g. ``export V80PP_DEB_PACKAGE=/path/to/v80++.deb``). The package
+2. Set the ``SLASHKIT_DEB_PACKAGE`` environment variable to the path of the ``slashkit``
+   Debian package (e.g. ``export SLASHKIT_DEB_PACKAGE=/path/to/slashkit.deb``). The package
    will be installed into the Docker image when ``run-docker.sh`` builds it.
 3. `Set up public key authentication <https://www.digitalocean.com/community/tutorials/how-to-configure-ssh-key-based-authentication-on-a-linux-server>`_.
    Copy your private key to the ``finn/ssh_keys`` folder on the host to get

--- a/run-docker.sh
+++ b/run-docker.sh
@@ -64,7 +64,7 @@ SCRIPTPATH=$(dirname "$SCRIPT")
 : ${FINN_SSH_KEY_DIR="$SCRIPTPATH/ssh_keys"}
 : ${PLATFORM_REPO_PATHS="/opt/xilinx/platforms"}
 : ${XRT_DEB_VERSION="xrt_202220.2.14.354_22.04-amd64-xrt"}
-: ${V80PP_DEB_PACKAGE=""}
+: ${SLASHKIT_DEB_PACKAGE=""}
 : ${FINN_HOST_BUILD_DIR="/tmp/$DOCKER_INST_NAME"}
 : ${FINN_DOCKER_TAG="xilinx/finn:$(OLD_PWD=$(pwd); cd $SCRIPTPATH; git describe --always --tags --dirty; cd $OLD_PWD).$XRT_DEB_VERSION"}
 : ${FINN_DOCKER_PREBUILT="0"}
@@ -112,8 +112,8 @@ if [ -z "$PLATFORM_REPO_PATHS" ];then
   recho "This is required to be able to use Vitis-based Alveo PCIe cards."
 fi
 
-if [ -z "$V80PP_DEB_PACKAGE" ];then
-  recho "Please set V80PP_DEB_PACKAGE pointing to the SLASH v80++ .deb package."
+if [ -z "$SLASHKIT_DEB_PACKAGE" ];then
+  recho "Please set SLASHKIT_DEB_PACKAGE pointing to the SLASH slashkit .deb package."
   recho "This is required to be able to use the Alveo V80 card."
 fi
 
@@ -197,9 +197,9 @@ if [ -f "$FINN_XRT_PATH/$XRT_DEB_VERSION.deb" ]; then
   export LOCAL_XRT=1
 fi
 
-# If v80++ deb package given, copy it to repo root for docker build
-if [ -n "$V80PP_DEB_PACKAGE" ] && [ -f "$V80PP_DEB_PACKAGE" ]; then
-  cp "$V80PP_DEB_PACKAGE" ./v80pp.deb
+# If slashkit deb package given, copy it to repo root for docker build
+if [ -n "$SLASHKIT_DEB_PACKAGE" ] && [ -f "$SLASHKIT_DEB_PACKAGE" ]; then
+  cp "$SLASHKIT_DEB_PACKAGE" ./slashkit.deb
 fi
 
 if [ "$FINN_DOCKER_NO_CACHE" = "1" ]; then
@@ -264,7 +264,7 @@ if [ "$FINN_DOCKER_PREBUILT" = "0" ] && [ -z "$FINN_SINGULARITY" ]; then
     --build-arg XRT_DEB_VERSION=$XRT_DEB_VERSION \
     --build-arg SKIP_XRT=$FINN_SKIP_XRT_DOWNLOAD \
     --build-arg LOCAL_XRT=$LOCAL_XRT \
-    --build-arg V80PP_DEB_PACKAGE=$V80PP_DEB_PACKAGE \
+    --build-arg SLASHKIT_DEB_PACKAGE=$SLASHKIT_DEB_PACKAGE \
     --tag=$FINN_DOCKER_TAG $FINN_DOCKER_BUILD_EXTRA \
     --build-arg GROUP_ID=$DOCKER_GID \
     --build-arg GROUPNAME=$DOCKER_GNAME \
@@ -279,9 +279,9 @@ if [ ! -z "$LOCAL_XRT" ];then
   rm $XRT_DEB_VERSION.deb
 fi
 
-# Remove local v80pp.deb file from repo
-if [ -f "./v80pp.deb" ]; then
-  rm ./v80pp.deb
+# Remove local slashkit.deb file from repo
+if [ -f "./slashkit.deb" ]; then
+  rm ./slashkit.deb
 fi
 
 # Launch container with current directory mounted

--- a/src/finn/transformation/fpgadataflow/alveo_build.py
+++ b/src/finn/transformation/fpgadataflow/alveo_build.py
@@ -595,9 +595,7 @@ class SlashLink(Transformation):
 
         # Construct the linker invocation
         vbin_path = link_dir / "finn.vbin"
-        command = _slash_link_argv(
-            config_path, vbin_path, component_xml_paths, self.build_hardware
-        )
+        command = _slash_link_argv(config_path, vbin_path, component_xml_paths, self.build_hardware)
 
         # Run the linker
         log_path = link_dir / "slash.log"

--- a/src/finn/transformation/fpgadataflow/alveo_build.py
+++ b/src/finn/transformation/fpgadataflow/alveo_build.py
@@ -465,6 +465,29 @@ class VitisLink(Transformation):
         return (model, False)
 
 
+def _slash_link_command(tool, config_path, vbin_path, component_xml_paths, build_hardware):
+    """Build the argv for a single SLASH linker "link" invocation.
+
+    :parameter tool: command used to invoke the SLASH linker.
+    :parameter config_path: path to the generated connectivity config.
+    :parameter vbin_path: path the linker should write the VBIN to.
+    :parameter component_xml_paths: IP-XACT component.xml files, one per kernel.
+    :parameter build_hardware: if True, link a hardware image, otherwise a simulation image.
+    :return: argv list for a single linker subprocess invocation.
+    """
+    return [
+        tool,
+        "link",
+        "--config",
+        str(config_path),
+        "--platform",
+        "hw" if build_hardware else "sim",
+        "--out",
+        str(vbin_path),
+        "--kernels",
+    ] + [str(path) for path in component_xml_paths]
+
+
 class SlashLink(Transformation):
     """Create a VBIN file with SLASH.
 
@@ -565,17 +588,9 @@ class SlashLink(Transformation):
 
         # Construct the linker invocation
         vbin_path = link_dir / "finn.vbin"
-        command = [
-            "v80++",
-            "link",
-            "--config",
-            str(config_path),
-            "--platform",
-            "hw" if self.build_hardware else "sim",
-            "--out",
-            str(vbin_path),
-            "--kernels",
-        ] + [str(path) for path in component_xml_paths]
+        command = _slash_link_command(
+            "v80++", config_path, vbin_path, component_xml_paths, self.build_hardware
+        )
 
         # Run the linker
         log_path = link_dir / "slash.log"

--- a/src/finn/transformation/fpgadataflow/alveo_build.py
+++ b/src/finn/transformation/fpgadataflow/alveo_build.py
@@ -488,6 +488,13 @@ def _slash_link_command(tool, config_path, vbin_path, component_xml_paths, build
     ] + [str(path) for path in component_xml_paths]
 
 
+def _slash_link_argv(config_path, vbin_path, component_xml_paths, build_hardware):
+    slash_linker = resolve_xilinx_tool("slashkit")
+    return _slash_link_command(
+        slash_linker, config_path, vbin_path, component_xml_paths, build_hardware
+    )
+
+
 class SlashLink(Transformation):
     """Create a VBIN file with SLASH.
 
@@ -588,8 +595,8 @@ class SlashLink(Transformation):
 
         # Construct the linker invocation
         vbin_path = link_dir / "finn.vbin"
-        command = _slash_link_command(
-            "v80++", config_path, vbin_path, component_xml_paths, self.build_hardware
+        command = _slash_link_argv(
+            config_path, vbin_path, component_xml_paths, self.build_hardware
         )
 
         # Run the linker

--- a/src/finn/util/basic.py
+++ b/src/finn/util/basic.py
@@ -307,6 +307,7 @@ def resolve_xilinx_tool(tool_name):
     - vitis-run
     - v++
     - xelab
+    - slashkit
 
     With FINN_TOOL_DIR_OVERRIDE set, the command resolves to
     <override>/<tool_name>, otherwise the bare tool_name is used.

--- a/tests/util/test_slash_link.py
+++ b/tests/util/test_slash_link.py
@@ -1,0 +1,56 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for the SLASH linker invocation used by the SLASH_ALVEO shell flow."""
+
+import pytest
+
+from pathlib import Path
+
+import finn.transformation.fpgadataflow.alveo_build as alveo_build
+from finn.transformation.fpgadataflow.alveo_build import (
+    _slash_link_argv,
+    _slash_link_command,
+)
+
+
+@pytest.mark.util
+def test_slash_link_argv_resolves_slashkit_via_shim(monkeypatch):
+    shim_path = "/ci/shims/slashkit"
+    resolved = []
+
+    def fake_resolve(tool_name):
+        resolved.append(tool_name)
+        return shim_path
+
+    monkeypatch.setattr(alveo_build, "resolve_xilinx_tool", fake_resolve)
+    cmd = _slash_link_argv(Path("config.cfg"), Path("finn.vbin"), [], True)
+    assert resolved == ["slashkit"]
+    assert cmd[0] == shim_path
+
+
+@pytest.mark.util
+def test_slash_link_command_hw_platform_and_flags():
+    config = Path("config.cfg")
+    vbin = Path("finn.vbin")
+    component = Path("ip/component.xml")
+    cmd = _slash_link_command("slashkit", config, vbin, [component], True)
+    assert cmd[0] == "slashkit"
+    assert cmd[1] == "link"
+    assert cmd[cmd.index("--config") + 1] == str(config)
+    assert cmd[cmd.index("--platform") + 1] == "hw"
+    assert cmd[cmd.index("--out") + 1] == str(vbin)
+    assert cmd[cmd.index("--kernels") + 1 :] == [str(component)]
+
+
+@pytest.mark.util
+def test_slash_link_command_simulation_toggles_platform():
+    cmd = _slash_link_command("slashkit", "config.cfg", "finn.vbin", [], False)
+    assert cmd[cmd.index("--platform") + 1] == "sim"
+
+
+@pytest.mark.util
+def test_slash_link_command_appends_all_kernels():
+    kernels = [Path("k0/component.xml"), Path("k1/component.xml")]
+    cmd = _slash_link_command("slashkit", "config.cfg", "finn.vbin", kernels, True)
+    assert cmd[cmd.index("--kernels") + 1 :] == [str(k) for k in kernels]


### PR DESCRIPTION
The V80 SLASH_ALVEO backend invokes the SLASH linker as "v80++". The current SLASH release (v1.0) renamed that tool to "slashkit", so SlashLink fails to link. This PR updates every instance of v80++ to slashkit and wires it through the heavy tool resolver (`resolve_xilinx_tool`).

This is a breaking change for:

- anyone using pre-v1.0 SLASH with FINN's SlashLink (I don't think that's anyone at the moment).
- anyone running a CI setup that shells out heavy processes to a compute farm (`FINN_TOOL_DIR_OVERRIDE`). A new slashkit shim needs to be added to the tool dir overrides, all slashkit invocations by FINN will fail in such a CI setup until this is done.

Two related dockerfile issues were also fixed:

- The linker deb is now installed after an `apt-get update`, standard best practice and slashkit declares apt dependencies such as python3-jinja2 that the image doesn't already install, so the local deb install needs current package lists (would fail against stale lists cached in an earlier layer).
- The final `USER` references the literal `USERNAME` instead of `$USERNAME` so the image default user was an account that doesn't exist (this affects any image that is layered *from* FINN's). This was fixed.

## Testing

- [x] New unit tests in `tests/fpgadataflow/test_slash_link.py` that test command construction for hw/sim, kernel list assembly.
- [x] One xfailing test added because SlashLink doesn't yet pass the synthesis clock period to the linker (follow-up work).
- [x] E2E test ongoing.