### PR TITLE
Make ApplyConfig subgraph descent opt-in and symmetric with config extraction

### DIFF
--- a/src/finn/builder/build_dataflow_steps.py
+++ b/src/finn/builder/build_dataflow_steps.py
@@ -641,7 +641,10 @@ def step_create_dataflow_partition(model: ModelWrapper, cfg: DataflowBuildConfig
         "preferred_impl_style",
     ]
     extract_model_config_to_json(
-        model, cfg.output_dir + "/template_specialize_layers_config.json", attrs
+        model,
+        cfg.output_dir + "/template_specialize_layers_config.json",
+        attrs,
+        apply_to_subgraphs=True,
     )
 
     return model
@@ -656,7 +659,9 @@ def step_specialize_layers(model: ModelWrapper, cfg: DataflowBuildConfig):
 
     if cfg.specialize_layers_config_file is not None:
         model = model.transform(GiveUniqueNodeNames())
-        model = model.transform(ApplyConfig(cfg.specialize_layers_config_file))
+        model = model.transform(
+            ApplyConfig(cfg.specialize_layers_config_file, apply_to_subgraphs=True)
+        )
     model = model.transform(SpecializeLayers(cfg._resolve_fpga_part()))
     model = model.transform(GiveUniqueNodeNames())
     model = model.transform(InferShapes())
@@ -730,7 +735,12 @@ def step_target_fps_parallelization(model: ModelWrapper, cfg: DataflowBuildConfi
             "depth_trigger_uram",
             "depth_trigger_bram",
         ]
-        extract_model_config_to_json(model, cfg.output_dir + "/auto_folding_config.json", hw_attrs)
+        extract_model_config_to_json(
+            model,
+            cfg.output_dir + "/auto_folding_config.json",
+            hw_attrs,
+            apply_to_subgraphs=True,
+        )
 
     else:
         print("No target_fps provided, skipping step_target_fps_parallelization.")
@@ -750,7 +760,7 @@ def step_apply_folding_config(model: ModelWrapper, cfg: DataflowBuildConfig):
         loop_model = loop_model.transform(GiveUniqueNodeNames(prefix=node.name + "_"))
         node_inst.set_nodeattr("body", loop_model.graph)
     if cfg.folding_config_file is not None:
-        model = model.transform(ApplyConfig(cfg.folding_config_file), apply_to_subgraphs=True)
+        model = model.transform(ApplyConfig(cfg.folding_config_file, apply_to_subgraphs=True))
     else:
         print("No folding config json provided, skipping step_apply_folding_config.")
 
@@ -1076,10 +1086,12 @@ def step_set_fifo_depths(model: ModelWrapper, cfg: DataflowBuildConfig):
         "OuterShuffle_hls"
     ):
         extract_model_config_consolidate_shuffles(
-            model, cfg.output_dir + "/final_hw_config.json", hw_attrs
+            model, cfg.output_dir + "/final_hw_config.json", hw_attrs, apply_to_subgraphs=True
         )
     else:
-        extract_model_config_to_json(model, cfg.output_dir + "/final_hw_config.json", hw_attrs)
+        extract_model_config_to_json(
+            model, cfg.output_dir + "/final_hw_config.json", hw_attrs, apply_to_subgraphs=True
+        )
 
     # perform FIFO splitting and shallow FIFO removal only after the final config
     # json file has been written. otherwise, since these transforms may add/remove

--- a/src/finn/transformation/fpgadataflow/floorplan.py
+++ b/src/finn/transformation/fpgadataflow/floorplan.py
@@ -66,7 +66,7 @@ class Floorplan(Transformation):
                 json.dump(self.user_floorplan, f, indent=4)
         else:
             model.set_metadata_prop("floorplan_json", self.user_floorplan)
-            model = model.transform(ApplyConfig(self.user_floorplan))
+            model = model.transform(ApplyConfig(self.user_floorplan, apply_to_subgraphs=True))
 
         try:
             default_slr = self.user_floorplan["Defaults"]["slr"][0]

--- a/src/finn/transformation/general.py
+++ b/src/finn/transformation/general.py
@@ -34,12 +34,26 @@ class ApplyConfig(Transformation):
         "Im2Col_0" : {"kernel_size" : 7}
         }
 
