### PR TITLE
Add ideal-memory MLO RTLSIM performance measurement

### DIFF
--- a/finn_xsi/finn_xsi/adapter.py
+++ b/finn_xsi/finn_xsi/adapter.py
@@ -17,6 +17,7 @@ from finn_xsi.srcutil import order_pkg_first
 from typing import Optional
 
 from finn.util.basic import launch_process_helper, resolve_xilinx_tool
+from finn.util.rtlsim_performance import summarize_output_frame_completions
 
 
 def locate_glbl() -> Optional[str]:
@@ -166,6 +167,7 @@ def rtlsim_multi_io(
     num_out_values,
     sname="_V_V",
     liveness_threshold=10000,
+    output_frame_sizes=None,
 ):
     if len(io_dict["outputs"]) > 1:
         assert isinstance(
@@ -176,6 +178,13 @@ def rtlsim_multi_io(
         # outputs from the single output stream) - make into dict
         oname = list(io_dict["outputs"].keys())[0]
         num_out_values = {oname: num_out_values}
+
+    if output_frame_sizes is not None and not isinstance(output_frame_sizes, dict):
+        assert (
+            len(io_dict["outputs"]) == 1
+        ), "Output frame sizes must be a dict for multiple outputs"
+        oname = list(io_dict["outputs"].keys())[0]
+        output_frame_sizes = {oname: output_frame_sizes}
 
     # FINN XSI expects hex strings, while rtlsim_multi_io uses
     # lists of arbitrary-precision integers, so need to convert
@@ -191,10 +200,12 @@ def rtlsim_multi_io(
     hex_output_streams = {}
     for out in io_dict["outputs"]:
         stream_name = out + sname
+        frame_size = None if output_frame_sizes is None else output_frame_sizes[out]
         hex_output_streams[out] = sim.collect_output(
             stream_name,
             num_out_values[out],
             watchdog=sim.create_watchdog(f"{stream_name} timeout", liveness_threshold),
+            frame_size=frame_size,
         )
 
     start_ticks = sim.ticks
@@ -204,5 +215,12 @@ def rtlsim_multi_io(
     end_ticks = sim.ticks
     for out in io_dict["outputs"]:
         io_dict["outputs"][out] = list(map(lambda var: int(var, base=16), hex_output_streams[out]))
+
+    if output_frame_sizes is not None:
+        completion_cycles = {
+            out: [int(tick - start_ticks) for tick in collector.completion_ticks]
+            for out, collector in hex_output_streams.items()
+        }
+        return summarize_output_frame_completions(completion_cycles, end_ticks - start_ticks)
 
     return end_ticks - start_ticks

--- a/finn_xsi/finn_xsi/sim_engine.py
+++ b/finn_xsi/finn_xsi/sim_engine.py
@@ -208,17 +208,28 @@ class SimEngine:
 
         self.enlist(InputStreamer(self, istream, values, throttle))
 
-    def collect_output(self, ostream, size, watchdog=None):
-        "Collect size outputs from the specified stream into the returned iterable buffer."
+    def collect_output(self, ostream, size, watchdog=None, frame_size=None):
+        """Collect output transactions and optionally record frame completions.
+
+        ``frame_size`` is the number of transactions in one output frame. When
+        provided, the returned collector exposes ``completion_ticks`` containing
+        the simulation tick at which each complete frame was accepted.
+        """
+
+        if frame_size is not None:
+            assert frame_size > 0, "Output frame size must be greater than zero"
+            assert size % frame_size == 0, "Output transaction count must contain whole frames"
 
         class OutputCollector:
-            def __init__(self, top, ostream, size, watchdog):
+            def __init__(self, top, ostream, size, watchdog, frame_size):
                 self.size = size
                 self.vld = top.get_bus_port(ostream, "tvalid")
                 self.rdy = top.get_bus_port(ostream, "tready")
                 self.dat = top.get_bus_port(ostream, "tdata")
                 self.buf = []
                 self.watchdog = watchdog
+                self.frame_size = frame_size
+                self.completion_ticks = []
 
             def __iter__(self):
                 return iter(self.buf)
@@ -231,6 +242,8 @@ class SimEngine:
                             self.watchdog.reset()
                         val = self.dat.read().as_hexstr()
                         self.buf.append(val)
+                        if self.frame_size is not None and len(self.buf) % self.frame_size == 0:
+                            self.completion_ticks.append(sim.ticks)
                         if len(self.buf) == size:
                             return {self.rdy: "0"}
                     return {}
@@ -239,7 +252,7 @@ class SimEngine:
                     return {self.rdy: "1"}
                 return None
 
-        ret = OutputCollector(self, ostream, size, watchdog)
+        ret = OutputCollector(self, ostream, size, watchdog, frame_size)
         self.enlist(ret)
         return ret
 

--- a/src/finn/builder/build_dataflow_checks.py
+++ b/src/finn/builder/build_dataflow_checks.py
@@ -341,18 +341,6 @@ def run_all_config_checks(cfg: DataflowBuildConfig) -> Report:
                     "generated",
                 )
             )
-        if DataflowOutputType.RTLSIM_PERFORMANCE in cfg.generate_outputs:
-            checks.append(
-                _check(
-                    "mlo_rtlsim",
-                    Severity.WARNING,
-                    False,
-                    "MLO enabled with RTLSIM_PERFORMANCE: RTL simulation performance "
-                    "measurement is skipped for MLO models",
-                    "Remove RTLSIM_PERFORMANCE from generate_outputs or disable MLO",
-                )
-            )
-
     if cfg.mlo and cfg.verify_save_full_context:
         checks.append(
             _check(

--- a/src/finn/builder/build_dataflow_config.py
+++ b/src/finn/builder/build_dataflow_config.py
@@ -364,7 +364,8 @@ class DataflowBuildConfig:
     #: If not given `max_multithreshold_bit_width` defaults to 16.
     max_multithreshold_bit_width: Optional[int] = 16
 
-    #: Override the number of inputs for rtlsim performance measurement.
+    #: Override the number of inputs for rtlsim performance measurement. MLO
+    #: measurements use at least two frames and an ideal AXI-MM memory model.
     rtlsim_batch_size: Optional[int] = 1
 
     #: If set to True, FIFOs with impl_style=vivado will be kept during

--- a/src/finn/builder/build_dataflow_steps.py
+++ b/src/finn/builder/build_dataflow_steps.py
@@ -93,6 +93,7 @@ from finn.builder.build_dataflow_config import (
 )
 from finn.core.onnx_exec import execute_onnx
 from finn.core.rtlsim_exec import rtlsim_exec
+from finn.core.throughput_test import throughput_test_rtlsim
 from finn.transformation.fpgadataflow.absorb_into_requant import (
     AbsorbElementwiseOpsIntoRequant,
 )
@@ -1177,7 +1178,68 @@ def step_measure_rtlsim_performance(model: ModelWrapper, cfg: DataflowBuildConfi
     Depends on the DataflowOutputType.STITCHED_IP output product.
     """
 
-    if DataflowOutputType.RTLSIM_PERFORMANCE in cfg.generate_outputs and not is_mlo(model):
+    if DataflowOutputType.RTLSIM_PERFORMANCE not in cfg.generate_outputs:
+        print(
+            """DataflowOutputType.RTLSIM_PERFORMANCE not in requested outputs,
+            skipping step_measure_rtlsim_performance."""
+        )
+        return model
+
+    if is_mlo(model):
+        assert (
+            DataflowOutputType.STITCHED_IP in cfg.generate_outputs
+        ), "rtlsim_perf needs stitched IP"
+        report_dir = cfg.output_dir + "/report"
+        os.makedirs(report_dir, exist_ok=True)
+        rtlsim_bs = int(cfg.rtlsim_batch_size)
+        if rtlsim_bs < 2:
+            print(
+                "MLO steady-state throughput requires at least two frames; "
+                "using rtlsim batch size 2."
+            )
+            rtlsim_bs = 2
+
+        rtlsim_model = deepcopy(model)
+        rtlsim_model = prepare_for_stitched_ip_rtlsim(rtlsim_model, cfg)
+        if cfg.verify_save_rtlsim_waveforms:
+            rtlsim_model.set_metadata_prop(
+                "rtlsim_trace",
+                "%s/rtlsim_perf_batch_%d.wdb" % (os.path.abspath(report_dir), rtlsim_bs),
+            )
+
+        rtlsim_model = rtlsim_model.transform(AnnotateCycles())
+        perf = rtlsim_model.analysis(dataflow_performance)
+        liveness_cycles = int(perf["critical_path_cycles"] * 1.1 + 50)
+        prev_liveness = get_liveness_threshold_cycles()
+        loop_nodes = rtlsim_model.get_nodes_by_op_type("FINNLoop")
+        assert len(loop_nodes) == 1, "MLO RTLSIM performance currently supports one FINNLoop"
+        mlo_prehook = mlo_prehook_func_factory(loop_nodes[0])
+        os.environ["LIVENESS_THRESHOLD"] = str(liveness_cycles)
+        try:
+            rtlsim_perf_dict = throughput_test_rtlsim(
+                rtlsim_model,
+                cfg.synth_clk_period_ns,
+                batchsize=rtlsim_bs,
+                pre_hook=mlo_prehook,
+                collect_performance=True,
+            )
+        finally:
+            os.environ["LIVENESS_THRESHOLD"] = str(prev_liveness)
+
+        rtlsim_perf_dict["measurement_scope"] = "stitched_mlo"
+        rtlsim_perf_dict["external_memory_model"] = "ideal_axi_mm"
+        rtlsim_perf_dict["external_memory_model_is_ideal"] = True
+        rtlsim_perf_dict["performance_interpretation"] = "ideal_memory_upper_bound"
+        rtlsim_perf_dict["io_bandwidth_scope"] = "top_level_axi_stream_only"
+        rtlsim_perf_dict["external_memory_model_notes"] = (
+            "AXI-MM accepts addresses without backpressure and returns up to one beat per "
+            "cycle per independent interface; platform memory latency, arbitration, "
+            "contention and refresh are not modeled."
+        )
+        with open(report_dir + "/rtlsim_performance.json", "w") as f:
+            json.dump(rtlsim_perf_dict, f, indent=2)
+
+    else:
         assert (
             DataflowOutputType.STITCHED_IP in cfg.generate_outputs
         ), "rtlsim_perf needs stitched IP"
@@ -1232,12 +1294,6 @@ def step_measure_rtlsim_performance(model: ModelWrapper, cfg: DataflowBuildConfi
         if cfg.verify_save_rtlsim_waveforms:
             # restore original trace depth
             os.environ["RTLSIM_TRACE_DEPTH"] = str(orig_rtlsim_trace_depth)
-
-    else:
-        print(
-            """DataflowOutputType.RTLSIM_PERFORMANCE not in requested outputs or model is MLO,
-            skipping step_measure_rtlsim_performance."""
-        )
 
     return model
 

--- a/src/finn/core/rtlsim_exec.py
+++ b/src/finn/core/rtlsim_exec.py
@@ -318,10 +318,33 @@ def rtlsim_exec_cppxsi(
     return ret_dict
 
 
-def rtlsim_exec_finnxsi(model, execution_context, pre_hook=None, post_hook=None):
+def _output_frame_sizes(num_out_values, batchsize):
+    """Return the number of transactions per output frame."""
+
+    if isinstance(num_out_values, dict):
+        frame_sizes = {}
+        for name, count in num_out_values.items():
+            assert count % batchsize == 0, f"Output {name} does not contain whole frames"
+            frame_sizes[name] = count // batchsize
+        return frame_sizes
+
+    assert num_out_values % batchsize == 0, "Output does not contain whole frames"
+    return num_out_values // batchsize
+
+
+def rtlsim_exec_finnxsi(
+    model,
+    execution_context,
+    pre_hook=None,
+    post_hook=None,
+    collect_performance=False,
+):
     """Use finnxsi to execute given model with stitched IP. The execution
     context contains the input values. Hook functions can be optionally
-    specified to observe/alter the state of the circuit
+    specified to observe/alter the state of the circuit. When
+    ``collect_performance`` is enabled, return output-frame completion timing
+    in addition to storing the total cycle count in model metadata.
+
     - pre_hook : hook function to be called before sim start (after reset)
     - post_hook : hook function to be called after sim end
     """
@@ -383,13 +406,18 @@ def rtlsim_exec_finnxsi(model, execution_context, pre_hook=None, post_hook=None)
 
     if pre_hook is not None:
         pre_hook(sim)
-    n_cycles = finnxsi.rtlsim_multi_io(
+    output_frame_sizes = (
+        _output_frame_sizes(num_out_values, batchsize) if collect_performance else None
+    )
+    rtlsim_result = finnxsi.rtlsim_multi_io(
         sim,
         io_dict,
         num_out_values,
         sname="",
         liveness_threshold=get_liveness_threshold_cycles() * batchsize,
+        output_frame_sizes=output_frame_sizes,
     )
+    n_cycles = rtlsim_result["cycles"] if collect_performance else rtlsim_result
     if post_hook is not None:
         post_hook(sim)
     # important to call close_rtlsim for finnxsi to flush traces and stop
@@ -407,14 +435,29 @@ def rtlsim_exec_finnxsi(model, execution_context, pre_hook=None, post_hook=None)
         execution_context[o_name] = o_folded_tensor.reshape(o_shape)
 
     model.set_metadata_prop("cycles_rtlsim", str(n_cycles))
+    return rtlsim_result if collect_performance else None
 
 
-def rtlsim_exec(model, execution_context, pre_hook=None, post_hook=None):
+def rtlsim_exec(
+    model,
+    execution_context,
+    pre_hook=None,
+    post_hook=None,
+    collect_performance=False,
+):
     """Use XSI to execute given model with stitched IP. The execution
     context contains the input values. Hook functions can be optionally
     specified to observe/alter the state of the circuit, receiving the
-    sim object as their first argument:
+    sim object as their first argument. When ``collect_performance`` is
+    enabled, return output-frame completion timing.
+
     - pre_hook : hook function to be called before sim start (after reset)
     - post_hook : hook function to be called after sim end
     """
-    rtlsim_exec_finnxsi(model, execution_context, pre_hook, post_hook)
+    return rtlsim_exec_finnxsi(
+        model,
+        execution_context,
+        pre_hook,
+        post_hook,
+        collect_performance=collect_performance,
+    )

--- a/src/finn/core/throughput_test.py
+++ b/src/finn/core/throughput_test.py
@@ -30,11 +30,22 @@ import numpy as np
 from qonnx.util.basic import gen_finn_dt_tensor
 
 from finn.core.rtlsim_exec import rtlsim_exec
+from finn.util.rtlsim_performance import annotate_rtlsim_completion_throughput
 
 
-def throughput_test_rtlsim(model, clk_ns, batchsize=100):
+def throughput_test_rtlsim(
+    model,
+    clk_ns,
+    batchsize=100,
+    pre_hook=None,
+    collect_performance=False,
+):
     """Runs a throughput test for the given IP-stitched model. When combined
-    with tracing, useful to determine bottlenecks and required FIFO sizes."""
+    with tracing, useful to determine bottlenecks and required FIFO sizes.
+    ``pre_hook`` can install models for non-stream interfaces. Enabling
+    ``collect_performance`` derives sustained throughput from output-frame
+    completion times rather than from pipeline-fill latency.
+    """
 
     assert (
         model.get_metadata_prop("exec_mode") == "rtlsim"
@@ -48,7 +59,7 @@ def throughput_test_rtlsim(model, clk_ns, batchsize=100):
         # create random input
         iname = i_vi.name
         ishape = model.get_tensor_shape(iname)
-        ishape_batch = ishape
+        ishape_batch = list(ishape)
         ishape_batch[0] = batchsize
         idt = model.get_tensor_datatype(iname)
         dummy_input = gen_finn_dt_tensor(idt, ishape_batch)
@@ -60,12 +71,17 @@ def throughput_test_rtlsim(model, clk_ns, batchsize=100):
     for o_vi in model.graph.output:
         oname = o_vi.name
         oshape = model.get_tensor_shape(oname)
-        oshape_batch = oshape
+        oshape_batch = list(oshape)
         oshape_batch[0] = batchsize
         odt = model.get_tensor_datatype(oname)
         o_bytes += (np.prod(oshape_batch) * odt.bitwidth()) / 8
 
-    rtlsim_exec(model, ctx)
+    completion_stats = rtlsim_exec(
+        model,
+        ctx,
+        pre_hook=pre_hook,
+        collect_performance=collect_performance,
+    )
     # extract metrics
     cycles = int(model.get_metadata_prop("cycles_rtlsim"))
     fclk_mhz = 1 / (clk_ns * 0.001)
@@ -78,5 +94,9 @@ def throughput_test_rtlsim(model, clk_ns, batchsize=100):
     res["DRAM_out_bandwidth[MB/s]"] = o_bytes * 0.000001 / runtime_s
     res["fclk[mhz]"] = fclk_mhz
     res["N"] = batchsize
+
+    if collect_performance:
+        res.update(completion_stats)
+        res = annotate_rtlsim_completion_throughput(res, clk_ns)
 
     return res

--- a/src/finn/util/rtlsim_performance.py
+++ b/src/finn/util/rtlsim_performance.py
@@ -1,0 +1,60 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Helpers for deriving throughput from RTLSIM frame completion times."""
+
+
+def summarize_output_frame_completions(completion_cycles, total_cycles):
+    """Summarize per-stream frame completion cycles conservatively.
+
+    A complete multi-output frame is available only when every output stream
+    has completed it. The reported latency and spans therefore use the slowest
+    output stream for each measurement.
+    """
+
+    assert completion_cycles, "At least one output stream is required"
+    completed_frames = min(len(cycles) for cycles in completion_cycles.values())
+    latency_cycles = 0
+    interval_cycles = 0
+    steady_state_cycles = 0
+    if completed_frames > 0:
+        latency_cycles = max(cycles[0] for cycles in completion_cycles.values())
+    if completed_frames > 1:
+        interval_cycles = max(
+            cycles[completed_frames - 1] - cycles[completed_frames - 2]
+            for cycles in completion_cycles.values()
+        )
+        steady_state_cycles = max(
+            cycles[completed_frames - 1] - cycles[0] for cycles in completion_cycles.values()
+        )
+
+    interval_valid = completed_frames > 1 and interval_cycles > 0
+    return {
+        "cycles": int(total_cycles),
+        "latency_cycles": int(latency_cycles),
+        "interval_cycles": int(interval_cycles),
+        "completed_output_frames": int(completed_frames),
+        "interval_valid": int(interval_valid),
+        "steady_state_frames": int(max(0, completed_frames - 1)),
+        "steady_state_cycles": int(steady_state_cycles),
+        "output_frame_completion_cycles": completion_cycles,
+    }
+
+
+def annotate_rtlsim_completion_throughput(stats, clk_ns):
+    """Add sustained-throughput metrics to frame completion statistics."""
+
+    clk_ns = float(clk_ns)
+    assert clk_ns > 0.0, "RTLSIM clock period must be greater than zero"
+    interval_cycles = int(stats["interval_cycles"])
+    interval_valid = bool(stats["interval_valid"])
+    steady_state_frames = int(stats["steady_state_frames"])
+    steady_state_cycles = int(stats["steady_state_cycles"])
+    stable_valid = interval_valid and steady_state_frames > 0 and steady_state_cycles > 0
+    stats["interval_is_steady_state"] = interval_valid
+    stats["fps_from_interval"] = 1.0e9 / (clk_ns * interval_cycles) if interval_valid else None
+    stats["stable_throughput_valid"] = stable_valid
+    stats["stable_throughput[images/s]"] = (
+        steady_state_frames * 1.0e9 / (clk_ns * steady_state_cycles) if stable_valid else None
+    )
+    return stats

--- a/tests/fpgadataflow/test_fpgadataflow_finnloop.py
+++ b/tests/fpgadataflow/test_fpgadataflow_finnloop.py
@@ -1,5 +1,6 @@
 import pytest
 
+import json
 import numpy as np
 import os
 import re
@@ -636,12 +637,28 @@ def test_finnloop_end2end_mlo(
         and not tail_node
     )
 
+    # Exercise multi-frame stitched-MLO performance measurement once. This
+    # path uses the ideal AXI-MM models for loop storage and MVAU weights.
+    run_rtlsim_performance = (
+        mvau_cfg == (16, 2, 2, 1, 2)
+        and elemwise_optype == "ElementwiseAdd_hls"
+        and rhs_shape == [1]
+        and eltw_param_dtype == "INT8"
+        and not tail_node
+    )
+    generate_outputs = [
+        build_cfg.DataflowOutputType.ESTIMATE_REPORTS,
+        build_cfg.DataflowOutputType.STITCHED_IP,
+    ]
+    if run_rtlsim_performance:
+        generate_outputs.append(build_cfg.DataflowOutputType.RTLSIM_PERFORMANCE)
+
     cfg = build_cfg.DataflowBuildConfig(
         output_dir=tmp_output_dir,
         steps=steps,
         synth_clk_period_ns=10.0,
         board="V80",
-        rtlsim_batch_size=100,
+        rtlsim_batch_size=2 if run_rtlsim_performance else 100,
         standalone_thresholds=True,
         mlo=True,
         loop_body_hierarchy=[["", "layers.0"]],
@@ -651,10 +668,7 @@ def test_finnloop_end2end_mlo(
         verify_expected_output_npy=tmp_output_dir + "/expected_output.npy",
         verify_save_full_context=True,  # Enable per-iteration context saving
         debug_fifo=run_fifo_debug,  # snapshot per-FIFO sizing logs (tagged per loop body)
-        generate_outputs=[
-            build_cfg.DataflowOutputType.ESTIMATE_REPORTS,
-            build_cfg.DataflowOutputType.STITCHED_IP,
-        ],
+        generate_outputs=generate_outputs,
     )
     build.build_dataflow_cfg(tmp_output_dir + "/mlo_model.onnx", cfg)
 
@@ -670,6 +684,19 @@ def test_finnloop_end2end_mlo(
     assert os.path.isfile(report_dir + "/op_and_param_counts_FINNLoop_0.json")
     assert os.path.isfile(report_dir + "/op_and_param_counts.json")
     assert os.path.isfile(tmp_output_dir + "/stitched_ip/ip/component.xml")
+    if run_rtlsim_performance:
+        with open(report_dir + "/rtlsim_performance.json") as f:
+            rtlsim_perf = json.load(f)
+        assert rtlsim_perf["measurement_scope"] == "stitched_mlo"
+        assert rtlsim_perf["external_memory_model"] == "ideal_axi_mm"
+        assert rtlsim_perf["external_memory_model_is_ideal"] is True
+        assert rtlsim_perf["performance_interpretation"] == "ideal_memory_upper_bound"
+        assert rtlsim_perf["N"] == 2
+        assert rtlsim_perf["completed_output_frames"] == 2
+        assert rtlsim_perf["interval_valid"] == 1
+        assert rtlsim_perf["steady_state_frames"] == 1
+        assert rtlsim_perf["steady_state_cycles"] > 0
+        assert rtlsim_perf["stable_throughput_valid"] is True
 
     verif_dir = tmp_output_dir + "/verification_output"
     # With verify_save_full_context=True, cppsim and node_by_node_rtlsim save as .npz

--- a/tests/util/test_mlo_rtlsim_performance.py
+++ b/tests/util/test_mlo_rtlsim_performance.py
@@ -1,0 +1,67 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import pytest
+
+from finn.core.rtlsim_exec import _output_frame_sizes
+from finn.util.rtlsim_performance import (
+    annotate_rtlsim_completion_throughput,
+    summarize_output_frame_completions,
+)
+
+
+def test_single_frame_has_no_steady_state_interval():
+    stats = summarize_output_frame_completions({"out0": [100]}, total_cycles=101)
+    result = annotate_rtlsim_completion_throughput(stats, clk_ns=5.0)
+
+    assert result["latency_cycles"] == 100
+    assert result["completed_output_frames"] == 1
+    assert result["interval_valid"] == 0
+    assert result["steady_state_frames"] == 0
+    assert result["steady_state_cycles"] == 0
+    assert result["fps_from_interval"] is None
+    assert result["stable_throughput_valid"] is False
+    assert result["stable_throughput[images/s]"] is None
+
+
+def test_multi_frame_throughput_uses_first_to_last_completion_span():
+    stats = summarize_output_frame_completions({"out0": [100, 210, 330]}, total_cycles=331)
+    result = annotate_rtlsim_completion_throughput(stats, clk_ns=10.0)
+
+    assert result["latency_cycles"] == 100
+    assert result["interval_cycles"] == 120
+    assert result["completed_output_frames"] == 3
+    assert result["steady_state_frames"] == 2
+    assert result["steady_state_cycles"] == 230
+    assert result["fps_from_interval"] == pytest.approx(1.0e9 / (10.0 * 120))
+    assert result["stable_throughput_valid"] is True
+    assert result["stable_throughput[images/s]"] == pytest.approx(2.0e9 / (10.0 * 230))
+
+
+def test_multi_output_summary_uses_slowest_complete_result():
+    stats = summarize_output_frame_completions(
+        {
+            "fast": [90, 180, 270],
+            "slow": [100, 205, 325],
+        },
+        total_cycles=326,
+    )
+
+    assert stats["latency_cycles"] == 100
+    assert stats["interval_cycles"] == 120
+    assert stats["completed_output_frames"] == 3
+    assert stats["steady_state_frames"] == 2
+    assert stats["steady_state_cycles"] == 225
+
+
+def test_output_frame_sizes_are_derived_from_batch():
+    assert _output_frame_sizes(24, batchsize=3) == 8
+    assert _output_frame_sizes({"out0": 24, "out1": 12}, batchsize=3) == {
+        "out0": 8,
+        "out1": 4,
+    }
+
+
+def test_output_frame_sizes_reject_partial_frames():
+    with pytest.raises(AssertionError, match="whole frames"):
+        _output_frame_sizes({"out0": 10}, batchsize=3)

--- a/tests/util/test_mlo_rtlsim_performance_step.py
+++ b/tests/util/test_mlo_rtlsim_performance_step.py
@@ -1,0 +1,73 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import json
+
+import finn.builder.build_dataflow_steps as steps
+from finn.builder.build_dataflow_config import DataflowBuildConfig, DataflowOutputType
+
+
+class _FakeMLOModel:
+    def transform(self, _transformation):
+        return self
+
+    def analysis(self, _analysis):
+        return {"critical_path_cycles": 100}
+
+    def get_nodes_by_op_type(self, op_type):
+        assert op_type == "FINNLoop"
+        return [object()]
+
+
+def test_mlo_performance_step_uses_two_frames_and_ideal_memory(tmp_path, monkeypatch):
+    model = _FakeMLOModel()
+    prehook = object()
+    call = {}
+
+    monkeypatch.setattr(steps, "is_mlo", lambda _model: True)
+    monkeypatch.setattr(steps, "deepcopy", lambda original: original)
+    monkeypatch.setattr(steps, "prepare_for_stitched_ip_rtlsim", lambda original, _cfg: original)
+    monkeypatch.setattr(steps, "mlo_prehook_func_factory", lambda _node: prehook)
+    monkeypatch.setattr(steps, "get_liveness_threshold_cycles", lambda: 123)
+
+    def fake_throughput_test(model_arg, clk_ns, **kwargs):
+        call.update(model=model_arg, clk_ns=clk_ns, **kwargs)
+        return {
+            "N": kwargs["batchsize"],
+            "completed_output_frames": 2,
+            "interval_valid": 1,
+            "steady_state_frames": 1,
+            "steady_state_cycles": 50,
+            "stable_throughput_valid": True,
+        }
+
+    monkeypatch.setattr(steps, "throughput_test_rtlsim", fake_throughput_test)
+
+    cfg = DataflowBuildConfig(
+        output_dir=str(tmp_path),
+        synth_clk_period_ns=5.0,
+        rtlsim_batch_size=1,
+        mlo=True,
+        generate_outputs=[
+            DataflowOutputType.STITCHED_IP,
+            DataflowOutputType.RTLSIM_PERFORMANCE,
+        ],
+    )
+
+    returned = steps.step_measure_rtlsim_performance(model, cfg)
+
+    assert returned is model
+    assert call["model"] is model
+    assert call["clk_ns"] == 5.0
+    assert call["batchsize"] == 2
+    assert call["pre_hook"] is prehook
+    assert call["collect_performance"] is True
+
+    with open(tmp_path / "report" / "rtlsim_performance.json") as report_file:
+        report = json.load(report_file)
+    assert report["measurement_scope"] == "stitched_mlo"
+    assert report["external_memory_model"] == "ideal_axi_mm"
+    assert report["external_memory_model_is_ideal"] is True
+    assert report["performance_interpretation"] == "ideal_memory_upper_bound"
+    assert report["io_bandwidth_scope"] == "top_level_axi_stream_only"
+    assert report["N"] == 2


### PR DESCRIPTION
# Add ideal-memory MLO RTLSIM performance measurement

## Summary

This PR enables `RTLSIM_PERFORMANCE` for stitched multi-level offloading (MLO) designs.

MLO performance simulation now uses the existing Python XSI path and MLO AXI-MM pre-hook to exercise:

- the complete stitched `FINNLoop` wrapper;
- queue-backed intermediate loop storage through `m_axi_hbm`;
- external MVAU weight fetches through `m_axi_MVAU_id_*`; and
- continuous multi-frame AXI-Stream input and output traffic.

The simulation records the completion cycle of every output frame and derives steady-state throughput from the spacing between completed frames. Results are explicitly labelled as an ideal-memory upper bound because the AXI-MM models do not reproduce platform HBM latency or contention.

The existing non-MLO C++ `xsi_fifosim` performance path is unchanged.

## Motivation

FINN previously skipped the RTLSIM performance step for MLO models. The normal performance path uses the C++ XSI driver, which only handles AXI-Stream interfaces, while a stitched MLO design also requires AXI-MM service for intermediate activations and external weights.

The existing functional MLO verification path already solves the interface problem through a Python XSI pre-hook. It registers:

- a read/write AXI-MM queue for `m_axi_hbm`; and
- read-only AXI-MM images for the `m_axi_MVAU_id_*` weight interfaces.

However, that path did not provide a continuous multi-frame performance measurement or expose output-frame completion times. A single-frame simulation can measure first-frame latency, but it cannot measure steady-state throughput because there is no output-to-output interval.

## Changes

### Output-frame timing in Python XSI

The XSI output collector now optionally accepts the number of AXI-Stream transactions per frame. It records a completion tick whenever the final transaction of a frame is accepted with `tvalid && tready`.

The multi-I/O simulation adapter returns:

- `latency_cycles`;
- `interval_cycles`;
- `completed_output_frames`;
- `interval_valid`;
- `steady_state_frames`;
- `steady_state_cycles`; and
- `output_frame_completion_cycles`.

For multiple output streams, the result is aggregated conservatively: the completed-frame count is limited by the least-complete stream, while latency and timing spans use the slowest output behavior.

### Completion-based throughput calculation

For output-frame completion cycles

```text
t1, t2, ..., tN
```

the first completion measures pipeline-fill latency:

```text
latency_cycles = t1
```

Steady-state throughput is calculated from the first-to-last completion span:

```text
steady_state_frames = N - 1
steady_state_cycles = tN - t1

stable_throughput[images/s] =
    (N - 1) * 1e9 / (clock_period_ns * (tN - t1))
```

The most recent individual completion interval is also exposed as:

```text
fps_from_interval = 1e9 / (clock_period_ns * interval_cycles)
```

A one-frame run has no valid steady-state interval. For MLO measurements, a configured `rtlsim_batch_size` below two is therefore promoted to two frames.

### MLO builder integration

When an MLO build requests `RTLSIM_PERFORMANCE`, the builder now:

1. prepares a copy of the stitched MLO model for Python XSI;
2. creates the existing MLO AXI-MM pre-hook;
3. drives at least two frames continuously;
4. collects output-frame completion timing;
5. calculates batch and steady-state throughput separately; and
6. writes `report/rtlsim_performance.json`.

The obsolete configuration warning stating that MLO performance measurement is skipped has been removed.

### Report labelling

MLO performance reports include:

```json
{
  "measurement_scope": "stitched_mlo",
  "external_memory_model": "ideal_axi_mm",
  "external_memory_model_is_ideal": true,
  "performance_interpretation": "ideal_memory_upper_bound",
  "io_bandwidth_scope": "top_level_axi_stream_only"
}
```

The report also records that platform memory latency, arbitration, contention and refresh are not modelled.

## Interpretation and limitations

This measurement exercises the accelerator-side AXI-MM protocol and weight-fetch behavior. The FINNLoop controller must issue and complete the intermediate-memory and weight-memory transactions for output frames to finish.

The memory side is intentionally idealized:

- address channels are accepted without backpressure;
- data can be returned at up to one beat per cycle;
- weight interfaces have independent memory images; and
- realistic HBM latency, arbitration, shared-port contention, refresh and platform effects are not included.

The resulting steady-state FPS is therefore an ideal-memory upper bound for the stitched MLO accelerator.

The `DRAM_in_bandwidth[MB/s]` and `DRAM_out_bandwidth[MB/s]` fields retain their existing meaning and cover top-level AXI-Stream traffic only, as indicated by `io_bandwidth_scope`.