### PR TITLE
Support conversion of unsigned identity Quant nodes to FINN-ONNX

### DIFF
--- a/src/finn/transformation/qonnx/qonnx_activation_handlers.py
+++ b/src/finn/transformation/qonnx/qonnx_activation_handlers.py
@@ -483,10 +483,6 @@ class QuantIdentityHandler(QuantActBaseHandler):
     def _check_compatibility(self):
         # Gather parameters to check
         if self._q_node.op_type == "Quant":
-            q_inst = getCustomOp(self._q_node)
-            signed = q_inst.get_nodeattr("signed")
-            if not signed:
-                raise ValueError("FINN only supports signed Quant nodes for identity activations.")
             if not self._model.get_initializer(self._q_node.input[2]) == 0:
                 raise ValueError(
                     "Only Quant nodes with zero-point == 0 "
@@ -508,6 +504,7 @@ class QuantIdentityHandler(QuantActBaseHandler):
         if self._q_node.op_type == "Quant":
             bit_width = self._model.get_initializer(self._q_node.input[3])
             narrow = q_inst.get_nodeattr("narrow")
+            signed = q_inst.get_nodeattr("signed")
         elif self._q_node.op_type == "BipolarQuant":
             bit_width = 1.0
         else:
@@ -518,10 +515,13 @@ class QuantIdentityHandler(QuantActBaseHandler):
         if bit_width == 1.0:
             bias = np.array([-0.5], dtype=np_default_dtype)
         else:
-            if narrow:
-                min_non_scaled_val = -(2 ** (bit_width - 1) - 1)
+            if not signed:
+                min_non_scaled_val = 0
             else:
-                min_non_scaled_val = -(2 ** (bit_width - 1))
+                if narrow:
+                    min_non_scaled_val = -(2 ** (bit_width - 1) - 1)
+                else:
+                    min_non_scaled_val = -(2 ** (bit_width - 1))
             bias = np.array([min_non_scaled_val], dtype=np_default_dtype)
         return bias
 
@@ -532,6 +532,7 @@ class QuantIdentityHandler(QuantActBaseHandler):
         if self._q_node.op_type == "Quant":
             bit_width = self._model.get_initializer(self._q_node.input[3])
             narrow = q_inst.get_nodeattr("narrow")
+            signed = q_inst.get_nodeattr("signed")
         elif self._q_node.op_type == "BipolarQuant":
             bit_width = 1.0
         else:
@@ -567,6 +568,8 @@ class QuantIdentityHandler(QuantActBaseHandler):
             min_threshold = -half_step - step * ((num_thresholds // 2) - 1)
             if not narrow:
                 min_threshold -= step
+            if not signed:
+                min_threshold = half_step
             for c in range(num_scale_channels):
                 for t in range(num_thresholds):
                     thresholds[c][t] = min_threshold[c] + step[c] * t

--- a/tests/brevitas/test_brevitas_quant_identity_export.py
+++ b/tests/brevitas/test_brevitas_quant_identity_export.py
@@ -1,0 +1,98 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import pytest
+
+import numpy as np
+import onnx  # noqa
+import os
+import torch
+from brevitas.core.scaling import ScalingImplType
+from brevitas.export import export_qonnx
+from brevitas.nn import QuantIdentity
+from brevitas.quant.scaled_int import Int8ActPerTensorFloat, Uint8ActPerTensorFloat
+from qonnx.core.modelwrapper import ModelWrapper
+from qonnx.util.basic import get_preferred_onnx_opset
+from qonnx.util.cleanup import cleanup as qonnx_cleanup
+
+import finn.core.onnx_exec as oxe
+from finn.transformation.qonnx.convert_qonnx_to_finn import ConvertQONNXtoFINN
+from finn.util.basic import make_build_dir, robust_rmtree
+
+
+@pytest.mark.brevitas_export
+@pytest.mark.parametrize("abits", [2, 4, 8])
+@pytest.mark.parametrize("ishape", [(1, 15), (1, 32, 1, 1)])
+@pytest.mark.parametrize("narrow", [True, False])
+@pytest.mark.parametrize("quant", [Int8ActPerTensorFloat, Uint8ActPerTensorFloat])
+def test_brevitas_quant_identity_export(abits, ishape, narrow, quant):
+    build_dir = make_build_dir("test_brevitas_quant_identity_export_")
+    export_path = os.path.join(build_dir, "quant_identity.onnx")
+    b_act = QuantIdentity(act_quant=quant, bit_width=abits, narrow_range=narrow)
+
+    export_qonnx(
+        b_act,
+        torch.randn(ishape),
+        export_path,
+        opset_version=get_preferred_onnx_opset(),
+    )
+    qonnx_cleanup(export_path, out_file=export_path)
+    model = ModelWrapper(export_path)
+    model = model.transform(ConvertQONNXtoFINN())
+
+    inp_tensor = np.random.uniform(low=-10.0, high=10.0, size=ishape).astype(np.float32)
+    idict = {model.graph.input[0].name: inp_tensor}
+    odict = oxe.execute_onnx(model, idict, True)
+    produced = odict[model.graph.output[0].name]
+    inp_tensor = torch.from_numpy(inp_tensor).float()
+    b_act.eval()
+    expected = b_act.forward(inp_tensor).detach().numpy()
+
+    # kept for diagnosis on failure: robust_rmtree below is skipped if the
+    # assert raises (see tests/README.md)
+    assert np.isclose(produced, expected, atol=1e-3).all()
+    robust_rmtree(build_dir)
+
+
+@pytest.mark.brevitas_export
+@pytest.mark.parametrize("abits", [2, 4, 8])
+@pytest.mark.parametrize("ishape", [(1, 15, 4, 4), (1, 32, 1, 1)])
+@pytest.mark.parametrize("narrow", [True, False])
+@pytest.mark.parametrize("quant", [Int8ActPerTensorFloat, Uint8ActPerTensorFloat])
+def test_brevitas_quant_identity_export_per_channel(abits, ishape, narrow, quant):
+    ch = ishape[1]
+    build_dir = make_build_dir("test_brevitas_quant_identity_export_per_channel_")
+    export_path = os.path.join(build_dir, "quant_identity.onnx")
+    b_act = QuantIdentity(
+        act_quant=quant,
+        bit_width=abits,
+        narrow_range=narrow,
+        min_val=-6.0,
+        max_val=6.0,
+        scaling_impl_type=ScalingImplType.CONST,
+        scaling_per_output_channel=True,
+        per_channel_broadcastable_shape=(1, ch, 1, 1),
+    )
+
+    export_qonnx(
+        b_act,
+        torch.randn(ishape),
+        export_path,
+        opset_version=get_preferred_onnx_opset(),
+    )
+    qonnx_cleanup(export_path, out_file=export_path)
+    model = ModelWrapper(export_path)
+    model = model.transform(ConvertQONNXtoFINN())
+
+    inp_tensor = np.random.uniform(low=-10.0, high=10.0, size=ishape).astype(np.float32)
+    idict = {model.graph.input[0].name: inp_tensor}
+    odict = oxe.execute_onnx(model, idict, True)
+    produced = odict[model.graph.output[0].name]
+    inp_tensor = torch.from_numpy(inp_tensor).float()
+    b_act.eval()
+    expected = b_act.forward(inp_tensor).detach().numpy()
+
+    # kept for diagnosis on failure: robust_rmtree below is skipped if the
+    # assert raises (see tests/README.md)
+    assert np.isclose(produced, expected, atol=1e-3).all()
+    robust_rmtree(build_dir)


### PR DESCRIPTION
### Summary
Adds support for converting **unsigned** identity `Quant` nodes to FINN-ONNX.
`QuantIdentityHandler` previously rejected unsigned identity activations (`"FINN only supports signed Quant nodes for identity activations."`); this removes that restriction and handles the unsigned case in the bias (`min_non_scaled_val = 0`) and threshold (`min_threshold = half_step`) derivation.

### Changes
  - Drop the signed-only guard in `QuantIdentityHandler._check_compatibility` and add the unsigned branches in `_calculate_act_bias` / `_calculate_thresholds`.
  - Add `tests/brevitas/test_brevitas_quant_identity_export.py`: brevitas export test parametrized over bitwidth, shape, `narrow_range`, and signed/unsigned quantizers, with per-tensor and per-channel scaling variants.

### Notes
  - Supersedes and closes #1117. Original implementation and test by @lecramdev; test updated per review (`narrow_range` fix) and made conformant with `tests/README.md` scratch-path conventions.
