### PR TITLE
Fix float32 accumulation error in Quant→MultiThreshold threshold derivation

### DIFF
--- a/src/finn/transformation/qonnx/qonnx_activation_handlers.py
+++ b/src/finn/transformation/qonnx/qonnx_activation_handlers.py
@@ -360,11 +360,15 @@ class QuantReluHandler(QuantActBaseHandler):
             # onnx/finn/handler/act.py#L21
             num_distinct_values = 2**bit_width
             num_thresholds = int(num_distinct_values - 1)
-            flat_scale = quant_scale.flatten().astype(np.float32)
+            # Accumulate in float64 and narrow to the storage dtype once at the
+            # end, so the per-threshold value carries at most a single float32
+            # rounding step rather than accumulated error across min_threshold +
+            # step*t (see QuantIdentityHandler._calculate_thresholds).
+            flat_scale = quant_scale.flatten().astype(np.float64)
             num_scale_channels = flat_scale.shape[0]
-            step = np.abs(flat_scale).astype(np.float32)
+            step = np.abs(flat_scale)
             min_threshold = step / 2
-            thresholds = np.empty((num_scale_channels, num_thresholds), dtype=np_default_dtype)
+            thresholds = np.empty((num_scale_channels, num_thresholds), dtype=np.float64)
             for c in range(num_scale_channels):
                 for t in range(num_thresholds):
                     thresholds[c][t] = min_threshold[c] + step[c] * t
@@ -378,15 +382,15 @@ class QuantReluHandler(QuantActBaseHandler):
                 num_distinct_values = 2**bit_width
 
             num_thresholds = int(num_distinct_values - 1)
-            flat_scale = quant_scale.flatten().astype(np.float32)
+            flat_scale = quant_scale.flatten().astype(np.float64)
             num_scale_channels = flat_scale.shape[0]
-            scale = np.abs(flat_scale).astype(np.float32)
+            scale = np.abs(flat_scale)
             half_scale = scale / 2
             # alpha and lambda
             # from https://pytorch.org/docs/stable/generated/torch.nn.SELU.html
             alpha = 1.6732632423543772848170429916717
             selu_scale = 1.0507009873554804934193349852946
-            thresholds = np.empty((num_scale_channels, num_thresholds), dtype=np_default_dtype)
+            thresholds = np.empty((num_scale_channels, num_thresholds), dtype=np.float64)
             for c in range(num_scale_channels):
                 for t in range(num_thresholds):
                     step = -1.0 + half_scale + scale[c] * t
@@ -394,6 +398,9 @@ class QuantReluHandler(QuantActBaseHandler):
                         thresholds[c][t] = np.log(step / (alpha * selu_scale) + 1)
                     else:
                         thresholds[c][t] = step / selu_scale
+
+        # narrow back to the storage dtype only after the accumulation
+        thresholds = thresholds.astype(np_default_dtype)
 
         # First try to consider the tensor layout of the output for determining
         # the number of output channels
@@ -544,11 +551,17 @@ class QuantIdentityHandler(QuantActBaseHandler):
                 num_distinct_values = 2**bit_width
 
             num_thresholds = int(num_distinct_values - 1)
-            flat_scale = quant_scale.flatten()
+            # Accumulate the thresholds in float64. Each threshold is computed as
+            # a large base (min_threshold ~ -step*num_thresholds/2) plus a large
+            # multiple (step*t); doing this in float32 leaves ~1 ulp of error at
+            # the base's magnitude (~5e-7 for typical scales), which can shift a
+            # boundary below an input that Quant legitimately rounds down, causing
+            # a one-step MultiThreshold mismatch. float64 keeps that error ~1e-15.
+            flat_scale = quant_scale.flatten().astype(np.float64)
             num_scale_channels = flat_scale.shape[0]
             step = np.abs(flat_scale)
             half_step = step / 2.0
