### PR TITLE
Separate InnerShuffle physical and logical input shapes

### DIFF
--- a/finn-rtllib/inner_shuffle/inner_shuffle.sv
+++ b/finn-rtllib/inner_shuffle/inner_shuffle.sv
@@ -264,7 +264,7 @@ module inner_shuffle #(
 	logic [1:0] WrJobsDone = 2'b00; // Bit vector tracking when writes have been completed to pages
 	logic CurrentPageRd = 0;     // 0 - reading from PAGE A, 1 - reading from PAGE B
 	uwire [$clog2(BANK_DEPTH)-1:0]  page_rd_offset;
-	uwire  rd_guard = !CurrentPageRd && !WrJobsDone[0] && !WrJobsDone[1];
+	uwire rd_guard = !WrJobsDone[CurrentPageRd];
 	uwire rd_inc = rd_req_en && rd_req_rdy_all;
 
 	// Counts reads across the columns

--- a/src/finn/custom_op/fpgadataflow/inner_shuffle.py
+++ b/src/finn/custom_op/fpgadataflow/inner_shuffle.py
@@ -22,7 +22,11 @@ class InnerShuffle(HWCustomOp):
     def get_nodeattr_types(self):
         my_attrs = {
             "data_type": ("s", True, ""),
-            "in_shape": ("ints", True, []),  # Needs to be len==2 can we assert that somewhere?
+            # Physical/normal input shape - matches the actual input tensor.
+            "in_shape": ("ints", True, []),
+            # Logical shape the transpose acts on (in_shape after any fused
+            # reshape). Equals in_shape when no reshape was fused.
+            "transpose_in_shape": ("ints", True, []),
             "SIMD": ("i", False, 1),
             "original_node_name": ("s", False, ""),  # Track original shuffle name for SIMD config
             "original_simd": ("i", False, 1),  # Track original shuffle SIMD for config export
@@ -34,12 +38,16 @@ class InnerShuffle(HWCustomOp):
         return self.get_nodeattr("in_shape")
 
     def get_normal_output_shape(self, ind=0):
-        ishape = tuple(self.get_normal_input_shape())
-        return ishape[:-2] + (ishape[-1], ishape[-2])
+        tshape = tuple(self.get_nodeattr("transpose_in_shape"))
+        return tshape[:-2] + (tshape[-1], tshape[-2])
 
     def execute_node(self, context, graph):
         node = self.onnx_node
         input_data = context[node.input[0]]
+        # The tensor arrives in its physical shape; reshape to the logical view
+        # the transpose acts on (identical data in row-major order).
+        in_shape = self.get_nodeattr("transpose_in_shape")
+        input_data = input_data.reshape(in_shape)
         assert len(input_data.shape) >= 2, "InnerShuffle HWCustomOp requires at least 2D input"
         # Transpose only the last two dimensions: (..., a, b) -> (..., b, a)
         axes = list(range(len(input_data.shape)))
@@ -99,7 +107,7 @@ class InnerShuffle(HWCustomOp):
         latency beyond the streaming throughput. Empirically verified to match
         cycles_rtlsim within atol=10.
         """
-        in_shape = self.get_nodeattr("in_shape")
+        in_shape = self.get_nodeattr("transpose_in_shape")
         simd = self.get_nodeattr("SIMD")
         I_dim = in_shape[-2]
         J_dim = in_shape[-1]

--- a/src/finn/custom_op/fpgadataflow/rtl/inner_shuffle_rtl.py
+++ b/src/finn/custom_op/fpgadataflow/rtl/inner_shuffle_rtl.py
@@ -49,7 +49,7 @@ class InnerShuffle_rtl(InnerShuffle, RTLBackend):
         super().__init__(onnx_node, **kwargs)
 
         # check some constraints that it is a legal InnerShuffle
-        I_dim = self.get_nodeattr("in_shape")[-2]
+        I_dim = self.get_nodeattr("transpose_in_shape")[-2]
         SIMD = self.get_nodeattr("SIMD")
         if I_dim % SIMD != 0:
             new_simd = auto_size_simd(I_dim, SIMD)
@@ -81,10 +81,11 @@ class InnerShuffle_rtl(InnerShuffle, RTLBackend):
         code_gen_dir = self.get_nodeattr("code_gen_dir_ipgen")
         dt = DataType[self.get_nodeattr("data_type")]
         simd = self.get_nodeattr("SIMD")
+        transpose_in_shape = self.get_nodeattr("transpose_in_shape")
         code_gen_dict = {
             "TOP_MODULE_NAME": self.get_verilog_top_module_name(),
-            "I": self.get_nodeattr("in_shape")[-2],
-            "J": self.get_nodeattr("in_shape")[-1],
+            "I": transpose_in_shape[-2],
+            "J": transpose_in_shape[-1],
             "SIMD": simd,
             "WIDTH": dt.bitwidth(),
             "STREAM_BITS": simd * dt.bitwidth(),

--- a/src/finn/custom_op/fpgadataflow/shuffle.py
+++ b/src/finn/custom_op/fpgadataflow/shuffle.py
@@ -165,7 +165,8 @@ class Shuffle(HWCustomOp):
             out_shape = list(itemgetter(*P)(current_shape))
 
             if _is_inner_shuffle(P, current_shape):
-                # InnerShuffle: in_shape = current_shape
+                # InnerShuffle: no reshape fused here, so physical in_shape and
+                # logical transpose_in_shape are both the current stage shape.
                 tmp_node = helper.make_node(
                     "InnerShuffle",
                     ["tmp_in"],
@@ -173,6 +174,7 @@ class Shuffle(HWCustomOp):
                     domain="finn.custom_op.fpgadataflow",
                     backend="fpgadataflow",
                     in_shape=current_shape,
+                    transpose_in_shape=current_shape,
                     data_type=data_type,
                     SIMD=simd,
                     name=f"tmp_inner_{step_idx}",

--- a/src/finn/transformation/fpgadataflow/transpose_decomposition.py
+++ b/src/finn/transformation/fpgadataflow/transpose_decomposition.py
@@ -460,7 +460,7 @@ class InferInnerOuterShuffles(Transformation):
                 perm = f_inst.get_nodeattr("perm")
                 simd = f_inst.get_nodeattr("SIMD")
 
-                if _is_inner_shuffle(perm, in_shape):
+                if _is_inner_shuffle(perm, in_reshaped):
                     # Get original node name if it exists, otherwise use current node name
                     try:
                         original_name = f_inst.get_nodeattr("original_node_name") or node.name
@@ -474,15 +474,16 @@ class InferInnerOuterShuffles(Transformation):
                         [new_out_tensor],
                         domain="finn.custom_op.fpgadataflow",
                         backend="fpgadataflow",
-                        in_shape=in_shape,
+                        in_shape=in_shape,  # physical shape (matches the input tensor)
+                        transpose_in_shape=in_reshaped,  # logical (post-fused-reshape) shape
                         data_type=data_type,
                         perm=perm,
                         name=f"InnerShuffle_{node.name}",
                         original_node_name=original_name,  # Preserve original shuffle name
                         original_simd=original_simd,  # Preserve original SIMD
                         SIMD=simd,
-                        I=in_shape[-2],  # Second to last dim
-                        J=in_shape[-1],  # Last dim
+                        I=in_reshaped[-2],  # Second to last dim
+                        J=in_reshaped[-1],  # Last dim
                     )
                 else:
                     # Get original node name if it exists, otherwise use current node name

--- a/tests/fpgadataflow/test_fpgadataflow_shuffle.py
+++ b/tests/fpgadataflow/test_fpgadataflow_shuffle.py
@@ -28,6 +28,7 @@ from qonnx.util.cleanup import cleanup as qonnx_cleanup
 from torch import nn
 
 import finn.core.onnx_exec as oxe
+from finn import xsi as finnxsi
 from finn.analysis.fpgadataflow.exp_cycles_per_layer import exp_cycles_per_layer
 from finn.transformation.fpgadataflow.compile_cppsim import CompileCppSim
 from finn.transformation.fpgadataflow.convert_to_hw_layers import InferShuffle
@@ -42,8 +43,9 @@ from finn.transformation.fpgadataflow.transpose_decomposition import (
     InferInnerOuterShuffles,
     ShuffleDecomposition,
 )
-from finn.util.basic import make_build_dir, robust_rmtree
+from finn.util.basic import get_liveness_threshold_cycles, make_build_dir, robust_rmtree
 from finn.util.config import extract_model_config_consolidate_shuffles
+from finn.util.data_packing import npy_to_rtlsim_input, rtlsim_output_to_npy
 
 test_fpga_part: str = "xcvc1902-vsva2197-2MP-e-S"
 test_synth_clk_period_ns: int = 10
@@ -730,3 +732,83 @@ def test_shuffle_config_consolidation():
     for decomposed_name in decomposed_nodes:
         assert decomposed_name not in consolidated_config
     robust_rmtree(test_dir)
+
+
+@pytest.mark.parametrize("throttle", [(float("inf"), 0), (1, 15)], ids=["backtoback", "bursty"])
+@pytest.mark.fpgadataflow
+@pytest.mark.vivado
+def test_inner_shuffle_rtl_bursty(throttle, monkeypatch):
+    monkeypatch.setenv("LIVENESS_THRESHOLD", "10000000")
+    if not finnxsi.is_available():
+        pytest.skip("finn_xsi (XSI rtlsim) not available")
+
+    SIMD = 4
+    dt = DataType["INT8"]
+    in_shape = (4, 8, 8)  # (N frames, rows, cols); transpose swaps rows/cols
+
+    model = construct_onnx_model(
+        input_shape=in_shape,
+        transpose_perm=(0, 2, 1),
+        reshape1_shape=None,
+        reshape2_shape=None,
+        dt=dt,
+    )
+
+    x = gen_finn_dt_tensor(dt, in_shape)
+    in_name = model.get_first_global_in()
+    out_name = model.get_first_global_out()
+    y_ref = oxe.execute_onnx(model, {in_name: x})[out_name]
+
+    model = model.transform(InferShuffle(_filter=lambda *_: True))
+    model = model.transform(SpecializeLayers(test_fpga_part))
+    model = model.transform(SetShuffleSIMD(SIMD))
+    model = model.transform(ShuffleDecomposition())
+    model = model.transform(InferInnerOuterShuffles())
+    model = model.transform(SpecializeLayers(test_fpga_part))
+    model = model.transform(GiveUniqueNodeNames())
+    model = model.transform(GiveReadableTensorNames())
+
+    model = model.transform(SetExecMode("rtlsim"))
+    model = model.transform(PrepareIP(test_fpga_part, test_synth_clk_period_ns))
+    model = model.transform(HLSSynthIP())
+    model = model.transform(PrepareRTLSim())
+
+    inst = getCustomOp(model.get_nodes_by_op_type("InnerShuffle_rtl")[0])
+
+    in_dt, in_w, in_folded = (
+        inst.get_input_datatype(0),
+        inst.get_instream_width(0),
+        inst.get_folded_input_shape(0),
+    )
+    out_dt, out_w, out_folded = (
+        inst.get_output_datatype(0),
+        inst.get_outstream_width(0),
+        inst.get_folded_output_shape(0),
+    )
+    out_normal = tuple(inst.get_normal_output_shape(0))
+    num_out = inst.get_number_output_values()
+
+    packed_in = npy_to_rtlsim_input(np.asarray(x, dtype=np.float32).reshape(in_folded), in_dt, in_w)
+    hex_in = map(lambda v: f"{v:0x}", packed_in)
+
+    sim = inst.get_rtlsim()
+    liveness = max(inst.get_exp_cycles(), get_liveness_threshold_cycles())
+    try:
+        inst.reset_rtlsim(sim)
+        sim.stream_input("in0_V", hex_in, throttle=throttle)
+        out_buf = sim.collect_output(
+            "out0_V", num_out, watchdog=sim.create_watchdog("out0_V timeout", liveness)
+        )
+        assert not sim.run(), "rtlsim watchdog timed out"
+        packed_out = [int(v, base=16) for v in out_buf]
+    finally:
+        inst.close_rtlsim(sim)
+
+    got = rtlsim_output_to_npy(packed_out, None, out_dt, out_folded, out_w, out_dt.bitwidth())
+    got = np.asarray(got, dtype=np.float32).reshape(out_normal)
+
+    assert got.shape == y_ref.shape, "shape %s != ref %s" % (got.shape, y_ref.shape)
+    assert np.allclose(got, y_ref), (
+        "InnerShuffle_rtl output does not match reference transpose (throttle=%s): "
+        "a read overtook its write on the ping-pong page" % (throttle,)
+    )

--- a/tests/fpgadataflow/test_fpgadataflow_shuffle.py
+++ b/tests/fpgadataflow/test_fpgadataflow_shuffle.py
@@ -209,6 +209,114 @@ def test_cppsim_shuffle_layer(cpp_shuffle_param, datatype, simd):
 
 
 @pytest.mark.parametrize(
+    "reshape_transpose_param",
+    [
+        {
+            "in_shape": (1, 768, 14, 14),  # exact SigLIP head dims
+            "transpose_in_shape": (1, 768, 196),
+            "out_shape": (1, 196, 768),
+            "transpose_out_shape": None,
+            "perm": (0, 2, 1),
+        },
+    ],
+    ids=["siglip_1x768x14x14"],
+)
+@pytest.mark.parametrize("datatype", ["INT8"])
+@pytest.mark.parametrize("simd", ["simd1"])
+@pytest.mark.parametrize("exec_mode", ["cppsim", "rtlsim"])
+@pytest.mark.fpgadataflow
+@pytest.mark.vivado
+@pytest.mark.slow
+def test_fused_reshape_inner_transpose(
+    reshape_transpose_param, datatype, simd, exec_mode, monkeypatch
+):
+    """cppsim/rtlsim of a single Reshape+Transpose that fuses into one Shuffle and
+    must decompose to a single InnerShuffle operating on the flattened view.
+
+    Guards against the regression where the InnerShuffle was built from the
+    physical in_shape (dropping the fused reshape) instead of transpose_in_shape.
+    """
+    monkeypatch.setenv("LIVENESS_THRESHOLD", "10000000")
+    dt = DataType[datatype]
+    simd = int(simd[-1])
+    in_shape = reshape_transpose_param["in_shape"]
+    transpose_in_shape = reshape_transpose_param["transpose_in_shape"]
+
+    model = construct_onnx_model(
+        input_shape=in_shape,
+        transpose_perm=reshape_transpose_param["perm"],
+        reshape1_shape=transpose_in_shape,
+        reshape2_shape=reshape_transpose_param["transpose_out_shape"],
+        dt=dt,
+    )
+
+    input = gen_finn_dt_tensor(dt, in_shape)
+    in_name = model.get_first_global_in()
+    out_name = model.get_first_global_out()
+    input_t = {in_name: input}
+
+    # Reference: the plain Reshape+Transpose ONNX
+    y_ref = oxe.execute_onnx(model, input_t)[out_name]
+
+    # Fuse Reshape+Transpose into one Shuffle and confirm the reshape was captured
+    # (physical in_shape differs from the shape the transpose acts on).
+    model = model.transform(InferShuffle(_filter=lambda *_: True))
+    model = model.transform(SpecializeLayers(test_fpga_part))
+    shuffle_nodes = [
+        n
+        for n in model.graph.node
+        if n.op_type == "Shuffle" and "finn.custom_op.fpgadataflow" in n.domain
+    ]
+    assert len(shuffle_nodes) == 1, "expected a single fused Shuffle node"
+    shuffle_inst = getCustomOp(shuffle_nodes[0])
+    assert list(shuffle_inst.get_nodeattr("in_shape")) == list(in_shape)
+    assert list(shuffle_inst.get_nodeattr("transpose_in_shape")) == list(transpose_in_shape)
+    assert list(shuffle_inst.get_nodeattr("in_shape")) != list(
+        transpose_in_shape
+    ), "this test must exercise a FUSED reshape (in_shape != transpose_in_shape)"
+
+    model = model.transform(SetShuffleSIMD(simd))
+    model = model.transform(ShuffleDecomposition())
+    model = model.transform(InferInnerOuterShuffles())
+    model = model.transform(SpecializeLayers(test_fpga_part))
+
+    # A swap-last-two transpose must map to exactly one InnerShuffle (no
+    # OuterShuffle), and that InnerShuffle must operate on the flattened
+    # transpose_in_shape rather than the physical in_shape.
+    inner = [n for n in model.graph.node if n.op_type == "InnerShuffle_rtl"]
+    outer = [n for n in model.graph.node if n.op_type == "OuterShuffle_hls"]
+    assert len(inner) == 1, "fused reshape + swap-last-two must yield one InnerShuffle"
+    assert len(outer) == 0, "no OuterShuffle expected for a pure inner transpose"
+    inner_inst = getCustomOp(inner[0])
+    # in_shape matches the physical input tensor; the flattened view the
+    # transpose acts on is carried separately in transpose_in_shape.
+    assert list(inner_inst.get_nodeattr("in_shape")) == list(
+        in_shape
+    ), "InnerShuffle in_shape must match the physical input tensor"
+    assert list(inner_inst.get_nodeattr("transpose_in_shape")) == list(
+        transpose_in_shape
+    ), "InnerShuffle must carry the flattened transpose_in_shape"
+    assert list(inner_inst.get_normal_output_shape()) == list(reshape_transpose_param["out_shape"])
+
+    model = model.transform(GiveUniqueNodeNames())
+    model = model.transform(GiveReadableTensorNames())
+
+    model = model.transform(SetExecMode(exec_mode))
+    if exec_mode == "cppsim":
+        model = model.transform(PrepareCppSim())
+        model = model.transform(CompileCppSim())
+    elif exec_mode == "rtlsim":
+        model = model.transform(PrepareIP(test_fpga_part, test_synth_clk_period_ns))
+        model = model.transform(HLSSynthIP())
+        model = model.transform(PrepareRTLSim())
+    else:
+        raise ValueError(f"unknown exec_mode {exec_mode}")
+
+    y_hw = oxe.execute_onnx(model, input_t)[out_name]
+    assert np.allclose(y_ref, y_hw), "Model output does not match expected output"
+
+
+@pytest.mark.parametrize(
     "shuffle_param",
     [
         {


### PR DESCRIPTION
## Problem

When a Reshape was fused into a Shuffle, InnerShuffle ignored it and transposed the physical tensors last two axes. So (1,768,14,14) -> reshape -> (1,768,196) -> transpose (0,2,1) -> (1,196,768) swapped the two 14 dims instead of swapping 768 and 196, producing the wrong result.


## Fix

Track the logical (post-reshape) shape the transpose acts on separately from the physical input tensor
- in_shape physical tensor
- transpose_in_shape (new) logical view

Update: Also fixed the InnerShuffle page guard