### PR TITLE
[Sim Engine] Adjust the cycle print rate and report on the liveness of each output

### DIFF
--- a/finn_xsi/finn_xsi/sim_engine.py
+++ b/finn_xsi/finn_xsi/sim_engine.py
@@ -115,9 +115,7 @@ class SimEngine:
             # Execute Cycle
             self.ticks += 1
             if self.ticks % 10000 == 0:
-                status = "  ".join(
-                    f"{w.name}: {w.ticks}/{w.timeout}" for w in self.watchdogs
-                )
+                status = "  ".join(f"{w.name}: {w.ticks}/{w.timeout}" for w in self.watchdogs)
                 print(f"Cycle {self.ticks}  {status}" if status else f"Cycle {self.ticks}")
             strong = False
             for task in self.tasks:

--- a/finn_xsi/finn_xsi/sim_engine.py
+++ b/finn_xsi/finn_xsi/sim_engine.py
@@ -114,7 +114,11 @@ class SimEngine:
 
             # Execute Cycle
             self.ticks += 1
-            print(f"Cycle {self.ticks}")
+            if self.ticks % 10000 == 0:
+                status = "  ".join(
+                    f"{w.name}: {w.ticks}/{w.timeout}" for w in self.watchdogs
+                )
+                print(f"Cycle {self.ticks}  {status}" if status else f"Cycle {self.ticks}")
             strong = False
             for task in self.tasks:
                 # Tasks read signals and derive updates to schedule for after the clock cycle


### PR DESCRIPTION
This PR is a small adjustment to the output printing while a `finnxsi` simulation is running. 
* Adjusts the cycle reporting from every cycle to every 10K cycles
* prints the current watchdog status for each output every 10K cycles so that it is easier to inspect how far away a timeout condition might be occurring.  