+    Note: ApplyConfig traverses subgraphs itself (using hierarchical config keys
+    of the form ``<parent_hier>_<attr_name>_<node_name>``, matching
+    finn.util.config.extract_model_config). This descent is controlled by the
+    ``apply_to_subgraphs`` constructor argument and defaults to False (top-level
+    only). Do NOT pass ``apply_to_subgraphs=True`` to ``ModelWrapper.transform``
+    for this transform - the generic mechanism re-enters each subgraph as a
+    standalone top-level model, which loses the hierarchical key context and
+    would look up nodes with the wrong (flat) keys.
     """
 
-    def __init__(self, config, node_filter=lambda x: True):
+    # Marker: this transform manages its own subgraph traversal (via the
+    # apply_to_subgraphs constructor argument). A guard in ModelWrapper.transform
+    # can check this marker to reject the generic apply_to_subgraphs=True path.
+    handles_subgraphs_internally = True
+
+    def __init__(self, config, node_filter=lambda x: True, apply_to_subgraphs=False):
         super().__init__()
         self.config = config
         self.node_filter = node_filter
+        self.apply_to_subgraphs = apply_to_subgraphs
         self.used_configurations = ["Defaults"]
         self.missing_configurations = []
         self.ignored_non_custom_configurations = []
@@ -97,16 +111,17 @@ class ApplyConfig(Transformation):
                 self.ignored_non_custom_configurations += [(config_key, node.op_type)]
 
             # Recursively handle nested subgraphs
-            for attr in node.attribute:
-                if attr.type == AttributeProto.GRAPH:
-                    # Build the subgraph hierarchy including the attribute name
-                    if subgraph_hier is None:
-                        new_hier = node.name
-                    else:
-                        new_hier = str(subgraph_hier) + "_" + node.name
-                    # Include the subgraph attribute name in the hierarchy
-                    new_hier = new_hier + "_" + attr.name
-                    self.configure_network(attr.g, model_config, subgraph_hier=new_hier)
+            if self.apply_to_subgraphs:
+                for attr in node.attribute:
+                    if attr.type == AttributeProto.GRAPH:
+                        # Build the subgraph hierarchy including the attribute name
+                        if subgraph_hier is None:
+                            new_hier = node.name
+                        else:
+                            new_hier = str(subgraph_hier) + "_" + node.name
+                        # Include the subgraph attribute name in the hierarchy
+                        new_hier = new_hier + "_" + attr.name
+                        self.configure_network(attr.g, model_config, subgraph_hier=new_hier)
 
     def apply(self, model):
         if isinstance(self.config, dict):

--- a/src/finn/util/config.py
+++ b/src/finn/util/config.py
@@ -20,14 +20,17 @@ from qonnx.custom_op.registry import getCustomOp, is_custom_op
 
 # update this code to handle export configs from subgraphs
 # where the subgraph is found in a node's attribute as a graph type
-def extract_model_config(model, subgraph_hier, attr_names_to_extract):
+def extract_model_config(model, subgraph_hier, attr_names_to_extract, apply_to_subgraphs=False):
     """Create a dictionary with layer name -> attribute mappings extracted from the
     model. The created dictionary can be later applied on a model with
-    qonnx.transform.general.ApplyConfig.
+    finn.transformation.general.ApplyConfig.
 
-    Nodes in subgraphs are prefixed with their parent hierarchy using '_' as separator.
-    For example, a node 'Conv_0' inside a subgraph of node 'IfNode_0' will be exported
-    as 'IfNode_0_Conv_0' in the config."""
+    When apply_to_subgraphs is True, nodes in subgraphs are also extracted and
+    prefixed with their parent hierarchy using '_' as separator. For example, a
+    node 'Conv_0' inside a subgraph of node 'IfNode_0' will be exported as
+    'IfNode_0_<attr>_Conv_0' in the config. This matches the hierarchical key
+    convention consumed by ApplyConfig(config, apply_to_subgraphs=True), so the
+    two form a symmetric export/import pair. Defaults to False (top-level only)."""
 
     cfg = dict()
     cfg["Defaults"] = dict()
@@ -46,18 +49,20 @@ def extract_model_config(model, subgraph_hier, attr_names_to_extract):
                     pass
 
         # Process node attributes - handle both subgraphs and extractable attributes
