### PR TITLE
Trim PYNQ driver dependencies

### DIFF
--- a/src/finn/transformation/fpgadataflow/make_driver.py
+++ b/src/finn/transformation/fpgadataflow/make_driver.py
@@ -27,10 +27,12 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import inspect
 import json
 import numpy as np
 import os
 import qonnx
+import qonnx.util.basic
 import shlex
 import shutil
 import subprocess
@@ -46,6 +48,55 @@ from finn.util.basic import get_driver_shapes, make_build_dir
 from finn.util.data_packing import to_external_tensor
 
 from . import template_driver
+
+
+def _extract_license_header(source_module):
+    """Return the leading comment/blank-line block from a module's source file.
+
+    Used so that generated minimal copies of a source file keep the original
+    copyright/license notice intact."""
+    src_lines = inspect.getsource(source_module).splitlines()
+    header = []
+    for line in src_lines:
+        if line.startswith("#") or line.strip() == "":
+            header.append(line)
+        else:
+            break
+    return "\n".join(header).rstrip()
+
+
+def _generate_minimal_module(target_file, source_module, functions, import_block):
+    """Write a lightweight copy of source_module to target_file that contains
+    only the given functions, the original license header and a minimal import
+    block.
+
+    The generated PYNQ driver only needs a small subset of the helper functions
+    in qonnx.util.basic and finn.util.data_packing. Copying those files verbatim
+    would pull heavy imports (onnx, bitstring) onto the deployment board, even
+    though none of that functionality is exercised by the driver. Emitting a
+    trimmed-down module keeps the board dependencies limited to numpy (+pynq)."""
+    orig_module = source_module.__name__
+    license_header = _extract_license_header(source_module)
+    note = (
+        "# This is a minimal version of {0}, containing only the subset of\n"
+        "# functions required by the generated PYNQ driver. It is trimmed down to\n"
+        "# keep the runtime dependencies on the deployment board lightweight\n"
+        "# (avoiding heavy imports such as onnx / bitstring). Refer to the full\n"
+        "# {0} in the original source tree for the complete implementation."
+    ).format(orig_module)
+    bodies = "\n\n\n".join(inspect.getsource(fn) for fn in functions)
+    content = (
+        license_header
+        + "\n\n"
+        + note
+        + "\n\n"
+        + import_block.strip()
+        + "\n\n\n"
+        + bodies.rstrip()
+        + "\n"
+    )
+    with open(target_file, "w") as f:
+        f.write(content)
 
 
 class MakeCPPDriver(Transformation):
@@ -334,15 +385,8 @@ class MakePYNQDriver(Transformation):
         files_to_copy.append(
             (qonnx_path + "/core/__init__.py", qonnx_target_path + "/core/__init__.py")
         )
