### PR TITLE
[Docker] Pin git describe abbrev in FINN_DOCKER_TAG to 12 characters

### DIFF
--- a/run-docker.sh
+++ b/run-docker.sh
@@ -66,7 +66,7 @@ SCRIPTPATH=$(dirname "$SCRIPT")
 : ${XRT_DEB_VERSION="xrt_202220.2.14.354_22.04-amd64-xrt"}
 : ${V80PP_DEB_PACKAGE=""}
 : ${FINN_HOST_BUILD_DIR="/tmp/$DOCKER_INST_NAME"}
-: ${FINN_DOCKER_TAG="xilinx/finn:$(OLD_PWD=$(pwd); cd $SCRIPTPATH; git describe --always --tags --dirty; cd $OLD_PWD).$XRT_DEB_VERSION"}
+: ${FINN_DOCKER_TAG="xilinx/finn:$(OLD_PWD=$(pwd); cd $SCRIPTPATH; git describe --always --tags --dirty --abbrev=12; cd $OLD_PWD).$XRT_DEB_VERSION"}
 : ${FINN_DOCKER_PREBUILT="0"}
 : ${FINN_DOCKER_RUN_AS_ROOT="0"}
 : ${FINN_DOCKER_EXTRA=""}


### PR DESCRIPTION
Unexpectedly, the git describe command can output variable length commit hashes. This fix uses a fixed git abbreviation length so independent Jenkins workspaces derive the same tag for the same commit.

Tested in finn_ci_testing run 94.