-        for attr in n.attribute:
-            if attr.type == onnx.AttributeProto.GRAPH:
-                # If the attribute is a graph, extract configs from the subgraph recursively
-                # Include the subgraph attribute name in the hierarchy
-                subgraph_hier_with_attr = new_hier + "_" + attr.name
-                cfg.update(
-                    extract_model_config(
-                        model.make_subgraph_modelwrapper(attr.g),
-                        subgraph_hier_with_attr,
-                        attr_names_to_extract,
+        if apply_to_subgraphs:
+            for attr in n.attribute:
+                if attr.type == onnx.AttributeProto.GRAPH:
+                    # If the attribute is a graph, extract configs from the subgraph
+                    # recursively. Include the subgraph attribute name in the hierarchy
+                    subgraph_hier_with_attr = new_hier + "_" + attr.name
+                    cfg.update(
+                        extract_model_config(
+                            model.make_subgraph_modelwrapper(attr.g),
+                            subgraph_hier_with_attr,
+                            attr_names_to_extract,
+                            apply_to_subgraphs=apply_to_subgraphs,
+                        )
                     )
-                )
 
         # Add the node's config if we extracted any attributes
         if is_custom and len(layer_dict) > 0:
@@ -66,24 +71,33 @@ def extract_model_config(model, subgraph_hier, attr_names_to_extract):
     return cfg
 
 
-def extract_model_config_to_json(model, json_filename, attr_names_to_extract):
+def extract_model_config_to_json(
+    model, json_filename, attr_names_to_extract, apply_to_subgraphs=False
+):
     """Create a json file with layer name -> attribute mappings extracted from the
     model. The created json file can be later applied on a model with
-    qonnx.transform.general.ApplyConfig."""
+    finn.transformation.general.ApplyConfig."""
 
     with open(json_filename, "w") as f:
         json.dump(
             extract_model_config(
-                model, subgraph_hier=None, attr_names_to_extract=attr_names_to_extract
+                model,
+                subgraph_hier=None,
+                attr_names_to_extract=attr_names_to_extract,
+                apply_to_subgraphs=apply_to_subgraphs,
             ),
             f,
             indent=2,
         )
 
 
-def extract_model_config_consolidate_shuffles(model, output_file, hw_attrs):
+def extract_model_config_consolidate_shuffles(
+    model, output_file, hw_attrs, apply_to_subgraphs=False
+):
     """Export flow that takes into consideration how Shuffle operations have been decomposed"""
-    extract_model_config_to_json(model, output_file, hw_attrs)
+    extract_model_config_to_json(
+        model, output_file, hw_attrs, apply_to_subgraphs=apply_to_subgraphs
+    )
 
     with open(output_file, "r") as f:
         config = json.load(f)

--- a/tests/util/test_config.py
+++ b/tests/util/test_config.py
@@ -145,7 +145,7 @@ def test_extract_model_config():
     attrs_to_extract = ["kernel_size", "stride", "pad_amount", "input_shape"]
 
     extracted_config = extract_model_config(
-        model, subgraph_hier=None, attr_names_to_extract=attrs_to_extract
+        model, subgraph_hier=None, attr_names_to_extract=attrs_to_extract, apply_to_subgraphs=True
     )
     assert extracted_config == expected_config, "Extracted config does not match expected config"
 
@@ -158,12 +158,12 @@ def test_roundtrip_export_import():
 
     # Extract config from model
     original_config = extract_model_config(
-        model, subgraph_hier=None, attr_names_to_extract=attrs_to_extract
+        model, subgraph_hier=None, attr_names_to_extract=attrs_to_extract, apply_to_subgraphs=True
     )
     # Save in json
     test_dir = make_build_dir("test_config_roundtrip_")
     config_json_file = os.path.join(test_dir, "original_config.json")
-    extract_model_config_to_json(model, config_json_file, attrs_to_extract)
+    extract_model_config_to_json(model, config_json_file, attrs_to_extract, apply_to_subgraphs=True)
 
     # Modify all Im2Col nodes to different values (recursively through subgraphs)
     def modify_all_im2col_nodes(graph_proto):
@@ -181,15 +181,15 @@ def test_roundtrip_export_import():
     modify_all_im2col_nodes(model.graph)
     # test that modification happened
     new_config = extract_model_config(
-        model, subgraph_hier=None, attr_names_to_extract=attrs_to_extract
+        model, subgraph_hier=None, attr_names_to_extract=attrs_to_extract, apply_to_subgraphs=True
     )
     assert new_config != original_config, "Config of nodes wasn't properly changed"
 
-    model = model.transform(ApplyConfig(config_json_file))
+    model = model.transform(ApplyConfig(config_json_file, apply_to_subgraphs=True))
 
     # Re-extract config and verify it matches original
     restored_config = extract_model_config(
-        model, subgraph_hier=None, attr_names_to_extract=attrs_to_extract
+        model, subgraph_hier=None, attr_names_to_extract=attrs_to_extract, apply_to_subgraphs=True
     )
     assert restored_config == original_config, "Config not properly restored after roundtrip"
 


### PR DESCRIPTION
### Summary
`ApplyConfig` always recursed into subgraphs, and `step_apply_folding_config` also drove it via the generic `transform(..., apply_to_subgraphs=True)`, so subgraph nodes were configured twice with conflicting (hierarchical vs. flat) key conventions, with no way to configure the top level only.

This makes subgraph descent explicit and opt-in on both sides of the round trip:
  - `ApplyConfig(config, apply_to_subgraphs=False)`: internal hierarchical-key recursion is now gated on this flag (default: top-level only).
  - `extract_model_config` (+ `_to_json` / `_consolidate_shuffles`) gain the same flag, keeping export/import symmetric.

`ApplyConfig` owns its traversal because it needs hierarchical keys the generic  mechanism can't provide, so it's marked `handles_subgraphs_internally = True`;  the guard in fastmachinelearning/qonnx#240 rejects the mistaken `transform(ApplyConfig(...), apply_to_subgraphs=True)` once the qonnx pin is bumped.

### Changes
  - `transformation/general.py`: `apply_to_subgraphs` arg (default `False`), `handles_subgraphs_internally` marker, gated recursion.
  - `util/config.py`: symmetric `apply_to_subgraphs` arg on the extract helpers.
  - `builder/build_dataflow_steps.py`: fixed the folding-config double-apply; preserved recursion at specialize-layers apply and template/auto/final extraction; non-auto-FIFO `ApplyConfig` is now top-level only.
  - `transformation/fpgadataflow/floorplan.py`: preserve recursion.
  - `tests/util/test_config.py`: subgraph tests opt in.