-        files_to_copy.append((qonnx_path + "/util/basic.py", qonnx_target_path + "/util/basic.py"))
         files_to_copy.append(
             (qonnx_path + "/util/__init__.py", qonnx_target_path + "/util/__init__.py")
-        )
-        files_to_copy.append(
-            (
-                finn_util_path + "/data_packing.py",
-                finn_target_path + "/util/data_packing.py",
-            )
         )
         files_to_copy.append(
             (
@@ -352,6 +396,48 @@ class MakePYNQDriver(Transformation):
         )
         for src_file, target_file in files_to_copy:
             shutil.copy(src_file, target_file)
+
+        # qonnx.util.basic and finn.util.data_packing are not copied verbatim:
+        # the driver only needs a handful of pure-numpy helpers from each, while
+        # the full files import onnx (qonnx.util.basic) and bitstring
+        # (finn.util.data_packing). Emitting a trimmed-down module keeps those
+        # heavy dependencies off the deployment board.
+        _generate_minimal_module(
+            qonnx_target_path + "/util/basic.py",
+            qonnx.util.basic,
+            [
+                qonnx.util.basic.roundup_to_integer_multiple,
+                qonnx.util.basic.gen_finn_dt_tensor,
+            ],
+            "import numpy as np\n"
+            "from typing import cast\n\n"
+            "from qonnx.core.datatype import BaseDataType, DataType, FixedPointType",
+        )
+        dp = finn.util.data_packing
+        _generate_minimal_module(
+            finn_target_path + "/util/data_packing.py",
+            dp,
+            [
+                dp.finnpy_to_packed_bytearray,
+                dp._pack_whole_byte_container,
+                dp._pack_bit_double_reverse,
+                dp._pack_general,
+                dp.finnpy_to_int_array,
+                dp.int_array_to_packed_bytearray,
+                dp.packed_bytearray_to_finnpy,
+                dp.prepare_values,
+                dp.unsiged_array_to_signed,
+                dp.packed_bytearray_to_finnpy_fast,
+                dp.data_prepared_to_finnpy_bipolar,
+                dp.data_prepared_to_finnpy_ternary,
+                dp.data_prepared_to_finnpy_fixed,
+                dp.data_prepared_to_finnpy_int,
+                dp.packed_bytearray_to_finnpy_float,
+            ],
+            "import numpy as np\n\n"
+            "from qonnx.core.datatype import DataType\n"
+            "from qonnx.util.basic import roundup_to_integer_multiple",
+        )
 
         driver_shapes: Dict = get_driver_shapes(model)
 

--- a/tests/fpgadataflow/test_make_driver_minimal_deps.py
+++ b/tests/fpgadataflow/test_make_driver_minimal_deps.py
@@ -1,0 +1,129 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Smoke test for the minimal qonnx/finn helper modules generated for the PYNQ
+driver. It checks two things quickly, without building or running any hardware:
+
+1. The generated ``basic.py`` and ``data_packing.py`` contain no heavy imports
+   (``onnx`` / ``bitstring``) and still import + work when those packages are
+   made unavailable -- i.e. the deployment board does not need them.
+2. The extracted subset of functions still works (a pack/unpack round-trip and
+   ``gen_finn_dt_tensor``).
+"""
+
+import importlib.util
+import numpy as np
+import qonnx.core.datatype
+import qonnx.util.basic
+import sys
+
+import finn.util.data_packing
+from finn.transformation.fpgadataflow.make_driver import _generate_minimal_module
+
+BASIC_FUNCS = [
+    "roundup_to_integer_multiple",
+    "gen_finn_dt_tensor",
+]
+BASIC_IMPORTS = (
+    "import numpy as np\n"
+    "from typing import cast\n\n"
+    "from qonnx.core.datatype import BaseDataType, DataType, FixedPointType"
+)
+DATA_PACKING_FUNCS = [
+    "finnpy_to_packed_bytearray",
+    "_pack_whole_byte_container",
+    "_pack_bit_double_reverse",
+    "_pack_general",
+    "finnpy_to_int_array",
+    "int_array_to_packed_bytearray",
+    "packed_bytearray_to_finnpy",
+    "prepare_values",
+    "unsiged_array_to_signed",
+    "packed_bytearray_to_finnpy_fast",
+    "data_prepared_to_finnpy_bipolar",
+    "data_prepared_to_finnpy_ternary",
+    "data_prepared_to_finnpy_fixed",
+    "data_prepared_to_finnpy_int",
+    "packed_bytearray_to_finnpy_float",
+]
+DATA_PACKING_IMPORTS = (
+    "import numpy as np\n\n"
+    "from qonnx.core.datatype import DataType\n"
+    "from qonnx.util.basic import roundup_to_integer_multiple"
+)
+
+
+def _write_minimal_tree(root):
+    """Emit the trimmed modules the same way the driver generator does, plus a
+    verbatim (dependency-free) copy of datatype.py."""
+    basic_py = root / "basic.py"
+    data_packing_py = root / "data_packing.py"
+    _generate_minimal_module(
+        str(basic_py),
+        qonnx.util.basic,
+        [getattr(qonnx.util.basic, n) for n in BASIC_FUNCS],
+        BASIC_IMPORTS,
+    )
+    _generate_minimal_module(
+        str(data_packing_py),
+        finn.util.data_packing,
+        [getattr(finn.util.data_packing, n) for n in DATA_PACKING_FUNCS],
+        DATA_PACKING_IMPORTS,
+    )
+    return basic_py, data_packing_py
+
+
+def _load_module(monkeypatch, name, path):
+    """Load a generated file under its real dotted name so downstream absolute
+    imports resolve to it, and register it via monkeypatch for auto-cleanup."""
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, name, module)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _imported_top_level_modules(text):
+    """Return the set of top-level module names imported by the given source."""
+    modules = set()
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("import "):
+            spec = line[len("import ") :]
+        elif line.startswith("from "):
+            spec = line[len("from ") :].split(" import ", 1)[0]
+        else:
+            continue
+        modules.add(spec.split()[0].split(".")[0].split(",")[0])
+    return modules
+
+
+def test_generated_modules_have_no_heavy_imports(tmp_path):
+    basic_py, data_packing_py = _write_minimal_tree(tmp_path)
+    for path in (basic_py, data_packing_py):
+        text = path.read_text()
+        imported = _imported_top_level_modules(text)
+        assert "onnx" not in imported, f"{path.name} unexpectedly imports onnx"
+        assert "bitstring" not in imported, f"{path.name} unexpectedly imports bitstring"
+        # the license header and "minimal version" note should be preserved
+        assert "minimal version of" in text
+        assert "Copyright" in text
+
+
+def test_generated_modules_import_and_roundtrip(tmp_path, monkeypatch):
+    basic_py, data_packing_py = _write_minimal_tree(tmp_path)
+    # make the heavy deps unavailable: importing them now raises ImportError
+    monkeypatch.setitem(sys.modules, "onnx", None)
+    monkeypatch.setitem(sys.modules, "bitstring", None)
+    # load the trimmed modules; data_packing's "from qonnx.util.basic import ..."
+    # must resolve to the trimmed basic we just registered
+    gen_basic = _load_module(monkeypatch, "qonnx.util.basic", basic_py)
+    gen_dp = _load_module(monkeypatch, "finn.util.data_packing", data_packing_py)
+
+    dt = qonnx.core.datatype.DataType["INT4"]
+    x = gen_basic.gen_finn_dt_tensor(dt, (2, 8))
+    packed = gen_dp.finnpy_to_packed_bytearray(x, dt, reverse_inner=True, reverse_endian=True)
+    y = gen_dp.packed_bytearray_to_finnpy(
+        packed, dt, x.shape, reverse_inner=True, reverse_endian=True
+    )
+    assert np.array_equal(x, y)


### PR DESCRIPTION
The generated PYNQ driver copies a handful of qonnx/finn source files into the  deployment folder. Two of them were copied verbatim and pulled heavy dependencies onto the board that the driver never uses:
- `qonnx.util.basic` imports `onnx` (only needed for `gen_finn_dt_tensor` + `roundup_to_integer_multiple`)
- `finn.util.data_packing` imports `bitstring` (only needed for `finnpy_to_packed_bytearray` / `packed_bytearray_to_finnpy` and their helpers, none of which touch `bitstring`)

This meant `onnx` and `bitstring` had to be installed on the target, which is a hassle for no functional benefit.

## Changes
- `make_driver.py` now emits trimmed-down versions of these two modules via `inspect.getsource`, containing only the functions the driver actually needs.
- Added a fast smoke test that verifies the generated modules import and round-trip with `onnx`/`bitstring` made unavailable, and contain no such imports.