-            thresholds = np.empty((num_scale_channels, num_thresholds), dtype=np_default_dtype)
+            thresholds = np.empty((num_scale_channels, num_thresholds), dtype=np.float64)
             # compute the value of the smallest threshold, we'll neg-bias all
             # generated thresholds by this much
             min_threshold = -half_step - step * ((num_thresholds // 2) - 1)
@@ -557,6 +570,8 @@ class QuantIdentityHandler(QuantActBaseHandler):
             for c in range(num_scale_channels):
                 for t in range(num_thresholds):
                     thresholds[c][t] = min_threshold[c] + step[c] * t
+            # narrow back to the storage dtype only after the accumulation
+            thresholds = thresholds.astype(np_default_dtype)
 
             # First try to consider the tensor layout of the output for
             # determining the number of output channels

--- a/tests/transformation/test_qonnx_to_finn.py
+++ b/tests/transformation/test_qonnx_to_finn.py
@@ -35,8 +35,11 @@ import onnx
 import onnx.numpy_helper as nph
 import torch
 from brevitas.export import export_qonnx
+from onnx import TensorProto, helper
 from pkgutil import get_data
 from qonnx.core.modelwrapper import ModelWrapper
+from qonnx.transformation.infer_datatypes import InferDataTypes
+from qonnx.transformation.infer_shapes import InferShapes
 from qonnx.util.cleanup import cleanup
 from tempfile import TemporaryDirectory
 
@@ -139,3 +142,63 @@ def test_QONNX_to_FINN(model_name, wbits, abits):
     _ = model.analysis(analysis_testing_for_no_quant_nodes)
 
     temp_dir.cleanup()
+
+
+def _make_single_quant_model(x, scale, zeropt, bitwidth, signed, narrow, rounding):
+    """Minimal graph: global_in -> Quant -> global_out, params as initializers."""
+    ish = list(x.shape)
+    gi = helper.make_tensor_value_info("global_in", TensorProto.FLOAT, ish)
+    go = helper.make_tensor_value_info("global_out", TensorProto.FLOAT, ish)
+
+    def _init(name, arr):
+        return nph.from_array(np.asarray(arr, dtype=np.float32), name)
+
+    inits = [_init("scale", scale), _init("zeropt", zeropt), _init("bitwidth", bitwidth)]
+    quant = helper.make_node(
+        "Quant",
+        ["global_in", "scale", "zeropt", "bitwidth"],
+        ["global_out"],
+        domain="qonnx.custom_op.general",
+        signed=int(signed),
+        narrow=int(narrow),
+        rounding_mode=str(rounding),
+    )
+    graph = helper.make_graph([quant], "single_quant", [gi], [go], initializer=inits)
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
+    model.opset_import.append(helper.make_opsetid("qonnx.custom_op.general", 1))
+    m = ModelWrapper(model)
+    return m.transform(InferShapes()).transform(InferDataTypes())
+
+
+@pytest.mark.transform
+def test_QONNX_to_FINN_threshold_precision():
+    """Regression test for a float32 accumulation error in MultiThreshold
+    threshold derivation (QuantActBaseHandler._calculate_thresholds).
+
+    Each threshold used to be accumulated as ``min_threshold + step * t`` in
+    float32. Because ``min_threshold`` grows to ~-step*(num_thresholds/2), that
+    accumulation carried ~1 ulp of error at the base's magnitude, which could
+    place a boundary slightly below an input that Quant legitimately rounds down.
+    MultiThreshold's exact ``>=`` compare then stepped up where Quant did not,
+    giving a one-step mismatch.
+
+    The input below sits just under the ideal 1->2 boundary (1.5*scale), inside
+    the sliver the float32 error opened up: x/scale = 1.4999988 rounds to level 1
+    under Quant, so the converted graph must agree.
+    """
+    x = np.array([[[0.39990925788879395]]], dtype=np.float32)
+    scale = np.array([0.2666063904762268], dtype=np.float32)
+    zeropt = np.array([0.0], dtype=np.float32)
+    bitwidth = np.array([6.0], dtype=np.float32)
+
+    ref_m = _make_single_quant_model(x, scale, zeropt, bitwidth, 1, 0, "ROUND")
+    conv_m = ref_m.transform(ConvertQONNXtoFINN())
+
+    ref = oxe.execute_onnx(ref_m, {"global_in": x.copy()})["global_out"]
+    conv = oxe.execute_onnx(conv_m, {"global_in": x.copy()})["global_out"]
+
+    assert np.allclose(ref, conv, atol=1e-6), (
+        "Quant and ConvertQONNXtoFINN disagree on a boundary input: "
+        f"Quant={ref.ravel()[0]!r} vs MultiThreshold={conv.ravel()[0]!r} "
+        "(threshold derivation precision regression)"
+    )


### PR DESCRIPTION
ConvertQONNXtoFINN could produce a MultiThreshold whose output differs from the original Quant node by one step on inputs sitting just below a level boundary.

Root cause: in _calculate_thresholds, each threshold was accumulated as `min_threshold + step*t` in float32. For the identity handler, `min_threshold ≈ -step*(num_thresholds/2)` is a large negative base and `step*t` a large positive term, so their sum (a small threshold) inherited ~1 ulp of error at the base's magnitude (~5e-7 for typical scales). That shifted a boundary slightly below an input that Quant legitimately rounds down, and MultiThreshold's exact >= compare then stepped up where Quant did not.

The threshold derivation now accumulates in float64 and narrows to the storage dtype (float32) once at the end, in both the identity and Relu/Selu handlers. Stored initializers stay float32; only the intermediate math changed. Adds a self-contained regression test covering a boundary input.
