### PR TITLE
[Tests] Isolate shared scratch and process-global test state

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -40,7 +40,7 @@ Decorate it with the existing markers. For example, `@pytest.mark.fpgadataflow`.
 
 ### Clean up scratch in a test
 
-Use FINN's `make_build_dir()` and tear it down with the `robust_rmtree()` helper.
+Do not write scratch into the current working directory. Use FINN's `make_build_dir()` and tear it down with the `robust_rmtree()` helper. Successful tests should remove disposable scratch, while failed tests can keep it for diagnosis.
 
 ### Add a new BNN parameter value
 

--- a/ci/finn_ci/plugin.py
+++ b/ci/finn_ci/plugin.py
@@ -62,7 +62,7 @@ def pytest_configure(config):
         "markers",
         "shard(N): pin this test to shard N (use sparingly for flaky-test isolation).",
     )
-    config.pluginmanager.register(_FinnCiShardingPlugin(), "_finn_ci_sharding")
+    config.pluginmanager.register(_FinnCiPlugin(), "_finn_ci")
 
 
 def _is_xdist_worker(config):
@@ -213,7 +213,7 @@ def _write_shard_map(config, kept, groups, assignment, source, weights_table, fa
         pass
 
 
-class _FinnCiShardingPlugin:
+class _FinnCiPlugin:
     """Stateful pytest hooks, one instance per process (xdist controller or worker).
 
     The timing dict is left as None on xdist workers so the per-test reports

--- a/docker/quicktest.sh
+++ b/docker/quicktest.sh
@@ -6,13 +6,13 @@ cd $FINN_ROOT
 # check if command line argument is empty or not present
 if [ -z $1 ]; then
   echo "Running quicktest: not (vivado or slow or board or bnn) with pytest-xdist"
-  pytest -m 'not (vivado or slow or vitis or board or notebooks or sanity_bnn or bnn_pynq or bnn_zcu104 or bnn_kv260 or bnn_u250)' --dist=loadfile -n $PYTEST_PARALLEL
+  pytest -m 'not (vivado or slow or vitis or board or notebooks or sanity_bnn or bnn_pynq or bnn_zcu104 or bnn_kv260 or bnn_u250)' --dist=loadgroup -n $PYTEST_PARALLEL
 elif [ $1 = "verify" ]; then
   echo "Running verification tests (minimal install verification with Vivado)"
   $FINN_ROOT/scripts/quicktest-local.sh vivado
 elif [ $1 = "main" ]; then
   echo "Running main test suite: not (rtlsim or end2end) with pytest-xdist"
-  pytest -k 'not (rtlsim or end2end)' --dist=loadfile -n $PYTEST_PARALLEL
+  pytest -k 'not (rtlsim or end2end)' --dist=loadgroup -n $PYTEST_PARALLEL
 elif [ $1 = "rtlsim" ]; then
   echo "Running rtlsim test suite with pytest-parallel"
   pytest -k rtlsim --workers $PYTEST_PARALLEL

--- a/docs/finn/developers.rst
+++ b/docs/finn/developers.rst
@@ -177,7 +177,7 @@ If you want to run tests in parallel (e.g. to take advantage of a multi-core CPU
 you can use:
 
 * pytest-parallel for any rtlsim tests, e.g. `pytest -k rtlsim --workers auto`
-* pytest-xdist for anything else, make sure to add `--dist=loadfile` if you have tests in the same file that have dependencies on each other e.g. `pytest -k mytest -n auto --dist=loadfile`
+* pytest-xdist for anything else, using `--dist=loadgroup`. e.g. `pytest -k mytest -n auto --dist=loadgroup`. Tests that exchange checkpoints must share an `xdist_group` marker so they stay on one worker.
 
 Finally, the full test suite with appropriate parallelization can be run inside the container by:
 

--- a/src/finn/builder/build_dataflow_steps.py
+++ b/src/finn/builder/build_dataflow_steps.py
@@ -66,7 +66,7 @@ from qonnx.transformation.infer_shapes import InferShapes
 from qonnx.transformation.lower_convs_to_matmul import LowerConvsToMatMul
 from qonnx.util.basic import get_by_name
 from qonnx.util.cleanup import cleanup_model
-from shutil import copy, move
+from shutil import copy
 
 import finn.transformation.fpgadataflow.convert_to_hw_layers as to_hw
 import finn.transformation.streamline.absorb as absorb
@@ -1404,10 +1404,10 @@ def step_loop_rolling(model, cfg):
             )
         if cfg.loop_body_hierarchy is not None:
             print(f"Running Loop Rolling on {cfg.loop_body_hierarchy} hierarchy")
-            loop_extraction = LoopExtraction(cfg.loop_body_hierarchy)
+            template_path = os.path.join(cfg.output_dir, "loop-body-template.onnx")
+            loop_extraction = LoopExtraction(cfg.loop_body_hierarchy, template_path)
             model = model.transform(loop_extraction)
             model = model.transform(LoopRolling(loop_extraction.loop_body_template))
-            move("loop-body-template.onnx", cfg.output_dir + "/loop-body-template.onnx")
     else:
         print("MLO not selected, skipping step_loop_rolling.")
 

--- a/src/finn/transformation/fpgadataflow/loop_rolling.py
+++ b/src/finn/transformation/fpgadataflow/loop_rolling.py
@@ -14,6 +14,7 @@ import copy
 import numpy as np
 import onnx
 import onnxscript
+import os
 from enum import Enum
 from onnxscript import ir
 from onnxscript.rewriter import pattern, rewrite
@@ -24,6 +25,7 @@ from qonnx.transformation.fold_constants import FoldConstants
 from typing import List, Tuple
 
 from finn.util import onnxscript_helpers as osh
+from finn.util.basic import make_build_dir
 
 
 def get_constant_from_value(value):
@@ -214,7 +216,7 @@ def build_loop_replace_pattern(graph, LoopBody):
 
 
 class LoopExtraction(Transformation):
-    def __init__(self, hierarchy_list: List[List[str]]):
+    def __init__(self, hierarchy_list: List[List[str]], loop_body_template_path=None):
         super().__init__()
 
         assert isinstance(hierarchy_list, list), "Hierarchy list must be a list of strings"
@@ -224,6 +226,10 @@ class LoopExtraction(Transformation):
                 isinstance(item, str) for item in hlist
             ), "All items in hierarchy sub-list must be strings"
         self.hierarchy_list = hierarchy_list
+        if loop_body_template_path is None:
+            template_dir = make_build_dir("loop_body_template_")
+            loop_body_template_path = os.path.join(template_dir, "loop-body-template.onnx")
+        self.loop_body_template_path = os.fspath(loop_body_template_path)
         self.loop_body_template = None
 
     def apply(self, model: ModelWrapper) -> Tuple[ModelWrapper, bool]:
@@ -275,8 +281,8 @@ class LoopExtraction(Transformation):
         )
         proto = onnxscript.ir.serde.serialize_model(loop_body_model)
 
-        onnx.save(proto, "loop-body-template.onnx")
-        self.loop_body_template = LoopBodyTemplate("loop-body-template.onnx")
+        onnx.save(proto, self.loop_body_template_path)
+        self.loop_body_template = LoopBodyTemplate(self.loop_body_template_path)
 
         # Replace instances of the loop body with a function call to the loop body
         change_layers_to_function_calls = pattern.RewriteRule(

--- a/src/finn/util/test.py
+++ b/src/finn/util/test.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2020, Xilinx
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -43,7 +44,13 @@ from qonnx.custom_op.registry import getCustomOp
 from finn.core.onnx_exec import execute_onnx
 from finn.transformation.fpgadataflow.alveo_build import VitisLink, VitisOptStrategy
 from finn.transformation.fpgadataflow.make_zynq_proj import ZynqBuild
-from finn.util.basic import pynq_part_map, vitis_default_platform, vitis_part_map
+from finn.util.basic import (
+    make_build_dir,
+    pynq_part_map,
+    robust_rmtree,
+    vitis_default_platform,
+    vitis_part_map,
+)
 
 # map of (wbits,abits) -> model
 example_map = {
@@ -103,6 +110,17 @@ def load_test_checkpoint_or_skip(filename):
     else:
         warnings.warn(filename + " not found from previous test step, skipping")
         pytest.skip(filename + " not found from previous test step, skipping")
+
+
+def make_runtime_weight_stream(op_inst, weights):
+    """Write runtime weights in FINN's standard format and return the parsed stream."""
+    weight_dir = make_build_dir("test_runtime_weights_")
+    weight_path = os.path.join(weight_dir, "weights.dat")
+    op_inst.make_weight_file(weights, "decoupled_runtime", weight_path)
+    with open(weight_path, "r") as f:
+        weight_stream = [int(x, 16) for x in f.read().strip().split("\n")]
+    robust_rmtree(weight_dir)
+    return weight_stream
 
 
 def get_build_env(board, target_clk_ns):

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,54 @@
+# FINN Test Guidelines
+
+Help keep FINN's testing suite fast, deterministic, and parallelisable when writing or modifying tests.
+
+### 1. Scratch paths
+
+Never write scratch files into the repo root or CWD. Collisions are guaranteed when tests run in parallel. Instead:
+
+- Use `make_build_dir()` to allocate a unique directory under `FINN_BUILD_DIR`.
+- Use `robust_rmtree()` to tear down the test.
+- If the test's outputs are useful for diagnosis, you may keep the outputs if the test failed.
+
+```python
+from finn.util.basic import make_build_dir, robust_rmtree
+
+test_dir = make_build_dir("test_my_feature_")
+
+# later on
+if not failed:
+    robust_rmtree(test_dir)
+```
+
+### 2. Process state & environment
+
+Don't mutate env variables or global process state. Use pytest's `monkeypatch` fixture to override env variables or system attributes.
+
+```python
+def test_sim_behaviour(monkeypatch):
+    monkeypatch.setenv("VIVADO_PATH", "/custom/path")
+    # original VIVADO_PATH restored automatically after the test
+```
+
+### 3. Parallel Scheduling (`xdist_group`)
+
+If you have a chain of tests where subsequent stages load the checkpoint from a previous step (using `load_test_checkpoint_or_skip`), they must run on the same worker process.
+
+Group related tests together using the `xdist_group` marker:
+
+```python
+@pytest.mark.xdist_group(name="my_feature_chain")
+def test_step_1(): ...
+
+@pytest.mark.xdist_group(name="my_feature_chain")
+def test_step_2(): ...
+```
+
+Run tests with `--dist loadgroup` if running with multiple workers (i.e. `-n <N>`) so that checkpoint chains stay on the same worker.
+
+
+### 4. Markers
+
+Decorate tests with the existing markers. For example, `@pytest.mark.fpgadataflow`.
+
+*For more detailed marker, pipeline, sharding, and Jenkins configurations, see [ci/README.md](../ci/README.md).*

--- a/tests/end2end/test_end2end_bnn_pynq.py
+++ b/tests/end2end/test_end2end_bnn_pynq.py
@@ -313,15 +313,7 @@ def topology2dataset(topology):
 
 
 def deploy_based_on_board(model, model_title, topology, wbits, abits, board):
-    # Check if a deployment directory for this board type already exists
-    if ("FINN_DEPLOY_DIR" in os.environ) and (board in os.environ["FINN_DEPLOY_DIR"]):
-        deploy_dir_root = os.environ["FINN_DEPLOY_DIR"]
-    else:
-        deploy_dir_root = make_build_dir(prefix="hw_deployment_" + board + "_")
-        # Set it for the next round if multiple bitstreams are selected for generation
-        os.environ["FINN_DEPLOY_DIR"] = deploy_dir_root
-
-    # create directory for deployment files
+    deploy_dir_root = make_build_dir(prefix="hw_deployment_" + board + "_")
     deployment_dir = deploy_dir_root + "/" + board + "/" + model_title
     os.makedirs(deployment_dir)
 
@@ -704,7 +696,7 @@ class TestEnd2End:
 
     @pytest.mark.slow
     @pytest.mark.vivado
-    def test_ipstitch_rtlsim(self, topology, wbits, abits, board):
+    def test_ipstitch_rtlsim(self, topology, wbits, abits, board, monkeypatch):
         prev_chkpt_name = get_checkpoint_name(board, topology, wbits, abits, "fifodepth")
         model = load_test_checkpoint_or_skip(prev_chkpt_name)
         test_fpga_part = get_build_env(board, target_clk_ns)["part"]
@@ -721,10 +713,10 @@ class TestEnd2End:
         model = model.transform(HLSSynthIP())
         model = model.transform(CreateStitchedIP(test_fpga_part, target_clk_ns))
         model.set_metadata_prop("exec_mode", "rtlsim")
-        os.environ["LIVENESS_THRESHOLD"] = str(int(latency * 1.1))
+        monkeypatch.setenv("LIVENESS_THRESHOLD", str(int(latency * 1.1)))
         if rtlsim_trace:
             model.set_metadata_prop("rtlsim_trace", "%s_w%da%d.vcd" % (topology, wbits, abits))
-            os.environ["RTLSIM_TRACE_DEPTH"] = "3"
+            monkeypatch.setenv("RTLSIM_TRACE_DEPTH", "3")
         rtlsim_chkpt = get_checkpoint_name(board, topology, wbits, abits, "ipstitch_rtlsim")
         model.save(rtlsim_chkpt)
         parent_chkpt = get_checkpoint_name(board, topology, wbits, abits, "dataflow_parent")

--- a/tests/end2end/test_end2end_mobilenet_v1.py
+++ b/tests/end2end/test_end2end_mobilenet_v1.py
@@ -480,14 +480,15 @@ def test_end2end_mobilenet_stitched_ip():
 @pytest.mark.slow
 @pytest.mark.vivado
 @pytest.mark.end2end
-def test_end2end_mobilenet_stitched_ip_rtlsim():
+def test_end2end_mobilenet_stitched_ip_rtlsim(monkeypatch):
     model = load_test_checkpoint_or_skip(build_dir + "/end2end_mobilenet_stitched_ip.onnx")
     # use critical path estimate to set rtlsim liveness threshold
     # (very conservative)
     model = model.transform(AnnotateCycles())
     estimate_network_performance = model.analysis(dataflow_performance)
-    os.environ["LIVENESS_THRESHOLD"] = str(
-        int(estimate_network_performance["critical_path_cycles"])
+    monkeypatch.setenv(
+        "LIVENESS_THRESHOLD",
+        str(int(estimate_network_performance["critical_path_cycles"])),
     )
     # Prepare input
     x = np.load(build_dir + "/end2end_mobilenet_input.npy")

--- a/tests/fpgadataflow/test_fpgadataflow_convinputgenerator_rtl_dynamic.py
+++ b/tests/fpgadataflow/test_fpgadataflow_convinputgenerator_rtl_dynamic.py
@@ -31,7 +31,6 @@ import pytest
 import copy
 import numpy as np
 import onnx.parser as oprs
-import os
 from bitstring import BitArray
 from onnx import TensorProto, helper
 from qonnx.core.datatype import DataType
@@ -64,7 +63,6 @@ from finn.transformation.fpgadataflow.insert_dwc import InsertDWC
 from finn.transformation.fpgadataflow.insert_fifo import InsertFIFO
 from finn.transformation.fpgadataflow.prepare_ip import PrepareIP
 from finn.transformation.fpgadataflow.specialize_layers import SpecializeLayers
-from finn.util.basic import get_liveness_threshold_cycles
 
 finnxsi = xsi if xsi.is_available() else None
 
@@ -222,7 +220,7 @@ cfg2 = {
 @pytest.mark.slow
 @pytest.mark.vivado
 @pytest.mark.fpgadataflow
-def test_fpgadataflow_conv_dynamic(cfg):
+def test_fpgadataflow_conv_dynamic(cfg, monkeypatch):
     do_synth = cfg["do_synth"]
     pad_mode = cfg["pad_mode"]
     depthwise = cfg["depthwise"]
@@ -362,10 +360,8 @@ def test_fpgadataflow_conv_dynamic(cfg):
         update_tensor_dim(model, last_node.onnx_node.output[0], (odim_h, odim_w))
         last_node.set_nodeattr("folded_shape", last_node_shp)
         ctx = {"global_in": inp.transpose(0, 2, 3, 1)}
-        liveness_prev = get_liveness_threshold_cycles()
-        os.environ["LIVENESS_THRESHOLD"] = "100000"
+        monkeypatch.setenv("LIVENESS_THRESHOLD", "100000")
         rtlsim_exec(model, ctx, pre_hook=config_hook(configs))
-        os.environ["LIVENESS_THRESHOLD"] = str(liveness_prev)
         ret = ctx["global_out"].transpose(0, 3, 1, 2)
         assert np.isclose(golden, ret).all()
 

--- a/tests/fpgadataflow/test_fpgadataflow_ipstitch.py
+++ b/tests/fpgadataflow/test_fpgadataflow_ipstitch.py
@@ -51,7 +51,13 @@ from finn.transformation.fpgadataflow.insert_iodma import InsertIODMA
 from finn.transformation.fpgadataflow.insert_tlastmarker import InsertTLastMarker
 from finn.transformation.fpgadataflow.make_zynq_proj import ZynqBuild
 from finn.transformation.fpgadataflow.prepare_ip import PrepareIP
-from finn.util.basic import pynq_part_map, vitis_default_platform, vitis_part_map
+from finn.util.basic import (
+    make_build_dir,
+    pynq_part_map,
+    robust_rmtree,
+    vitis_default_platform,
+    vitis_part_map,
+)
 from finn.util.test import load_test_checkpoint_or_skip
 from finn.util.vivado import parse_ooc_synth_results
 
@@ -308,6 +314,7 @@ def test_fpgadataflow_ipstitch_iodma_floorplan():
 def test_fpgadataflow_ipstitch_vitis_end2end(board, period_ns, extw):
     if "VITIS_PATH" not in os.environ:
         pytest.skip("VITIS_PATH not set")
+    test_dir = make_build_dir("test_fpgadataflow_ipstitch_vitis_")
     platform = vitis_default_platform[board]
     fpga_part = vitis_part_map[board]
     model = create_two_fc_model("external" if extw else "internal_decoupled")
@@ -321,10 +328,11 @@ def test_fpgadataflow_ipstitch_vitis_end2end(board, period_ns, extw):
     model = model.transform(HLSSynthIP())
     model = model.transform(PrepareForLinking(fpga_part, period_ns, "vitis-xrt"))
     model = model.transform(VitisLink(platform, period_ns))
-    model.save(ip_stitch_model_dir + "/test_fpgadataflow_ipstitch_vitis.onnx")
+    model.save(os.path.join(test_dir, "test_fpgadataflow_ipstitch_vitis.onnx"))
     assert model.get_metadata_prop("platform") == "vitis-xrt"
     assert os.path.isdir(model.get_metadata_prop("vitis_link_proj"))
     assert os.path.isfile(model.get_metadata_prop("bitfile"))
+    robust_rmtree(test_dir)
 
 
 # board

--- a/tests/fpgadataflow/test_fpgadataflow_mvau.py
+++ b/tests/fpgadataflow/test_fpgadataflow_mvau.py
@@ -29,7 +29,6 @@
 import pytest
 
 import numpy as np
-import os
 import qonnx.custom_op.general.xnorpopcount as xp
 from onnx import TensorProto, helper
 from qonnx.core.datatype import DataType
@@ -69,6 +68,7 @@ from finn.transformation.fpgadataflow.specialize_layers import SpecializeLayers
 from finn.transformation.general import ApplyConfig
 from finn.transformation.streamline.round_thresholds import RoundAndClipThresholds
 from finn.util.basic import is_versal
+from finn.util.test import make_runtime_weight_stream
 
 finnxsi = xsi if xsi.is_available() else None
 
@@ -649,12 +649,7 @@ def test_fpgadataflow_mvau_large_depth_decoupled_mode_rtlsim(
         node = model.get_nodes_by_op_type("MVAU_rtl")[0]
     inst = getCustomOp(node)
     weights = model.get_initializer(node.input[1])
-    inst.make_weight_file(weights, "decoupled_runtime", "weights.dat")
-    with open("weights.dat", "r") as f:
-        weight_stream = f.read().strip()
-    os.remove("weights.dat")
-    weight_stream = map(lambda x: int(x, 16), weight_stream.split("\n"))
-    weight_stream = list(weight_stream)
+    weight_stream = make_runtime_weight_stream(inst, weights)
 
     # helper functions to write or read axilite
     def write_weights(sim):

--- a/tests/fpgadataflow/test_fpgadataflow_shuffle.py
+++ b/tests/fpgadataflow/test_fpgadataflow_shuffle.py
@@ -428,9 +428,9 @@ def test_cppsim_shuffle_layer(cpp_shuffle_param, datatype, simd):
 @pytest.mark.fpgadataflow
 @pytest.mark.slow
 @pytest.mark.vivado
-def test_rtlsim_shuffle_layer(shuffle_param, datatype, simd):
+def test_rtlsim_shuffle_layer(shuffle_param, datatype, simd, monkeypatch):
     """Checks rtlsim of the shuffle_hls layer"""
-    os.environ["LIVENESS_THRESHOLD"] = "10000000"  # Need to bump this up for these RTL sims
+    monkeypatch.setenv("LIVENESS_THRESHOLD", "10000000")
     dt = DataType[datatype]
     simd = int(simd[-1])
     in_shape = shuffle_param["in_shape"]

--- a/tests/fpgadataflow/test_fpgadataflow_shuffle.py
+++ b/tests/fpgadataflow/test_fpgadataflow_shuffle.py
@@ -42,6 +42,7 @@ from finn.transformation.fpgadataflow.transpose_decomposition import (
     InferInnerOuterShuffles,
     ShuffleDecomposition,
 )
+from finn.util.basic import make_build_dir, robust_rmtree
 from finn.util.config import extract_model_config_consolidate_shuffles
 
 test_fpga_part: str = "xcvc1902-vsva2197-2MP-e-S"
@@ -609,7 +610,8 @@ def test_shuffle_config_consolidation():
 
     assert len(decomposed_nodes) > 0
 
-    consolidated_file = os.environ["FINN_BUILD_DIR"] + "/consolidated.json"
+    test_dir = make_build_dir("test_shuffle_config_")
+    consolidated_file = os.path.join(test_dir, "consolidated.json")
     extract_model_config_consolidate_shuffles(model, consolidated_file, ["SIMD"])
 
     with open(consolidated_file, "r") as f:
@@ -619,3 +621,4 @@ def test_shuffle_config_consolidation():
     assert consolidated_config[original_shuffle_name]["SIMD"] == 4
     for decomposed_name in decomposed_nodes:
         assert decomposed_name not in consolidated_config
+    robust_rmtree(test_dir)

--- a/tests/fpgadataflow/test_fpgadataflow_thresholding_runtime.py
+++ b/tests/fpgadataflow/test_fpgadataflow_thresholding_runtime.py
@@ -29,7 +29,6 @@
 import pytest
 
 import numpy as np
-import os
 from onnx import TensorProto, helper
 from qonnx.core.datatype import DataType
 from qonnx.core.modelwrapper import ModelWrapper
@@ -46,6 +45,7 @@ from finn.transformation.fpgadataflow.insert_fifo import InsertFIFO
 from finn.transformation.fpgadataflow.prepare_ip import PrepareIP
 from finn.transformation.fpgadataflow.prepare_rtlsim import PrepareRTLSim
 from finn.transformation.fpgadataflow.specialize_layers import SpecializeLayers
+from finn.util.test import make_runtime_weight_stream
 
 finnxsi = xsi if xsi.is_available() else None
 
@@ -172,13 +172,7 @@ def test_runtime_thresholds_read(impl_style, idt_act_cfg, cfg, narrow, per_tenso
         op_inst.set_nodeattr("mem_mode", hls_mem_mode)
     op_inst.set_nodeattr("runtime_writeable_weights", 1)
 
-    dat_fname = f"old_weights_{cfg}.dat"
-    op_inst.make_weight_file(T, "decoupled_runtime", dat_fname)
-    with open(dat_fname, "r") as f:
-        old_weight_stream = f.read().strip()
-    os.remove(dat_fname)
-    old_weight_stream = map(lambda x: int(x, 16), old_weight_stream.split("\n"))
-    old_weight_stream = list(old_weight_stream)
+    old_weight_stream = make_runtime_weight_stream(op_inst, T)
     # need to create stitched IP for runtime weight testing
     model = model.transform(InsertFIFO(True))
     model = model.transform(SpecializeLayers(test_fpga_part))
@@ -289,14 +283,7 @@ def test_runtime_thresholds_write(impl_style, idt_act_cfg, cfg, narrow, per_tens
     # provide non-decreasing/ascending thresholds
     T_write = sort_thresholds_increasing(T_write)
 
-    dat_fname = f"T_write_{cfg}.dat"  # distinguish fname per paramter for distributed testing
-    op_inst.make_weight_file(T_write, "decoupled_runtime", dat_fname)
-    with open(dat_fname, "r") as f:
-        T_write_stream = f.read().strip()
-    os.remove(dat_fname)
-
-    T_write_stream = map(lambda x: int(x, 16), T_write_stream.split("\n"))
-    T_write_stream = list(T_write_stream)
+    T_write_stream = make_runtime_weight_stream(op_inst, T_write)
 
     # need to create stitched IP for runtime weight testing
     model = model.transform(InsertFIFO(True))

--- a/tests/fpgadataflow/test_fpgadataflow_upsampler.py
+++ b/tests/fpgadataflow/test_fpgadataflow_upsampler.py
@@ -30,8 +30,6 @@
 import pytest
 
 import numpy as np
-import os
-import shutil
 import torch
 from brevitas.export import export_qonnx
 from qonnx.core.datatype import DataType
@@ -57,9 +55,7 @@ from finn.transformation.fpgadataflow.prepare_rtlsim import PrepareRTLSim
 from finn.transformation.fpgadataflow.set_exec_mode import SetExecMode
 from finn.transformation.fpgadataflow.specialize_layers import SpecializeLayers
 from finn.transformation.qonnx.convert_qonnx_to_finn import ConvertQONNXtoFINN
-from finn.util.basic import make_build_dir
-
-tmpdir = os.environ["FINN_BUILD_DIR"]
+from finn.util.basic import make_build_dir, robust_rmtree
 
 
 class ForceDataTypeForTensors(Transformation):
@@ -202,4 +198,4 @@ def test_fpgadataflow_upsampler(dt, IFMDim, scale, NumChannels, exec_mode, SIMD)
         assert output_matches, "Cppsim output doesn't match ONNX/PyTorch."
     elif exec_mode == "rtlsim":
         assert output_matches, "Rtlsim output doesn't match ONNX/PyTorch."
-    shutil.rmtree(tmpdir, ignore_errors=True)
+    robust_rmtree(tmpdir)

--- a/tests/fpgadataflow/test_runtime_weights.py
+++ b/tests/fpgadataflow/test_runtime_weights.py
@@ -30,7 +30,6 @@
 import pytest
 
 import numpy as np
-import os
 from qonnx.core.datatype import DataType
 from qonnx.custom_op.registry import getCustomOp
 from qonnx.transformation.general import GiveUniqueNodeNames
@@ -43,6 +42,7 @@ from finn.transformation.fpgadataflow.insert_fifo import InsertFIFO
 from finn.transformation.fpgadataflow.prepare_ip import PrepareIP
 from finn.transformation.fpgadataflow.specialize_layers import SpecializeLayers
 from finn.util.create import hls_random_mlp_maker
+from finn.util.test import make_runtime_weight_stream
 
 test_fpga_part = "xczu3eg-sbva484-1-e"
 target_clk_ns = 5
@@ -75,12 +75,7 @@ def test_runtime_weights_single_layer():
     op_inst.set_nodeattr("mem_mode", "internal_decoupled")
     op_inst.set_nodeattr("runtime_writeable_weights", 1)
     old_weights = model.get_initializer(fcl.input[1])
-    op_inst.make_weight_file(old_weights, "decoupled_runtime", "old_weights.dat")
-    with open("old_weights.dat", "r") as f:
-        old_weight_stream = f.read().strip()
-    os.remove("old_weights.dat")
-    old_weight_stream = map(lambda x: int(x, 16), old_weight_stream.split("\n"))
-    old_weight_stream = list(old_weight_stream)
+    old_weight_stream = make_runtime_weight_stream(op_inst, old_weights)
     model = model.transform(InsertFIFO(True))
     model = model.transform(SpecializeLayers(test_fpga_part))
     model = model.transform(GiveUniqueNodeNames())
@@ -116,12 +111,7 @@ def test_runtime_weights_single_layer():
     assert (y[1] == np.dot(in_tensor[1], old_weights)).all()
 
     new_weights = gen_finn_dt_tensor(wdt, (mw, mh))
-    op_inst.make_weight_file(new_weights, "decoupled_runtime", "new_weights.dat")
-    with open("new_weights.dat", "r") as f:
-        new_weight_stream = f.read().strip()
-    os.remove("new_weights.dat")
-    new_weight_stream = map(lambda x: int(x, 16), new_weight_stream.split("\n"))
-    new_weight_stream = list(new_weight_stream)
+    new_weight_stream = make_runtime_weight_stream(op_inst, new_weights)
 
     def write_weights(sim):
         addr = 0

--- a/tests/transformation/test_general_transformation.py
+++ b/tests/transformation/test_general_transformation.py
@@ -18,6 +18,7 @@ from qonnx.transformation.general import GiveUniqueNodeNames
 from qonnx.transformation.lower_convs_to_matmul import LowerConvsToMatMul
 
 from finn.transformation.general import ApplyConfig
+from finn.util.basic import make_build_dir, robust_rmtree
 
 
 @pytest.mark.transform
@@ -31,10 +32,12 @@ def test_apply_config():
     config = {}
     config["Defaults"] = {"kernel_size": [[3, 3], ["Im2Col"]]}
     config["Im2Col_0"] = {"kernel_size": [7, 7]}
-    with open("config.json", "w") as f:
+    test_dir = make_build_dir("test_apply_config_")
+    config_path = os.path.join(test_dir, "config.json")
+    with open(config_path, "w") as f:
         json.dump(config, f, indent=4)
-    model = model.transform(ApplyConfig("config.json"))
+    model = model.transform(ApplyConfig(config_path))
     # check model
     assert getCustomOp(model.graph.node[2]).get_nodeattr("kernel_size") == [7, 7]
     assert getCustomOp(model.graph.node[9]).get_nodeattr("kernel_size") == [3, 3]
-    os.remove("config.json")
+    robust_rmtree(test_dir)

--- a/tests/transformation/test_loop_rolling.py
+++ b/tests/transformation/test_loop_rolling.py
@@ -116,17 +116,25 @@ def check_tensor_shape(model_wrapper, name, expected_shape):
     ), f"Shape mismatch for {name}: expected {expected_shape}, got {actual_shape}"
 
 
+@pytest.mark.transform
+def test_loop_extraction_default_paths_are_unique():
+    first = LoopExtraction(hierarchy_list=[["", "layers.0"]])
+    second = LoopExtraction(hierarchy_list=[["", "layers.0"]])
+    first_dir = Path(first.loop_body_template_path).parent
+    second_dir = Path(second.loop_body_template_path).parent
+    assert first_dir != second_dir
+    assert first_dir.parent == second_dir.parent
+    robust_rmtree(first_dir)
+    robust_rmtree(second_dir)
+
+
 # input_size == hidden_size to create model that can be rolled
 @pytest.mark.parametrize("input_size", [20, 30, 40])
 # num_layers
 @pytest.mark.parametrize("num_layers", [6, 12, 24])
 @pytest.mark.transform
-def test_finn_loop(input_size, num_layers, monkeypatch):
+def test_finn_loop(input_size, num_layers):
     out_dir = Path(make_build_dir(prefix="test_finn_loop_"))
-    # LoopExtraction saves and reloads a fixed-name loop-body-template.onnx in
-    # the cwd, so run each case in its own build dir (kept on failure for
-    # debugging) to stop concurrent workers racing on that file
-    monkeypatch.chdir(out_dir)
     # fixed seed so the deep quantised configs stay within tolerance run to run
     torch.manual_seed(0)
     np.random.seed(0)
@@ -179,7 +187,10 @@ def test_finn_loop(input_size, num_layers, monkeypatch):
     model_wrapper = model_wrapper.transform(SetLoopBoundary(node_metadata, node_range=node_range))
 
     # Loop extraction
-    loop_extraction = LoopExtraction(hierarchy_list=[["", "layers.0"]])
+    template_path = out_dir / "loop-body-template.onnx"
+    loop_extraction = LoopExtraction(
+        hierarchy_list=[["", "layers.0"]], loop_body_template_path=template_path
+    )
     model_wrapper = model_wrapper.transform(loop_extraction)
 
     # should be one constant node and one loop-body node per layer
@@ -284,10 +295,8 @@ def test_finn_loop(input_size, num_layers, monkeypatch):
 
 
 @pytest.mark.transform
-def test_inconsistent_initializer_shape(monkeypatch):
+def test_inconsistent_initializer_shape():
     out_dir = Path(make_build_dir(prefix="test_inconsistent_initializer_"))
-    # isolate LoopExtraction's fixed-name cwd file per test, see test_finn_loop
-    monkeypatch.chdir(out_dir)
     # test that if the initializer shape is inconsistent with the value info
     # shape, the transformation fails
     input_size = 20
@@ -307,7 +316,10 @@ def test_inconsistent_initializer_shape(monkeypatch):
     param0 = model_wrapper.get_initializer("Mul_0_param0")
     model_wrapper.set_initializer("Mul_0_param0", np.append(param0, param0))
 
-    loop_extraction = LoopExtraction(hierarchy_list=[["", "layers.0"]])
+    template_path = out_dir / "loop-body-template.onnx"
+    loop_extraction = LoopExtraction(
+        hierarchy_list=[["", "layers.0"]], loop_body_template_path=template_path
+    )
     model_wrapper = model_wrapper.transform(loop_extraction)
 
     # should throw an error because the initializer shape is inconsistent with the value info shape

--- a/tests/util/test_config.py
+++ b/tests/util/test_config.py
@@ -19,6 +19,7 @@ from qonnx.custom_op.registry import getCustomOp
 from typing import Any, Dict
 
 from finn.transformation.general import ApplyConfig
+from finn.util.basic import make_build_dir, robust_rmtree
 from finn.util.config import extract_model_config, extract_model_config_to_json
 
 # this is a pretend opset so that we can create
@@ -160,7 +161,8 @@ def test_roundtrip_export_import():
         model, subgraph_hier=None, attr_names_to_extract=attrs_to_extract
     )
     # Save in json
-    config_json_file = os.environ["FINN_BUILD_DIR"] + "/original_config.json"
+    test_dir = make_build_dir("test_config_roundtrip_")
+    config_json_file = os.path.join(test_dir, "original_config.json")
     extract_model_config_to_json(model, config_json_file, attrs_to_extract)
 
     # Modify all Im2Col nodes to different values (recursively through subgraphs)
@@ -191,8 +193,7 @@ def test_roundtrip_export_import():
     )
     assert restored_config == original_config, "Config not properly restored after roundtrip"
 
-    if os.path.exists(config_json_file):
-        os.remove(config_json_file)
+    robust_rmtree(test_dir)
 
 
 @pytest.mark.util

--- a/tests/util/test_finn_ci_plugin.py
+++ b/tests/util/test_finn_ci_plugin.py
@@ -256,7 +256,7 @@ class _FakeSession:
 def _drive_sessionfinish(tmp_path, exitstatus):
     # exercise the per-shard trust guard via a stub session, without spinning up
     # a full pytest run just to reach pytest_sessionfinish.
-    instance = plugin._FinnCiShardingPlugin()
+    instance = plugin._FinnCiPlugin()
     instance.timings = {
         "per_test_seconds": {"tests/foo.py::test_a": 1.0},
         "nodeid_to_group": {},

--- a/tests/util/test_test_helpers.py
+++ b/tests/util/test_test_helpers.py
@@ -1,0 +1,41 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import pytest
+
+from finn.util.test import make_runtime_weight_stream
+
+pytestmark = pytest.mark.util
+
+
+class RuntimeWeightOp:
+    def __init__(self, content):
+        self.content = content
+
+    def make_weight_file(self, weights, mode, path):
+        assert weights == "weights"
+        assert mode == "decoupled_runtime"
+        with open(path, "w") as f:
+            f.write(self.content)
+
+
+def test_make_runtime_weight_stream_removes_clean_scratch(tmp_path, monkeypatch):
+    monkeypatch.setenv("FINN_BUILD_DIR", str(tmp_path))
+
+    stream = make_runtime_weight_stream(RuntimeWeightOp("1\na\nff\n"), "weights")
+
+    assert stream == [1, 10, 255]
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_make_runtime_weight_stream_retains_failed_scratch(tmp_path, monkeypatch):
+    monkeypatch.setenv("FINN_BUILD_DIR", str(tmp_path))
+
+    with pytest.raises(ValueError):
+        make_runtime_weight_stream(RuntimeWeightOp("not-hex\n"), "weights")
+
+    retained = list(tmp_path.iterdir())
+    assert len(retained) == 1
+    assert (retained[0] / "weights.dat").read_text() == "not-hex\n"


### PR DESCRIPTION
The existing test suite leaks files and environment mutations into globally accessible state, which make different tests interfere with each other when run concurrently under xdist.

This is the mentioned follow-up to https://github.com/Xilinx/finn/pull/1599 . This PR systematically eliminates the remaining unsafe practices and adds a new test guidelines README that will enforce these going forward.

### List of changes

**Scratch paths**

- move runtime-weight serialisation, configuration exports, and temporary JSON files into unique build directories
- introduce a shared runtime-weight-stream helper that cleans successful temporary output and retains it on failure
- remove the global deploy dir for the BNN tests and use normal build dir instead (deploy dir no longer necessary after https://github.com/Xilinx/finn/pull/1608 with find_copy_zip.sh).
- `test_fpgadataflow_ipstitch.py` no longer saves into the module-level `ip_stitch_model_dir`.

**Loop extraction template path**

`LoopExtraction` previously always wrote `loop-body-template.onnx` into the cwd which is racy with concurrent tests. It now has an optional `loop_body_template_path`:

- The dataflow builder passes `cfg.output_dir/loop-body-template.onnx` directly and no longer moves the file afterward.
- Without passing the arg, the caller gets a unique directory under `FINN_BUILD_DIR`.
- Loop-rolling tests pass an explicit path under their per-test build dir.

**Environment**

- Replace direct environment mutation with monkeypatch.

**Documentation**

- Switch `docker/quicktest.sh` and `docs/finn/developers.rst` from `--dist=loadfile` to `--dist=loadgroup`.
- Added `tests/README.md` with test guidelines going forward.

### Testing

Successful validation in Jenkins in finn_ci_testing job 94.

### Other

I renamed `FinnCiShardingPlugin` to `FinnCiPlugin` because I planned to add worker isolation logic but it ended up being too complicated for the benefit. But I still prefer the rename and it has no external effects.