### PR TITLE
Requant Enhancements for Decoupled Parameters and Custom Signedness of Outputs

### DIFF
--- a/finn-rtllib/requant/hdl/requant.sv
+++ b/finn-rtllib/requant/hdl/requant.sv
@@ -1,6 +1,8 @@
 /****************************************************************************
- * Copyright Advanced Micro Devices, Inc.
- * SPDX-License-Identifier: MIT
+ * Copyright (C) 2026, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  * @author	Thomas B. Preußer <thomas.preusser@amd.com>
  * @brief	Integer requantization from K to N bits by clip(round(x*scale+bias)).

--- a/finn-rtllib/requant/hdl/requant.sv
+++ b/finn-rtllib/requant/hdl/requant.sv
@@ -23,7 +23,9 @@ module requant #(
 	int unsigned  PE = 1,  // Vector parallelism, must divide C
 
 	shortreal     SCALES[PE][C/PE],
-	shortreal     BIASES[PE][C/PE]
+	shortreal     BIASES[PE][C/PE],
+
+	bit  SIGNED_OUT = 0  // 0: unsigned clip [0, 2^N-1], 1: signed clip [-2^(N-1), 2^(N-1)-1]
 )(
 	input	logic  clk,
 	input	logic  rst,
@@ -238,18 +240,16 @@ module requant #(
 		end
 
 		logic [N-1:0]  R4 = 'x;
-		if(1) begin : blkStage4
-			localparam int unsigned  TAP_SPAN = TAP_MINMAX.max - TAP_MINMAX.min;
+		localparam int unsigned  TAP_SPAN = TAP_MINMAX.max - TAP_MINMAX.min;
+		uwire  neg = P3[$left(P3)];
+		if(!SIGNED_OUT) begin : blkStage4Unsigned
 			uwire [TAP_SPAN + N-1:0]  win = P3[TAP_MINMAX.max+N-1 : TAP_MINMAX.min];
 			uwire [TAP_SPAN + N-1:0]  tap = win >> T3;
-			uwire  neg = P3[$left(P3)];
 			uwire  ovf =
 				(($left(P3)      > TAP_MINMAX.max+N)? |P3[$left(P3)-1:TAP_MINMAX.max+N] : 0) ||
 				((TAP_MINMAX.min < TAP_MINMAX.max  )? |tap[$left(tap):N] : 0);
 			always_ff @(posedge clk) begin
-				if(rst) begin
-					R4 <= 'x;
-				end
+				if(rst)  R4 <= 'x;
 				else begin
 					R4 <=
 						neg?  0 :
@@ -257,7 +257,18 @@ module requant #(
 						tap[N-1:0];
 				end
 			end
-		end : blkStage4
+		end : blkStage4Unsigned
+		else begin : blkStage4Signed
+			uwire signed [TAP_SPAN + N-1:0]  win = P3[TAP_MINMAX.max+N-1 : TAP_MINMAX.min];
+			uwire signed [TAP_SPAN + N-1:0]  tap = win >>> T3;
+			uwire  ovf =
+				(($left(P3)      > TAP_MINMAX.max+N-1)? |(P3[$left(P3)-1:TAP_MINMAX.max+N-1] ^ {($left(P3)-TAP_MINMAX.max-N+1){neg}}) : 0) ||
+				((TAP_MINMAX.min < TAP_MINMAX.max    )? ~(&tap[$left(tap):N-1]) && (|tap[$left(tap):N-1]) : 0);
+			always_ff @(posedge clk) begin
+				if(rst)  R4 <= 'x;
+				else     R4 <= ovf? {neg, {(N-1){!neg}}} : tap[N-1:0];
+			end
+		end : blkStage4Signed
 
 		assign	odat[pe] = R4;
 	end : genPE

--- a/finn-rtllib/requant/hdl/requant.sv
+++ b/finn-rtllib/requant/hdl/requant.sv
@@ -1,8 +1,6 @@
 /****************************************************************************
- * Copyright (C) 2026, Advanced Micro Devices, Inc.
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
+ * Copyright Advanced Micro Devices, Inc.
+ * SPDX-License-Identifier: MIT
  *
  * @author	Thomas B. Preußer <thomas.preusser@amd.com>
  * @brief	Integer requantization from K to N bits by clip(round(x*scale+bias)).
@@ -12,6 +10,26 @@
  *		round(x*scale+bias)
  *	The used single-precision floating-point scale and bias parameters are
  *	rotated round-robin through the list of C channel-specific values.
+ *
+ *	The floating-point scale and bias are decomposed into fixed-point
+ *	representations at elaboration time (derive_PARAMS). The scale
+ *	mantissa is captured in S_WIDTH-1 magnitude bits (+ sign). When
+ *	K <= DSP port width, S_WIDTH=25 and all 24 IEEE 754 significand
+ *	bits are preserved exactly. When K exceeds the DSP port width,
+ *	S_WIDTH < 25 and the mantissa is rounded to fewer bits.
+ *
+ *	The integer multiply (x * scale_fixed) is exact within the product
+ *	datapath — unlike a single-precision floating-point multiply, which
+ *	rounds its result to 24 significant bits. Consequently, for
+ *	non-power-of-two scales (dense mantissa fractions), the hardware
+ *	result may differ by ±1 from a single-precision evaluation of
+ *	round(scale*x+bias). Power-of-two scales (zero mantissa fraction)
+ *	produce bit-exact agreement with the floating-point specification.
+ *
+ *	Similarly, the bias mantissa is aligned into the product datapath
+ *	by shifting. When the bias exponent is small relative to the tap
+ *	position, right-shifting truncates least-significant mantissa bits,
+ *	which can also contribute to ±1 deviations at rounding boundaries.
  ***************************************************************************/
 
 module requant #(
@@ -36,6 +54,7 @@ module requant #(
 	output	logic [PE-1:0][N-1:0]  odat,
 	output	logic  ovld
 );
+`default_nettype none
 	localparam int unsigned  CF = C/PE;  // Channel fold
 
 	// Parameter Constraints Checking
@@ -148,7 +167,17 @@ module requant #(
 	endfunction : derive_PARAMS
 	localparam params_mat_t  PARAMS = derive_PARAMS();
 	initial begin
-		void'(derive_PARAMS());
+		for(int unsigned  pe = 0; pe < PE; pe++) begin
+			for(int unsigned  cf = 0; cf < CF; cf++) begin
+				automatic bit [31:0]  s = $shortrealtobits(SCALES[pe][cf]);
+				if(s[22:0] != 0 && 25 > MUL_WIDTHS.s) begin
+					// Dense mantissa with S_WIDTH < 25: check for actual bit loss
+					automatic bit [24:0]  sm = { 1'b1, s[0+:23], 1'b0 };
+					if(sm[0+:25-MUL_WIDTHS.s] != 0)
+						$warning("%m: SCALES[%0d][%0d] scale mantissa truncated (%0d to %0d bits).", pe, cf, 25, MUL_WIDTHS.s);
+				end
+			end
+		end
 	end
 	typedef struct {
 		int unsigned  min;
@@ -273,4 +302,5 @@ module requant #(
 		assign	odat[pe] = R4;
 	end : genPE
 
+`default_nettype wire
 endmodule : requant

--- a/finn-rtllib/requant/hdl/requant_axi.sv
+++ b/finn-rtllib/requant/hdl/requant_axi.sv
@@ -1,12 +1,10 @@
-/******************************************************************************
- * Copyright (C) 2026, Advanced Micro Devices, Inc.
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
+/****************************************************************************
+ * Copyright Advanced Micro Devices, Inc.
+ * SPDX-License-Identifier: MIT
  *
  * @author	Thomas B. Preußer <thomas.preusser@amd.com>
  * @brief	AXI stream wrapper for integer requantization.
- *****************************************************************************/
+ ***************************************************************************/
 
 module requant_axi #(
 	int unsigned  VERSION = 1,  // DSP Version
@@ -38,6 +36,7 @@ module requant_axi #(
 	output	logic  m_axis_tvalid,
 	output	logic [OUTPUT_STREAM_WIDTH-1:0]  m_axis_tdata
 );
+`default_nettype none
 	localparam int unsigned  CF = C/PE;  // Channel fold
 
 	uwire  rst = !ap_rst_n;
@@ -57,7 +56,7 @@ module requant_axi #(
 	uwire  have_cap = !Credit[$left(Credit)];
 	uwire  issue  = s_axis_tvalid && s_axis_tready;
 	uwire  settle = m_axis_tvalid && m_axis_tready;
-	always @(posedge ap_clk) begin
+	always_ff @(posedge ap_clk) begin
 		if(rst)  Credit <= CREDIT-1;
 		else     Credit <= Credit + (issue == settle? 0 : settle? 1 : -1);
 	end
@@ -103,4 +102,5 @@ module requant_axi #(
 	assign	m_axis_tvalid = q_ovld;
 	assign	m_axis_tdata = { {(OUTPUT_STREAM_WIDTH-PE*N){1'b0}}, q_odat };
 
+`default_nettype wire
 endmodule : requant_axi

--- a/finn-rtllib/requant/hdl/requant_axi.sv
+++ b/finn-rtllib/requant/hdl/requant_axi.sv
@@ -1,6 +1,8 @@
 /****************************************************************************
- * Copyright Advanced Micro Devices, Inc.
- * SPDX-License-Identifier: MIT
+ * Copyright (C) 2026, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  * @author	Thomas B. Preußer <thomas.preusser@amd.com>
  * @brief	AXI stream wrapper for integer requantization.

--- a/finn-rtllib/requant/hdl/requant_axi.sv
+++ b/finn-rtllib/requant/hdl/requant_axi.sv
@@ -19,6 +19,8 @@ module requant_axi #(
 	shortreal     SCALES[PE][C/PE],
 	shortreal     BIASES[PE][C/PE],
 
+	bit  SIGNED_OUT = 0,  // 0: unsigned clip [0, 2^N-1], 1: signed clip [-2^(N-1), 2^(N-1)-1]
+
 	localparam int unsigned  INPUT_STREAM_WIDTH = ((PE*K+7)/8)*8,
 	localparam int unsigned  OUTPUT_STREAM_WIDTH = ((PE*N+7)/8)*8
 )(
@@ -69,7 +71,8 @@ module requant_axi #(
 	requant #(
 		.VERSION(VERSION),
 		.K(K), .N(N), .C(C), .PE(PE),
-		.SCALES(SCALES), .BIASES(BIASES)
+		.SCALES(SCALES), .BIASES(BIASES),
+		.SIGNED_OUT(SIGNED_OUT)
 	) impl (
 		.clk(ap_clk), .rst,
 		.idat(core_idat), .ivld(issue),

--- a/finn-rtllib/requant/hdl/requant_axi_decoupled.sv
+++ b/finn-rtllib/requant/hdl/requant_axi_decoupled.sv
@@ -23,6 +23,8 @@ module requant_axi_decoupled #(
 	int unsigned  TAP_MIN,  // Worst-case minimum tap across all channels
 	int unsigned  TAP_MAX,  // Worst-case maximum tap across all channels
 
+	bit  SIGNED_OUT = 0,  // 0: unsigned clip [0, 2^N-1], 1: signed clip [-2^(N-1), 2^(N-1)-1]
+
 	// Derived multiplier operand widths (must match derive_MUL_WIDTHS)
 	localparam int unsigned  S_WIDTH = (K <= (VERSION==3? 24 : 18))? 25 :
 	                                    (VERSION==3? 24 : 18),
@@ -93,7 +95,8 @@ module requant_axi_decoupled #(
 	requant_decoupled #(
 		.VERSION(VERSION),
 		.K(K), .N(N), .C(C), .PE(PE),
-		.TAP_MIN(TAP_MIN), .TAP_MAX(TAP_MAX)
+		.TAP_MIN(TAP_MIN), .TAP_MAX(TAP_MAX),
+		.SIGNED_OUT(SIGNED_OUT)
 	) impl (
 		.clk(ap_clk), .rst,
 		.idat(core_idat), .ivld(issue),

--- a/finn-rtllib/requant/hdl/requant_axi_decoupled.sv
+++ b/finn-rtllib/requant/hdl/requant_axi_decoupled.sv
@@ -1,0 +1,137 @@
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: BSD-3-Clause
+/******************************************************************************
+ * @brief	AXI stream wrapper for integer requantization with decoupled
+ *		(streamed) scale/bias parameters.
+ *
+ * @description
+ *	Like requant_axi.sv but the scale/bias are not embedded as module
+ *	parameters. Instead two additional AXI-Stream slave ports deliver the
+ *	fixed-point parameter words (one word per lane-parallel compute beat),
+ *	produced by two memstreams. A compute beat is only issued when the input
+ *	data and both parameter words are simultaneously available.
+ *****************************************************************************/
+
+module requant_axi_decoupled #(
+	int unsigned  VERSION = 1,  // DSP Version
+	int unsigned  K,  // Input Precision
+	int unsigned  N,  // Output Precision
+
+	int unsigned  C,  // Channel count
+	int unsigned  PE = 1,  // parallel processing elements, requires C = k*PE
+
+	int unsigned  TAP_MIN,  // Worst-case minimum tap across all channels
+	int unsigned  TAP_MAX,  // Worst-case maximum tap across all channels
+
+	// Derived multiplier operand widths (must match derive_MUL_WIDTHS)
+	localparam int unsigned  S_WIDTH = (K <= (VERSION==3? 24 : 18))? 25 :
+	                                    (VERSION==3? 24 : 18),
+	localparam int unsigned  X_WIDTH = (K <= (VERSION==3? 24 : 18))? K :
+	                                    ((VERSION==1? 25 : 27) < K? (VERSION==1? 25 : 27) : K),
+	localparam int unsigned  BIAS_W  = S_WIDTH + X_WIDTH,
+	localparam int unsigned  TAP_RANGE = TAP_MAX - TAP_MIN + 1,
+	localparam int unsigned  TAP_BITS  = (TAP_RANGE > 1)? $clog2(TAP_RANGE) : 1,
+	localparam int unsigned  SCALE_LANE_W = S_WIDTH + TAP_BITS,
+
+	localparam int unsigned  INPUT_STREAM_WIDTH  = ((PE*K+7)/8)*8,
+	localparam int unsigned  OUTPUT_STREAM_WIDTH = ((PE*N+7)/8)*8,
+	localparam int unsigned  SCALE_STREAM_WIDTH  = ((PE*SCALE_LANE_W+7)/8)*8,
+	localparam int unsigned  BIAS_STREAM_WIDTH   = ((PE*BIAS_W+7)/8)*8
+)(
+	//- Global Control ------------------
+	input	logic  ap_clk,
+	input	logic  ap_rst_n,
+
+	//- AXI Stream - Data Input ---------
+	output	logic  s_axis_tready,
+	input	logic  s_axis_tvalid,
+	input	logic [INPUT_STREAM_WIDTH-1:0]  s_axis_tdata,
+
+	//- AXI Stream - Scale Param Input --
+	output	logic  s_scale_tready,
+	input	logic  s_scale_tvalid,
+	input	logic [SCALE_STREAM_WIDTH-1:0]  s_scale_tdata,
+
+	//- AXI Stream - Bias Param Input ---
+	output	logic  s_bias_tready,
+	input	logic  s_bias_tvalid,
+	input	logic [BIAS_STREAM_WIDTH-1:0]  s_bias_tdata,
+
+	//- AXI Stream - Output -------------
+	input	logic  m_axis_tready,
+	output	logic  m_axis_tvalid,
+	output	logic [OUTPUT_STREAM_WIDTH-1:0]  m_axis_tdata
+);
+	localparam int unsigned  CF = C/PE;  // Channel fold
+
+	uwire  rst = !ap_rst_n;
+
+	// Parameter Constraints Checking
+	initial begin
+		if(CF*PE != C) begin
+			$error("%m: Parallelism PE=%0d does not divide channel count C=%0d.", PE, C);
+			$finish;
+		end
+	end
+
+	//-----------------------------------------------------------------------
+	// Credit-based Input Admission
+	localparam int unsigned  CREDIT = 7;
+	logic signed [$clog2(CREDIT):0]  Credit = CREDIT-1; // CREDIT-1, ..., 1, 0, -1
+	uwire  have_cap = !Credit[$left(Credit)];
+
+	// Synchronized join: fire only when data and both param words are present
+	uwire  params_vld = s_scale_tvalid && s_bias_tvalid;
+	uwire  issue  = have_cap && s_axis_tvalid && params_vld;
+	uwire  settle = m_axis_tvalid && m_axis_tready;
+	always @(posedge ap_clk) begin
+		if(rst)  Credit <= CREDIT-1;
+		else     Credit <= Credit + (issue == settle? 0 : settle? 1 : -1);
+	end
+	assign	s_axis_tready  = issue;
+	assign	s_scale_tready = issue;
+	assign	s_bias_tready  = issue;
+
+	//-----------------------------------------------------------------------
+	// Free-running decoupled requant compute core
+	uwire signed [PE-1:0][K-1:0]  core_idat = s_axis_tdata[0+:PE*K];
+	uwire [PE-1:0][SCALE_LANE_W-1:0]  core_sdat = s_scale_tdata[0+:PE*SCALE_LANE_W];
+	uwire [PE-1:0][BIAS_W-1:0]  core_bdat = s_bias_tdata[0+:PE*BIAS_W];
+	uwire [PE-1:0][N-1:0]  core_odat;
+	uwire  core_ovld;
+	requant_decoupled #(
+		.VERSION(VERSION),
+		.K(K), .N(N), .C(C), .PE(PE),
+		.TAP_MIN(TAP_MIN), .TAP_MAX(TAP_MAX)
+	) impl (
+		.clk(ap_clk), .rst,
+		.idat(core_idat), .ivld(issue),
+		.sdat(core_sdat), .bdat(core_bdat),
+		.odat(core_odat), .ovld(core_ovld)
+	);
+
+	//-----------------------------------------------------------------------
+	// Output AXI stream queue
+	uwire [PE-1:0][N-1:0]  q_odat;
+	uwire  q_ovld;
+	uwire  q_irdy;
+	always_ff @(posedge ap_clk) begin
+		assert(!core_ovld || q_irdy) else begin
+			$error("%m: Overrrun of output queue.");
+			$stop;
+		end
+	end
+
+	queue #(
+		.DATA_WIDTH(PE*N),
+		.ELASTICITY(CREDIT)
+	) outq (
+		.clk(ap_clk), .rst,
+		.idat(core_odat), .ivld(core_ovld), .irdy(q_irdy),
+		.odat(q_odat), .ovld(q_ovld), .ordy(m_axis_tready)
+	);
+
+	assign	m_axis_tvalid = q_ovld;
+	assign	m_axis_tdata = { {(OUTPUT_STREAM_WIDTH-PE*N){1'b0}}, q_odat };
+
+endmodule : requant_axi_decoupled

--- a/finn-rtllib/requant/hdl/requant_axi_decoupled.sv
+++ b/finn-rtllib/requant/hdl/requant_axi_decoupled.sv
@@ -2,14 +2,14 @@
 // SPDX-License-Identifier: BSD-3-Clause
 /******************************************************************************
  * @brief	AXI stream wrapper for integer requantization with decoupled
- *		(streamed) scale/bias parameters.
+ *		(streamed) parameters.
  *
  * @description
  *	Like requant_axi.sv but the scale/bias are not embedded as module
- *	parameters. Instead two additional AXI-Stream slave ports deliver the
- *	fixed-point parameter words (one word per lane-parallel compute beat),
- *	produced by two memstreams. A compute beat is only issued when the input
- *	data and both parameter words are simultaneously available.
+ *	parameters. Instead a single additional AXI-Stream slave port delivers
+ *	the packed parameter words (one word per lane-parallel compute beat),
+ *	produced by a memstream. A compute beat is only issued when the input
+ *	data and the parameter word are simultaneously available.
  *****************************************************************************/
 
 module requant_axi_decoupled #(
@@ -28,15 +28,14 @@ module requant_axi_decoupled #(
 	                                    (VERSION==3? 24 : 18),
 	localparam int unsigned  X_WIDTH = (K <= (VERSION==3? 24 : 18))? K :
 	                                    ((VERSION==1? 25 : 27) < K? (VERSION==1? 25 : 27) : K),
-	localparam int unsigned  BIAS_W  = S_WIDTH + X_WIDTH,
+	localparam int unsigned  BIAS_WIDTH  = S_WIDTH + X_WIDTH,
 	localparam int unsigned  TAP_RANGE = TAP_MAX - TAP_MIN + 1,
-	localparam int unsigned  TAP_BITS  = (TAP_RANGE > 1)? $clog2(TAP_RANGE) : 1,
-	localparam int unsigned  SCALE_LANE_W = S_WIDTH + TAP_BITS,
+	localparam int unsigned  TAP_WIDTH  = (TAP_RANGE > 1)? $clog2(TAP_RANGE) : 1,
+	localparam int unsigned  PARAMS_LANE_WIDTH = S_WIDTH + TAP_WIDTH + BIAS_WIDTH,
 
 	localparam int unsigned  INPUT_STREAM_WIDTH  = ((PE*K+7)/8)*8,
 	localparam int unsigned  OUTPUT_STREAM_WIDTH = ((PE*N+7)/8)*8,
-	localparam int unsigned  SCALE_STREAM_WIDTH  = ((PE*SCALE_LANE_W+7)/8)*8,
-	localparam int unsigned  BIAS_STREAM_WIDTH   = ((PE*BIAS_W+7)/8)*8
+	localparam int unsigned  PARAMS_STREAM_WIDTH = ((PE*PARAMS_LANE_WIDTH+7)/8)*8
 )(
 	//- Global Control ------------------
 	input	logic  ap_clk,
@@ -47,15 +46,10 @@ module requant_axi_decoupled #(
 	input	logic  s_axis_tvalid,
 	input	logic [INPUT_STREAM_WIDTH-1:0]  s_axis_tdata,
 
-	//- AXI Stream - Scale Param Input --
-	output	logic  s_scale_tready,
-	input	logic  s_scale_tvalid,
-	input	logic [SCALE_STREAM_WIDTH-1:0]  s_scale_tdata,
-
-	//- AXI Stream - Bias Param Input ---
-	output	logic  s_bias_tready,
-	input	logic  s_bias_tvalid,
-	input	logic [BIAS_STREAM_WIDTH-1:0]  s_bias_tdata,
+	//- AXI Stream - Params Input -------
+	output	logic  s_params_tready,
+	input	logic  s_params_tvalid,
+	input	logic [PARAMS_STREAM_WIDTH-1:0]  s_params_tdata,
 
 	//- AXI Stream - Output -------------
 	input	logic  m_axis_tready,
@@ -80,23 +74,20 @@ module requant_axi_decoupled #(
 	logic signed [$clog2(CREDIT):0]  Credit = CREDIT-1; // CREDIT-1, ..., 1, 0, -1
 	uwire  have_cap = !Credit[$left(Credit)];
 
-	// Synchronized join: fire only when data and both param words are present
-	uwire  params_vld = s_scale_tvalid && s_bias_tvalid;
-	uwire  issue  = have_cap && s_axis_tvalid && params_vld;
+	// Synchronized join: fire only when data and params are present
+	uwire  issue  = have_cap && s_axis_tvalid && s_params_tvalid;
 	uwire  settle = m_axis_tvalid && m_axis_tready;
 	always @(posedge ap_clk) begin
 		if(rst)  Credit <= CREDIT-1;
 		else     Credit <= Credit + (issue == settle? 0 : settle? 1 : -1);
 	end
-	assign	s_axis_tready  = issue;
-	assign	s_scale_tready = issue;
-	assign	s_bias_tready  = issue;
+	assign	s_axis_tready   = issue;
+	assign	s_params_tready = issue;
 
 	//-----------------------------------------------------------------------
 	// Free-running decoupled requant compute core
 	uwire signed [PE-1:0][K-1:0]  core_idat = s_axis_tdata[0+:PE*K];
-	uwire [PE-1:0][SCALE_LANE_W-1:0]  core_sdat = s_scale_tdata[0+:PE*SCALE_LANE_W];
-	uwire [PE-1:0][BIAS_W-1:0]  core_bdat = s_bias_tdata[0+:PE*BIAS_W];
+	uwire [PE-1:0][PARAMS_LANE_WIDTH-1:0]  core_pdat = s_params_tdata[0+:PE*PARAMS_LANE_WIDTH];
 	uwire [PE-1:0][N-1:0]  core_odat;
 	uwire  core_ovld;
 	requant_decoupled #(
@@ -106,7 +97,7 @@ module requant_axi_decoupled #(
 	) impl (
 		.clk(ap_clk), .rst,
 		.idat(core_idat), .ivld(issue),
-		.sdat(core_sdat), .bdat(core_bdat),
+		.pdat(core_pdat),
 		.odat(core_odat), .ovld(core_ovld)
 	);
 

--- a/finn-rtllib/requant/hdl/requant_axi_decoupled.sv
+++ b/finn-rtllib/requant/hdl/requant_axi_decoupled.sv
@@ -1,6 +1,8 @@
 /****************************************************************************
- * Copyright Advanced Micro Devices, Inc.
- * SPDX-License-Identifier: MIT
+ * Copyright (C) 2026, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  * @author	Thomas B. Preußer <thomas.preusser@amd.com>
  * @brief	AXI stream wrapper for integer requantization with decoupled

--- a/finn-rtllib/requant/hdl/requant_axi_decoupled.sv
+++ b/finn-rtllib/requant/hdl/requant_axi_decoupled.sv
@@ -1,6 +1,8 @@
-// Copyright Advanced Micro Devices, Inc.
-// SPDX-License-Identifier: BSD-3-Clause
-/******************************************************************************
+/****************************************************************************
+ * Copyright Advanced Micro Devices, Inc.
+ * SPDX-License-Identifier: MIT
+ *
+ * @author	Thomas B. Preußer <thomas.preusser@amd.com>
  * @brief	AXI stream wrapper for integer requantization with decoupled
  *		(streamed) parameters.
  *
@@ -10,7 +12,7 @@
  *	the packed parameter words (one word per lane-parallel compute beat),
  *	produced by a memstream. A compute beat is only issued when the input
  *	data and the parameter word are simultaneously available.
- *****************************************************************************/
+ ***************************************************************************/
 
 module requant_axi_decoupled #(
 	int unsigned  VERSION = 1,  // DSP Version
@@ -58,6 +60,7 @@ module requant_axi_decoupled #(
 	output	logic  m_axis_tvalid,
 	output	logic [OUTPUT_STREAM_WIDTH-1:0]  m_axis_tdata
 );
+`default_nettype none
 	localparam int unsigned  CF = C/PE;  // Channel fold
 
 	uwire  rst = !ap_rst_n;
@@ -79,7 +82,7 @@ module requant_axi_decoupled #(
 	// Synchronized join: fire only when data and params are present
 	uwire  issue  = have_cap && s_axis_tvalid && s_params_tvalid;
 	uwire  settle = m_axis_tvalid && m_axis_tready;
-	always @(posedge ap_clk) begin
+	always_ff @(posedge ap_clk) begin
 		if(rst)  Credit <= CREDIT-1;
 		else     Credit <= Credit + (issue == settle? 0 : settle? 1 : -1);
 	end
@@ -128,4 +131,5 @@ module requant_axi_decoupled #(
 	assign	m_axis_tvalid = q_ovld;
 	assign	m_axis_tdata = { {(OUTPUT_STREAM_WIDTH-PE*N){1'b0}}, q_odat };
 
+`default_nettype wire
 endmodule : requant_axi_decoupled

--- a/finn-rtllib/requant/hdl/requant_decoupled.sv
+++ b/finn-rtllib/requant/hdl/requant_decoupled.sv
@@ -1,6 +1,8 @@
 /****************************************************************************
- * Copyright Advanced Micro Devices, Inc.
- * SPDX-License-Identifier: MIT
+ * Copyright (C) 2026, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  * @author	Thomas B. Preußer <thomas.preusser@amd.com>
  * @brief	Integer requantization core with decoupled (streamed) parameters.

--- a/finn-rtllib/requant/hdl/requant_decoupled.sv
+++ b/finn-rtllib/requant/hdl/requant_decoupled.sv
@@ -1,6 +1,8 @@
-// Copyright Advanced Micro Devices, Inc.
-// SPDX-License-Identifier: BSD-3-Clause
 /****************************************************************************
+ * Copyright Advanced Micro Devices, Inc.
+ * SPDX-License-Identifier: MIT
+ *
+ * @author	Thomas B. Preußer <thomas.preusser@amd.com>
  * @brief	Integer requantization core with decoupled (streamed) parameters.
  *
  * @description
@@ -12,16 +14,13 @@
  *		- SCALE [S_WIDTH]     — signed scale mantissa
  *		- T     [TAP_WIDTH]   — tap - TAP_MIN (unsigned)
  *		- BIAS  [BIAS_WIDTH]  — signed bias (round constant folded in)
- *	The Python codegen (Requant.decompose_params) performs the float32 ->
- *	fixed-point decomposition that requant.sv does at elaboration time via
- *	derive_PARAMS(). The datapath here is otherwise identical to requant.sv.
  *
- *	The parameter words are expected to arrive in lockstep with the input
- *	beats, cycling through the CF channel-fold entries in order (0..CF-1).
- *	The memstream feeding these ports provides exactly this ordering. The
- *	Stage-4 output window is sized from the worst-case TAP_MIN/TAP_MAX span
- *	(computed in Python) rather than the per-PE derive_TAP_MINMAX() used in the
- *	embedded core, because the individual taps are not known at elaboration.
+ *	The fixed-point precision considerations documented in requant.sv apply
+ *	equally here: the exact integer multiply may produce results differing
+ *	by ±1 from a single-precision floating-point evaluation of
+ *	round(scale*x+bias) when the scale has a dense (non-power-of-two)
+ *	mantissa. The external parameter decomposition feeding the pdat stream
+ *	must follow the same fixed-point format as requant.sv::derive_PARAMS.
  ***************************************************************************/
 
 module requant_decoupled #(
@@ -61,6 +60,7 @@ module requant_decoupled #(
 	output	logic [PE-1:0][N-1:0]  odat,
 	output	logic  ovld
 );
+`default_nettype none
 	localparam int unsigned  CF = C/PE;  // Channel fold
 
 	// Parameter Constraints Checking
@@ -173,4 +173,5 @@ module requant_decoupled #(
 		assign	odat[pe] = R4;
 	end : genPE
 
+`default_nettype wire
 endmodule : requant_decoupled

--- a/finn-rtllib/requant/hdl/requant_decoupled.sv
+++ b/finn-rtllib/requant/hdl/requant_decoupled.sv
@@ -7,12 +7,11 @@
  *	Decoupled variant of the requant core. Instead of embedding the
  *	single-precision scale/bias as compile-time module parameters (which are
  *	constant-folded into fixed-point in requant.sv), this variant receives the
- *	*already decomposed* fixed-point parameters through two streams, one word
- *	per compute beat:
- *		- scale stream: per lane { T[TAP_BITS], SCALE[S_WIDTH] }
- *		    SCALE is the signed scale mantissa, T = tap - TAP_MIN.
- *		- bias  stream: per lane { BIAS[S_WIDTH+X_WIDTH] }
- *		    BIAS is the aligned signed bias (round constant folded in).
+ *	*already decomposed* fixed-point parameters through a single stream, one
+ *	word per compute beat.  Each PE lane carries a packed struct (LSB to MSB):
+ *		- SCALE [S_WIDTH]     — signed scale mantissa
+ *		- T     [TAP_WIDTH]   — tap - TAP_MIN (unsigned)
+ *		- BIAS  [BIAS_WIDTH]  — signed bias (round constant folded in)
  *	The Python codegen (Requant.decompose_params) performs the float32 ->
  *	fixed-point decomposition that requant.sv does at elaboration time via
  *	derive_PARAMS(). The datapath here is otherwise identical to requant.sv.
@@ -41,10 +40,10 @@ module requant_decoupled #(
 	                                    (VERSION==3? 24 : 18),
 	localparam int unsigned  X_WIDTH = (K <= (VERSION==3? 24 : 18))? K :
 	                                    ((VERSION==1? 25 : 27) < K? (VERSION==1? 25 : 27) : K),
-	localparam int unsigned  BIAS_W  = S_WIDTH + X_WIDTH,
+	localparam int unsigned  BIAS_WIDTH  = S_WIDTH + X_WIDTH,
 	localparam int unsigned  TAP_RANGE = TAP_MAX - TAP_MIN + 1,
-	localparam int unsigned  TAP_BITS  = (TAP_RANGE > 1)? $clog2(TAP_RANGE) : 1,
-	localparam int unsigned  SCALE_LANE_W = S_WIDTH + TAP_BITS
+	localparam int unsigned  TAP_WIDTH  = (TAP_RANGE > 1)? $clog2(TAP_RANGE) : 1,
+	localparam int unsigned  PARAMS_LANE_WIDTH = S_WIDTH + TAP_WIDTH + BIAS_WIDTH
 )(
 	input	logic  clk,
 	input	logic  rst,
@@ -53,10 +52,8 @@ module requant_decoupled #(
 	input	logic signed [PE-1:0][K-1:0]  idat,
 	input	logic  ivld,
 
-	// Scale parameter stream (per lane: { T, SCALE })
-	input	logic [PE-1:0][SCALE_LANE_W-1:0]  sdat,
-	// Bias parameter stream (per lane: BIAS)
-	input	logic [PE-1:0][BIAS_W-1:0]  bdat,
+	// Parameter stream (per lane: { BIAS, T, SCALE })
+	input	logic [PE-1:0][PARAMS_LANE_WIDTH-1:0]  pdat,
 
 	// Output data stream
 	output	logic [PE-1:0][N-1:0]  odat,
@@ -86,12 +83,12 @@ module requant_decoupled #(
 
 	// Instantiate individual compute lanes
 	for(genvar  pe = 0; pe < PE; pe++) begin : genPE
-		typedef logic [TAP_BITS-1:0]  tap_t;
+		typedef logic [TAP_WIDTH-1:0]  tap_t;
 
 		//- Stage #1: sample input + streamed parameters
 		logic signed [X_WIDTH-1:0]  X1 = 'x;
 		logic signed [S_WIDTH-1:0]  S1 = 'x;
-		logic signed [BIAS_W -1:0]  B1 = 'x;
+		logic signed [BIAS_WIDTH -1:0]  B1 = 'x;
 		tap_t  T1 = 'x;
 		always_ff @(posedge clk) begin
 			if(rst) begin
@@ -102,15 +99,15 @@ module requant_decoupled #(
 			end
 			else begin
 				X1 <= K > X_WIDTH? idat[pe][K-X_WIDTH+:X_WIDTH] : idat[pe];
-				S1 <= $signed(sdat[pe][0+:S_WIDTH]);
-				T1 <= sdat[pe][S_WIDTH+:TAP_BITS];
-				B1 <= $signed(bdat[pe][0+:BIAS_W]);
+				S1 <= $signed(pdat[pe][0+:S_WIDTH]);
+				T1 <= pdat[pe][S_WIDTH+:TAP_WIDTH];
+				B1 <= $signed(pdat[pe][S_WIDTH+TAP_WIDTH+:BIAS_WIDTH]);
 			end
 		end
 
 		//- Stage #2: multiply
-		logic signed [BIAS_W-1:0]  M2 = 'x;
-		logic signed [BIAS_W-1:0]  B2 = 'x;
+		logic signed [BIAS_WIDTH-1:0]  M2 = 'x;
+		logic signed [BIAS_WIDTH-1:0]  B2 = 'x;
 		tap_t  T2 = 'x;
 		always_ff @(posedge clk) begin
 			if(rst) begin
@@ -126,7 +123,7 @@ module requant_decoupled #(
 		end
 
 		//- Stage #3: add bias
-		logic signed [BIAS_W:0]  P3 = 'x;
+		logic signed [BIAS_WIDTH:0]  P3 = 'x;
 		tap_t  T3 = 'x;
 		always_ff @(posedge clk) begin
 			if(rst) begin

--- a/finn-rtllib/requant/hdl/requant_decoupled.sv
+++ b/finn-rtllib/requant/hdl/requant_decoupled.sv
@@ -1,0 +1,168 @@
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: BSD-3-Clause
+/****************************************************************************
+ * @brief	Integer requantization core with decoupled (streamed) parameters.
+ *
+ * @description
+ *	Decoupled variant of the requant core. Instead of embedding the
+ *	single-precision scale/bias as compile-time module parameters (which are
+ *	constant-folded into fixed-point in requant.sv), this variant receives the
+ *	*already decomposed* fixed-point parameters through two streams, one word
+ *	per compute beat:
+ *		- scale stream: per lane { T[TAP_BITS], SCALE[S_WIDTH] }
+ *		    SCALE is the signed scale mantissa, T = tap - TAP_MIN.
+ *		- bias  stream: per lane { BIAS[S_WIDTH+X_WIDTH] }
+ *		    BIAS is the aligned signed bias (round constant folded in).
+ *	The Python codegen (Requant.decompose_params) performs the float32 ->
+ *	fixed-point decomposition that requant.sv does at elaboration time via
+ *	derive_PARAMS(). The datapath here is otherwise identical to requant.sv.
+ *
+ *	The parameter words are expected to arrive in lockstep with the input
+ *	beats, cycling through the CF channel-fold entries in order (0..CF-1).
+ *	The memstream feeding these ports provides exactly this ordering. The
+ *	Stage-4 output window is sized from the worst-case TAP_MIN/TAP_MAX span
+ *	(computed in Python) rather than the per-PE derive_TAP_MINMAX() used in the
+ *	embedded core, because the individual taps are not known at elaboration.
+ ***************************************************************************/
+
+module requant_decoupled #(
+	int unsigned  VERSION = 1,  // DSP Version
+	int unsigned  K,  // Input Precision
+	int unsigned  N,  // Output Precision
+
+	int unsigned  C,       // Channel count
+	int unsigned  PE = 1,  // Vector parallelism, must divide C
+
+	int unsigned  TAP_MIN,  // Worst-case minimum tap across all channels
+	int unsigned  TAP_MAX,  // Worst-case maximum tap across all channels
+
+	// Derived multiplier operand widths (must match derive_MUL_WIDTHS)
+	localparam int unsigned  S_WIDTH = (K <= (VERSION==3? 24 : 18))? 25 :
+	                                    (VERSION==3? 24 : 18),
+	localparam int unsigned  X_WIDTH = (K <= (VERSION==3? 24 : 18))? K :
+	                                    ((VERSION==1? 25 : 27) < K? (VERSION==1? 25 : 27) : K),
+	localparam int unsigned  BIAS_W  = S_WIDTH + X_WIDTH,
+	localparam int unsigned  TAP_RANGE = TAP_MAX - TAP_MIN + 1,
+	localparam int unsigned  TAP_BITS  = (TAP_RANGE > 1)? $clog2(TAP_RANGE) : 1,
+	localparam int unsigned  SCALE_LANE_W = S_WIDTH + TAP_BITS
+)(
+	input	logic  clk,
+	input	logic  rst,
+
+	// Input data stream lane-packed
+	input	logic signed [PE-1:0][K-1:0]  idat,
+	input	logic  ivld,
+
+	// Scale parameter stream (per lane: { T, SCALE })
+	input	logic [PE-1:0][SCALE_LANE_W-1:0]  sdat,
+	// Bias parameter stream (per lane: BIAS)
+	input	logic [PE-1:0][BIAS_W-1:0]  bdat,
+
+	// Output data stream
+	output	logic [PE-1:0][N-1:0]  odat,
+	output	logic  ovld
+);
+	localparam int unsigned  CF = C/PE;  // Channel fold
+
+	// Parameter Constraints Checking
+	initial begin
+		if(CF*PE != C) begin
+			$error("%m: Parallelism PE=%0d does not divide channel count C=%0d.", PE, C);
+			$finish;
+		end
+		if(TAP_MAX < TAP_MIN) begin
+			$error("%m: TAP_MAX=%0d smaller than TAP_MIN=%0d.", TAP_MAX, TAP_MIN);
+			$finish;
+		end
+	end
+
+	// Global valid flag forwarding (4 pipeline stages, matches requant.sv)
+	logic  Vld[4] = '{ default: 0 };
+	always_ff @(posedge clk) begin
+		if(rst)  Vld <= '{ default: 0 };
+		else     Vld <= { ivld, Vld[0:2] };
+	end
+	assign	ovld = Vld[3];
+
+	// Instantiate individual compute lanes
+	for(genvar  pe = 0; pe < PE; pe++) begin : genPE
+		typedef logic [TAP_BITS-1:0]  tap_t;
+
+		//- Stage #1: sample input + streamed parameters
+		logic signed [X_WIDTH-1:0]  X1 = 'x;
+		logic signed [S_WIDTH-1:0]  S1 = 'x;
+		logic signed [BIAS_W -1:0]  B1 = 'x;
+		tap_t  T1 = 'x;
+		always_ff @(posedge clk) begin
+			if(rst) begin
+				X1 <= 'x;
+				S1 <= 'x;
+				B1 <= 'x;
+				T1 <= 'x;
+			end
+			else begin
+				X1 <= K > X_WIDTH? idat[pe][K-X_WIDTH+:X_WIDTH] : idat[pe];
+				S1 <= $signed(sdat[pe][0+:S_WIDTH]);
+				T1 <= sdat[pe][S_WIDTH+:TAP_BITS];
+				B1 <= $signed(bdat[pe][0+:BIAS_W]);
+			end
+		end
+
+		//- Stage #2: multiply
+		logic signed [BIAS_W-1:0]  M2 = 'x;
+		logic signed [BIAS_W-1:0]  B2 = 'x;
+		tap_t  T2 = 'x;
+		always_ff @(posedge clk) begin
+			if(rst) begin
+				M2 <= 'x;
+				B2 <= 'x;
+				T2 <= 'x;
+			end
+			else begin
+				M2 <= X1 * S1;
+				B2 <= B1;
+				T2 <= T1;
+			end
+		end
+
+		//- Stage #3: add bias
+		logic signed [BIAS_W:0]  P3 = 'x;
+		tap_t  T3 = 'x;
+		always_ff @(posedge clk) begin
+			if(rst) begin
+				P3 <= 'x;
+				T3 <= 'x;
+			end
+			else begin
+				P3 <= M2 + B2;
+				T3 <= T2;
+			end
+		end
+
+		//- Stage #4: window extract, shift, clip (window sized worst-case)
+		logic [N-1:0]  R4 = 'x;
+		if(1) begin : blkStage4
+			localparam int unsigned  TAP_SPAN = TAP_MAX - TAP_MIN;
+			uwire [TAP_SPAN + N-1:0]  win = P3[TAP_MAX+N-1 : TAP_MIN];
+			uwire [TAP_SPAN + N-1:0]  tap = win >> T3;
+			uwire  neg = P3[$left(P3)];
+			uwire  ovf =
+				(($left(P3)  > TAP_MAX+N)? |P3[$left(P3)-1:TAP_MAX+N] : 0) ||
+				((TAP_MIN    < TAP_MAX  )? |tap[$left(tap):N] : 0);
+			always_ff @(posedge clk) begin
+				if(rst) begin
+					R4 <= 'x;
+				end
+				else begin
+					R4 <=
+						neg?  0 :
+						ovf? '1 :
+						tap[N-1:0];
+				end
+			end
+		end : blkStage4
+
+		assign	odat[pe] = R4;
+	end : genPE
+
+endmodule : requant_decoupled

--- a/finn-rtllib/requant/hdl/requant_decoupled.sv
+++ b/finn-rtllib/requant/hdl/requant_decoupled.sv
@@ -35,6 +35,8 @@ module requant_decoupled #(
 	int unsigned  TAP_MIN,  // Worst-case minimum tap across all channels
 	int unsigned  TAP_MAX,  // Worst-case maximum tap across all channels
 
+	bit  SIGNED_OUT = 0,  // 0: unsigned clip [0, 2^N-1], 1: signed clip [-2^(N-1), 2^(N-1)-1]
+
 	// Derived multiplier operand widths (must match derive_MUL_WIDTHS)
 	localparam int unsigned  S_WIDTH = (K <= (VERSION==3? 24 : 18))? 25 :
 	                                    (VERSION==3? 24 : 18),
@@ -138,18 +140,16 @@ module requant_decoupled #(
 
 		//- Stage #4: window extract, shift, clip (window sized worst-case)
 		logic [N-1:0]  R4 = 'x;
-		if(1) begin : blkStage4
-			localparam int unsigned  TAP_SPAN = TAP_MAX - TAP_MIN;
+		localparam int unsigned  TAP_SPAN = TAP_MAX - TAP_MIN;
+		uwire  neg = P3[$left(P3)];
+		if(!SIGNED_OUT) begin : blkStage4Unsigned
 			uwire [TAP_SPAN + N-1:0]  win = P3[TAP_MAX+N-1 : TAP_MIN];
 			uwire [TAP_SPAN + N-1:0]  tap = win >> T3;
-			uwire  neg = P3[$left(P3)];
 			uwire  ovf =
 				(($left(P3)  > TAP_MAX+N)? |P3[$left(P3)-1:TAP_MAX+N] : 0) ||
 				((TAP_MIN    < TAP_MAX  )? |tap[$left(tap):N] : 0);
 			always_ff @(posedge clk) begin
-				if(rst) begin
-					R4 <= 'x;
-				end
+				if(rst)  R4 <= 'x;
 				else begin
 					R4 <=
 						neg?  0 :
@@ -157,7 +157,18 @@ module requant_decoupled #(
 						tap[N-1:0];
 				end
 			end
-		end : blkStage4
+		end : blkStage4Unsigned
+		else begin : blkStage4Signed
+			uwire signed [TAP_SPAN + N-1:0]  win = P3[TAP_MAX+N-1 : TAP_MIN];
+			uwire signed [TAP_SPAN + N-1:0]  tap = win >>> T3;
+			uwire  ovf =
+				(($left(P3)  > TAP_MAX+N-1)? |(P3[$left(P3)-1:TAP_MAX+N-1] ^ {($left(P3)-TAP_MAX-N+1){neg}}) : 0) ||
+				((TAP_MIN    < TAP_MAX     )? ~(&tap[$left(tap):N-1]) && (|tap[$left(tap):N-1]) : 0);
+			always_ff @(posedge clk) begin
+				if(rst)  R4 <= 'x;
+				else     R4 <= ovf? {neg, {(N-1){!neg}}} : tap[N-1:0];
+			end
+		end : blkStage4Signed
 
 		assign	odat[pe] = R4;
 	end : genPE

--- a/finn-rtllib/requant/hdl/requant_wrapper_decoupled_template.v
+++ b/finn-rtllib/requant/hdl/requant_wrapper_decoupled_template.v
@@ -8,11 +8,33 @@
  * SystemVerilog top module. Unlike the embedded variant, no intermediate
  * SystemVerilog wrapper is needed: all parameters are plain integers that
  * Verilog can pass straight through to the SystemVerilog core.
+ *
+ * Primary parameters are substituted by Python codegen; stream widths are
+ * derived as localparams to keep the template in sync with the SV modules.
  ***************************************************************************/
 
-module $TOP_MODULE_NAME$ (
+module $TOP_MODULE_NAME$ #(
+    parameter VERSION = $VERSION$,
+    parameter K       = $K$,
+    parameter N       = $N$,
+    parameter C       = $C$,
+    parameter PE      = $PE$,
+    parameter TAP_MIN = $TAP_MIN$,
+    parameter TAP_MAX = $TAP_MAX$,
+
+    // Derived widths (matching requant_axi_decoupled.sv localparam chain)
+    parameter S_WIDTH = (K <= (VERSION == 3 ? 24 : 18)) ? 25 : (VERSION == 3 ? 24 : 18),
+    parameter X_WIDTH = (K <= (VERSION == 3 ? 24 : 18)) ? K  : ((VERSION == 1 ? 25 : 27) < K ? (VERSION == 1 ? 25 : 27) : K),
+    parameter BIAS_WIDTH  = S_WIDTH + X_WIDTH,
+    parameter TAP_RANGE = TAP_MAX - TAP_MIN + 1,
+    parameter TAP_WIDTH  = (TAP_RANGE > 1) ? $clog2(TAP_RANGE) : 1,
+    parameter PARAMS_LANE_WIDTH = S_WIDTH + TAP_WIDTH + BIAS_WIDTH,
+    parameter INPUT_STREAM_WIDTH  = ((PE * K + 7) / 8) * 8,
+    parameter OUTPUT_STREAM_WIDTH = ((PE * N + 7) / 8) * 8,
+    parameter PARAMS_STREAM_WIDTH = ((PE * PARAMS_LANE_WIDTH + 7) / 8) * 8
+)(
     //- Global Control ------------------
-    (* X_INTERFACE_PARAMETER = "ASSOCIATED_BUSIF in0_V:s_scale_V:s_bias_V:out0_V, ASSOCIATED_RESET ap_rst_n" *)
+    (* X_INTERFACE_PARAMETER = "ASSOCIATED_BUSIF in0_V:s_params_V:out0_V, ASSOCIATED_RESET ap_rst_n" *)
     (* X_INTERFACE_INFO = "xilinx.com:signal:clock:1.0 ap_clk CLK" *)
     input  ap_clk,
     (* X_INTERFACE_PARAMETER = "POLARITY ACTIVE_LOW" *)
@@ -21,40 +43,32 @@ module $TOP_MODULE_NAME$ (
     //- AXI Stream - Data Input ---------
     output  in0_V_TREADY,
     input   in0_V_TVALID,
-    input  [$IN_STREAM_WIDTH$-1:0]  in0_V_TDATA,
+    input  [INPUT_STREAM_WIDTH-1:0]  in0_V_TDATA,
 
-    //- AXI Stream - Scale Param Input --
-    output  s_scale_V_TREADY,
-    input   s_scale_V_TVALID,
-    input  [$SCALE_STREAM_WIDTH$-1:0]  s_scale_V_TDATA,
-
-    //- AXI Stream - Bias Param Input ---
-    output  s_bias_V_TREADY,
-    input   s_bias_V_TVALID,
-    input  [$BIAS_STREAM_WIDTH$-1:0]  s_bias_V_TDATA,
+    //- AXI Stream - Params Input -------
+    output  s_params_V_TREADY,
+    input   s_params_V_TVALID,
+    input  [PARAMS_STREAM_WIDTH-1:0]  s_params_V_TDATA,
 
     //- AXI Stream - Output -------------
     input   out0_V_TREADY,
     output  out0_V_TVALID,
-    output [$OUT_STREAM_WIDTH$-1:0]  out0_V_TDATA
+    output [OUTPUT_STREAM_WIDTH-1:0]  out0_V_TDATA
 );
 
     requant_axi_decoupled #(
-        .VERSION($VERSION$),
-        .K($K$), .N($N$), .C($C$), .PE($PE$),
-        .TAP_MIN($TAP_MIN$), .TAP_MAX($TAP_MAX$)
+        .VERSION(VERSION),
+        .K(K), .N(N), .C(C), .PE(PE),
+        .TAP_MIN(TAP_MIN), .TAP_MAX(TAP_MAX)
     ) core (
         .ap_clk(ap_clk),
         .ap_rst_n(ap_rst_n),
         .s_axis_tready(in0_V_TREADY),
         .s_axis_tvalid(in0_V_TVALID),
         .s_axis_tdata(in0_V_TDATA),
-        .s_scale_tready(s_scale_V_TREADY),
-        .s_scale_tvalid(s_scale_V_TVALID),
-        .s_scale_tdata(s_scale_V_TDATA),
-        .s_bias_tready(s_bias_V_TREADY),
-        .s_bias_tvalid(s_bias_V_TVALID),
-        .s_bias_tdata(s_bias_V_TDATA),
+        .s_params_tready(s_params_V_TREADY),
+        .s_params_tvalid(s_params_V_TVALID),
+        .s_params_tdata(s_params_V_TDATA),
         .m_axis_tready(out0_V_TREADY),
         .m_axis_tvalid(out0_V_TVALID),
         .m_axis_tdata(out0_V_TDATA)

--- a/finn-rtllib/requant/hdl/requant_wrapper_decoupled_template.v
+++ b/finn-rtllib/requant/hdl/requant_wrapper_decoupled_template.v
@@ -1,0 +1,63 @@
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: BSD-3-Clause
+/****************************************************************************
+ * @brief   Verilog wrapper for IP packaging (decoupled requant).
+ *
+ * Directly instantiates the SystemVerilog requant_axi_decoupled core. A plain
+ * Verilog top module is required because Vivado IP packaging does not allow a
+ * SystemVerilog top module. Unlike the embedded variant, no intermediate
+ * SystemVerilog wrapper is needed: all parameters are plain integers that
+ * Verilog can pass straight through to the SystemVerilog core.
+ ***************************************************************************/
+
+module $TOP_MODULE_NAME$ (
+    //- Global Control ------------------
+    (* X_INTERFACE_PARAMETER = "ASSOCIATED_BUSIF in0_V:s_scale_V:s_bias_V:out0_V, ASSOCIATED_RESET ap_rst_n" *)
+    (* X_INTERFACE_INFO = "xilinx.com:signal:clock:1.0 ap_clk CLK" *)
+    input  ap_clk,
+    (* X_INTERFACE_PARAMETER = "POLARITY ACTIVE_LOW" *)
+    input  ap_rst_n,
+
+    //- AXI Stream - Data Input ---------
+    output  in0_V_TREADY,
+    input   in0_V_TVALID,
+    input  [$IN_STREAM_WIDTH$-1:0]  in0_V_TDATA,
+
+    //- AXI Stream - Scale Param Input --
+    output  s_scale_V_TREADY,
+    input   s_scale_V_TVALID,
+    input  [$SCALE_STREAM_WIDTH$-1:0]  s_scale_V_TDATA,
+
+    //- AXI Stream - Bias Param Input ---
+    output  s_bias_V_TREADY,
+    input   s_bias_V_TVALID,
+    input  [$BIAS_STREAM_WIDTH$-1:0]  s_bias_V_TDATA,
+
+    //- AXI Stream - Output -------------
+    input   out0_V_TREADY,
+    output  out0_V_TVALID,
+    output [$OUT_STREAM_WIDTH$-1:0]  out0_V_TDATA
+);
+
+    requant_axi_decoupled #(
+        .VERSION($VERSION$),
+        .K($K$), .N($N$), .C($C$), .PE($PE$),
+        .TAP_MIN($TAP_MIN$), .TAP_MAX($TAP_MAX$)
+    ) core (
+        .ap_clk(ap_clk),
+        .ap_rst_n(ap_rst_n),
+        .s_axis_tready(in0_V_TREADY),
+        .s_axis_tvalid(in0_V_TVALID),
+        .s_axis_tdata(in0_V_TDATA),
+        .s_scale_tready(s_scale_V_TREADY),
+        .s_scale_tvalid(s_scale_V_TVALID),
+        .s_scale_tdata(s_scale_V_TDATA),
+        .s_bias_tready(s_bias_V_TREADY),
+        .s_bias_tvalid(s_bias_V_TVALID),
+        .s_bias_tdata(s_bias_V_TDATA),
+        .m_axis_tready(out0_V_TREADY),
+        .m_axis_tvalid(out0_V_TVALID),
+        .m_axis_tdata(out0_V_TDATA)
+    );
+
+endmodule

--- a/finn-rtllib/requant/hdl/requant_wrapper_decoupled_template.v
+++ b/finn-rtllib/requant/hdl/requant_wrapper_decoupled_template.v
@@ -21,6 +21,7 @@ module $TOP_MODULE_NAME$ #(
     parameter PE      = $PE$,
     parameter TAP_MIN = $TAP_MIN$,
     parameter TAP_MAX = $TAP_MAX$,
+    parameter SIGNED_OUT = $SIGNED_OUT$,
 
     // Derived widths (matching requant_axi_decoupled.sv localparam chain)
     parameter S_WIDTH = (K <= (VERSION == 3 ? 24 : 18)) ? 25 : (VERSION == 3 ? 24 : 18),
@@ -59,7 +60,8 @@ module $TOP_MODULE_NAME$ #(
     requant_axi_decoupled #(
         .VERSION(VERSION),
         .K(K), .N(N), .C(C), .PE(PE),
-        .TAP_MIN(TAP_MIN), .TAP_MAX(TAP_MAX)
+        .TAP_MIN(TAP_MIN), .TAP_MAX(TAP_MAX),
+        .SIGNED_OUT(SIGNED_OUT)
     ) core (
         .ap_clk(ap_clk),
         .ap_rst_n(ap_rst_n),

--- a/finn-rtllib/requant/hdl/requant_wrapper_template.sv
+++ b/finn-rtllib/requant/hdl/requant_wrapper_template.sv
@@ -38,10 +38,13 @@ module $TOP_MODULE_NAME$_impl (
 	localparam shortreal  SCALES[PE][CF] = $SCALES$;
 	localparam shortreal  BIASES[PE][CF] = $BIASES$;
 
+	localparam bit  SIGNED_OUT = $SIGNED_OUT$;
+
 	requant_axi #(
 		.VERSION(VERSION),
 		.K(K), .N(N), .C(C), .PE(PE),
-		.SCALES(SCALES), .BIASES(BIASES)
+		.SCALES(SCALES), .BIASES(BIASES),
+		.SIGNED_OUT(SIGNED_OUT)
 	) core (
 		.ap_clk(ap_clk),
 		.ap_rst_n(ap_rst_n),

--- a/src/finn/core/rtlsim_exec.py
+++ b/src/finn/core/rtlsim_exec.py
@@ -255,9 +255,11 @@ def rtlsim_exec_cppxsi(
         ), f"cppxsi sim doesn't know how to handle full AXI MM interfaces: {ifnames['aximm']}"
     instream_names = [x[0] for x in ifnames["s_axis"]]
     outstream_names = [x[0] for x in ifnames["m_axis"]]
-    assert len(instream_names) == len(instream_iters), (
-        "stitched-IP s_axis ports (%d) don't match streamed graph inputs (%d)"
-        % (len(instream_names), len(instream_iters))
+    assert len(instream_names) == len(
+        instream_iters
+    ), "stitched-IP s_axis ports (%d) don't match streamed graph inputs (%d)" % (
+        len(instream_names),
+        len(instream_iters),
     )
     instream_descrs = [
         (instream_names[i], instream_iters[i], instream_iters[i] + throttle_cycles)

--- a/src/finn/core/rtlsim_exec.py
+++ b/src/finn/core/rtlsim_exec.py
@@ -45,16 +45,33 @@ from finn.util.rtlsim import dat_file_to_numpy_array
 finnxsi = xsi if xsi.is_available() else None
 
 
+def has_s_axis_port(node_onnx, node_inp_ind):
+    """Whether input `node_inp_ind` of `node_onnx` is backed by an s_axis port.
+
+    Mirrors the skip rule in CreateStitchedIP.connect_s_axis_external: an input
+    beyond the node's declared s_axis interfaces gets no external port and does
+    not consume an s_axis_<n> index. Requant_rtl in MLO mode is such a case, as
+    it packs its bias (input[2]) into the input[1] parameter memstream.
+    """
+    s_axis_names = getCustomOp(node_onnx).get_verilog_top_module_intf_names()["s_axis"]
+    return node_inp_ind < len(s_axis_names)
+
+
 def prep_rtlsim_io_dict(model, execution_context):
     # extract i/o info to prepare io_dict
     io_dict = {"inputs": {}, "outputs": {}}
     if_dict = eval(model.get_metadata_prop("vivado_stitch_ifnames"))
-    # go over and prepare inputs
-    for i, i_vi in enumerate(model.graph.input):
+    # go over and prepare inputs, skipping those without an s_axis port so that
+    # the rest stay aligned with if_dict
+    i = -1
+    for i_vi in model.graph.input:
         i_name = i_vi.name
+        first_node_onnx = model.find_consumer(i_name)
+        if not has_s_axis_port(first_node_onnx, list(first_node_onnx.input).index(i_name)):
+            continue
+        i += 1
         i_tensor = execution_context[i_name]
         i_dt = model.get_tensor_datatype(i_name)
-        first_node_onnx = model.find_consumer(i_name)
         first_node = getCustomOp(first_node_onnx)
         node_inp_ind = list(first_node_onnx.input).index(i_name)
         if node_inp_ind == 0:
@@ -211,6 +228,9 @@ def rtlsim_exec_cppxsi(
         assert first_node is not None, "Failed to find consumer for " + iname
         fnode_inst = getCustomOp(first_node)
         top_ind = list(first_node.input).index(iname)
+        # skip inputs without an s_axis port to stay aligned with ifnames below
+        if not has_s_axis_port(first_node, top_ind):
+            continue
         ishape_folded = fnode_inst.get_folded_input_shape(ind=top_ind)
         instream_iters.append(np.prod(ishape_folded[:-1]))
     for top_out in model.graph.output:
@@ -235,6 +255,10 @@ def rtlsim_exec_cppxsi(
         ), f"cppxsi sim doesn't know how to handle full AXI MM interfaces: {ifnames['aximm']}"
     instream_names = [x[0] for x in ifnames["s_axis"]]
     outstream_names = [x[0] for x in ifnames["m_axis"]]
+    assert len(instream_names) == len(instream_iters), (
+        "stitched-IP s_axis ports (%d) don't match streamed graph inputs (%d)"
+        % (len(instream_names), len(instream_iters))
+    )
     instream_descrs = [
         (instream_names[i], instream_iters[i], instream_iters[i] + throttle_cycles)
         for i in range(len(instream_names))

--- a/src/finn/custom_op/fpgadataflow/hwcustomop.py
+++ b/src/finn/custom_op/fpgadataflow/hwcustomop.py
@@ -304,37 +304,56 @@ class HWCustomOp(CustomOp):
         out_width = self.get_outstream_width(ind=ind)
         return roundup_to_integer_multiple(out_width, 8)
 
-    def generate_hdl_memstream(self, fpgapart, pumped_memory=0):
+    def generate_hdl_memstream(
+        self,
+        fpgapart,
+        pumped_memory=0,
+        name=None,
+        depth=None,
+        width=None,
+        init_file=None,
+        ram_style=None,
+    ):
         """Helper function to generate verilog code for memstream component.
-        Currently utilized by MVAU, VVAU and HLS Thresholding layer."""
-        ops = ["MVAU_hls", "MVAU_rtl", "VVAU_hls", "VVAU_rtl", "Thresholding_hls"]
+        Currently utilized by MVAU, VVAU, HLS Thresholding and RTL Requant layer.
+
+        By default a single memstream wrapper named after the node is emitted,
+        with depth/width/init_file/ram_style derived from the node. Callers that
+        need more than one memstreamer (e.g. RTL Requant streams scale and bias
+        separately) can pass explicit ``name``, ``depth``, ``width``,
+        ``init_file`` and ``ram_style`` to emit a named streamer without relying
+        on the op-specific defaults."""
+        ops = ["MVAU_hls", "MVAU_rtl", "VVAU_hls", "VVAU_rtl", "Thresholding_hls", "Requant_rtl"]
         if self.onnx_node.op_type in ops or self.onnx_node.op_type.startswith("Elementwise"):
             template_path = (
                 os.environ["FINN_ROOT"] + "/finn-rtllib/memstream/hdl/memstream_wrapper_template.v"
             )
-            mname = self.onnx_node.name
+            mname = name if name is not None else self.onnx_node.name
             sets = 1
             mlo_max_iter = self.get_nodeattr("mlo_max_iter")
             if mlo_max_iter:
                 sets = mlo_max_iter
-            if self.onnx_node.op_type.startswith("Thresholding"):
-                depth = self.calc_tmem()
-            elif self.onnx_node.op_type.startswith("MVAU"):
-                depth = self.calc_wmem() * self.get_nodeattr("TH")
-            else:
-                depth = self.calc_wmem()
-            padded_width = self.get_instream_width_padded(1)
             code_gen_dir = self.get_nodeattr("code_gen_dir_ipgen")
-
-            ram_style = self.get_nodeattr("ram_style")
-            init_file = code_gen_dir + "/memblock.dat"
+            if depth is None:
+                if self.onnx_node.op_type.startswith("Thresholding"):
+                    depth = self.calc_tmem()
+                elif self.onnx_node.op_type.startswith("MVAU"):
+                    depth = self.calc_wmem() * self.get_nodeattr("TH")
+                else:
+                    depth = self.calc_wmem()
+            if width is None:
+                width = self.get_instream_width_padded(1)
+            if ram_style is None:
+                ram_style = self.get_nodeattr("ram_style")
+            if init_file is None:
+                init_file = code_gen_dir + "/memblock.dat"
             if ram_style == "ultra" and not is_versal(fpgapart):
                 init_file = ""
             code_gen_dict = {
                 "$MODULE_NAME$": [mname],
                 "$SETS$": [str(sets)],
                 "$DEPTH$": [str(depth)],
-                "$WIDTH$": [str(padded_width)],
+                "$WIDTH$": [str(width)],
                 "$INIT_FILE$": [init_file],
                 "$RAM_STYLE$": [ram_style],
                 "$PUMPED_MEMORY$": [str(pumped_memory)],

--- a/src/finn/custom_op/fpgadataflow/hwcustomop.py
+++ b/src/finn/custom_op/fpgadataflow/hwcustomop.py
@@ -245,10 +245,15 @@ class HWCustomOp(CustomOp):
         check if the number of inputs is equal to the expected number."""
         pass
 
-    def generate_params(self, model, path):
+    def generate_params(self, model, path, fpgapart=None):
         """Function to generate parameters (i.e. weights and thresholds),
         is member function of HWCustomOp class but has to be filled
-        by every node that needs to generate parameters."""
+        by every node that needs to generate parameters.
+
+        ``fpgapart`` is optional and only consumed by nodes whose parameter
+        layout depends on the target device (e.g. Requant, which resolves the
+        DSP version from it). Overrides that don't need it may keep the shorter
+        ``(model, path)`` signature."""
         pass
 
     def get_number_output_values(self):

--- a/src/finn/custom_op/fpgadataflow/requant.py
+++ b/src/finn/custom_op/fpgadataflow/requant.py
@@ -74,6 +74,133 @@ class Requant(HWCustomOp):
         bias = self.get_bias(model)
         return scale.size > 1 or bias.size > 1
 
+    @staticmethod
+    def _derive_mul_widths(version, k):
+        """Python port of ``derive_MUL_WIDTHS`` in finn-rtllib/requant/hdl/requant.sv.
+
+        Returns (s, x): the multiplier operand widths implied by the DSP
+        ``version`` and the input precision ``k``."""
+        if version == 1:
+            aw, bw = 25, 18
+        elif version == 2:
+            aw, bw = 27, 18
+        elif version == 3:
+            aw, bw = 27, 24
+        else:
+            raise ValueError(f"Unsupported DSP VERSION {version}.")
+        if k <= bw:
+            return 25, k
+        return bw, (aw if aw < k else k)
+
+    def decompose_params(self, model, version):
+        """Port of ``derive_PARAMS`` in finn-rtllib/requant/hdl/requant.sv.
+
+        Decomposes the float32 scale/bias per channel into the fixed-point
+        parameters the RTL datapath consumes: an integer ``scale`` mantissa, an
+        aligned integer ``bias`` (with the round-half-up constant folded in) and
+        a per-channel ``tap`` shift amount. This is the single source of truth
+        for the float->fixed-point conversion, used both by the embedded codegen
+        and by the decoupled memstream param generation.
+
+        Returns a dict with numpy int arrays shaped ``[PE][CF]``:
+        ``scale``, ``bias``, ``tap`` plus scalars ``tap_min``, ``tap_max`` and
+        the operand widths ``s_width`` (scale), ``x_width`` (data).
+        Raises ``ValueError`` for the same out-of-range conditions the RTL
+        asserts (``$error``/``$finish``), so failures surface at build time.
+        """
+        pe = self.get_nodeattr("PE")
+        num_channels = self.get_nodeattr("NumChannels")
+        cf = num_channels // pe
+
+        idt = self.get_input_datatype(0)
+        odt = self.get_output_datatype()
+        k = idt.bitwidth()
+        n = odt.bitwidth()
+
+        s_width, x_width = self._derive_mul_widths(version, k)
+
+        scale = self.get_scale(model)
+        bias = self.get_bias(model)
+        if scale.size == 1:
+            scale = np.full(num_channels, scale.item(), dtype=np.float32)
+        if bias.size == 1:
+            bias = np.full(num_channels, bias.item(), dtype=np.float32)
+        # [PE][CF] layout, matching requant_rtl.generate_hdl
+        scale = scale.astype(np.float32).reshape(cf, pe).T
+        bias = bias.astype(np.float32).reshape(cf, pe).T
+
+        scale_fixed = np.zeros((pe, cf), dtype=object)
+        bias_fixed = np.zeros((pe, cf), dtype=object)
+        tap_arr = np.zeros((pe, cf), dtype=object)
+
+        for p in range(pe):
+            for c in range(cf):
+                sc_val = scale[p][c]
+                bs_val = bias[p][c]
+                s_bits = int(np.float32(sc_val).view(np.uint32))
+                b_bits = int(np.float32(bs_val).view(np.uint32))
+
+                # Decomposed scale: sm = {1'b1, mant[22:0], 1'b0} (25 bits, *2^-24)
+                sm = (1 << 24) | ((s_bits & 0x7FFFFF) << 1)
+                se = ((s_bits >> 23) & 0xFF) - 127
+                sign_s = (s_bits >> 31) & 1
+
+                # Decomposed bias: bm = {1'b1, mant[22:0]} (24 bits, *2^-23)
+                bm = (1 << 23) | (b_bits & 0x7FFFFF)
+                be = ((b_bits >> 23) & 0xFF) - 127
+                sign_b = (b_bits >> 31) & 1
+
+                tap = (s_width - 2) - se
+                if tap < 0:
+                    raise ValueError(
+                        f"{self.onnx_node.name}: Scale {sc_val} is too large "
+                        f"for the output precision."
+                    )
+                if s_width + x_width + 1 < tap + n:
+                    raise ValueError(
+                        f"{self.onnx_node.name}: Scale {sc_val} is too small "
+                        f"for the output precision."
+                    )
+
+                # Mantissa into product datapath
+                sm >>= 25 - s_width
+                scale_mag = ((sm >> 1) & ((1 << 24) - 1)) + (sm & 1)
+                p_scale = -scale_mag if sign_s else scale_mag
+
+                # Align bias mantissa into product datapath
+                if be > (x_width - n):
+                    raise ValueError(
+                        f"{self.onnx_node.name}: Bias {bs_val} overflows the " f"output range."
+                    )
+                shift = be - (23 - tap)
+                if shift < -24:
+                    bias_mag = 0
+                elif shift < 0:
+                    bias_mag = bm >> (-shift)
+                else:
+                    bias_mag = bm << shift
+                p_bias = -bias_mag if sign_b else bias_mag
+                # Rounding (round-half-up constant folded into the bias)
+                if tap > 0:
+                    p_bias += 1 << (tap - 1)
+                elif shift < 0:
+                    p_bias += (bm >> (-shift - 1)) & 1
+
+                scale_fixed[p][c] = p_scale
+                bias_fixed[p][c] = p_bias
+                tap_arr[p][c] = tap
+
+        tap_flat = [int(tap_arr[p][c]) for p in range(pe) for c in range(cf)]
+        return {
+            "scale": scale_fixed,
+            "bias": bias_fixed,
+            "tap": tap_arr,
+            "tap_min": min(tap_flat),
+            "tap_max": max(tap_flat),
+            "s_width": s_width,
+            "x_width": x_width,
+        }
+
     def infer_node_datatype(self, model):
         node = self.onnx_node
         idt = model.get_tensor_datatype(node.input[0])

--- a/src/finn/custom_op/fpgadataflow/rtl/finn_loop.py
+++ b/src/finn/custom_op/fpgadataflow/rtl/finn_loop.py
@@ -587,18 +587,17 @@ class FINNLoop(HWCustomOp, RTLBackend):
     def _generate_params_requant(self, model, path, loop_node, loop_body, param_node, fpgapart):
         """Generate per-iteration memstream init files for a Requant_rtl body node.
 
-        Requant is the first body op with two parameter inputs (scale=input[1],
-        bias=input[2]). Its fixed-point decomposition is *coupled*: the bias
-        alignment depends on the scale-derived per-channel tap of the SAME
-        iteration (see requant.py). Therefore both initializers must be set
-        together for each iteration before calling ``generate_params`` (the
-        generic one-param-per-pass flow would produce mismatched bias files).
+        Requant has two parameter inputs (scale=input[1], bias=input[2]) whose
+        fixed-point decomposition is *coupled*: the bias alignment depends on
+        the scale-derived per-channel tap of the SAME iteration. Therefore both
+        initializers must be set together for each iteration before calling
+        ``generate_params``.
 
-        Each iteration emits ``scale_memblock.dat``/``bias_memblock.dat``; these
-        are renamed per iteration, concatenated (set i at offset i*DEPTH) into
-        ``scale_memblock_id_{gid}.dat``/``bias_memblock_id_{gid}.dat``, and the
-        two memstream wrappers' ``$INIT_FILE$`` paths are rewritten to point at
-        the concatenated files.
+        Each iteration emits a single ``params_memblock.dat`` (unified struct
+        packing scale+tap+bias per PE lane); these are renamed per iteration,
+        then concatenated (set i at offset i*DEPTH) into
+        ``params_memblock_id_{gid}.dat``. The single memstream wrapper's
+        ``$INIT_FILE$`` path is rewritten to point at the concatenated file.
         """
         iteration = self.get_nodeattr("iteration")
         inst = getCustomOp(param_node)
@@ -608,11 +607,11 @@ class FINNLoop(HWCustomOp, RTLBackend):
         scale_tensor = param_node.input[1]
         bias_tensor = param_node.input[2]
         scale_gid = graph_input_names.index(scale_tensor)
-        bias_gid = graph_input_names.index(bias_tensor)
 
         # Stacked per-iteration params live on the matching FINNLoop inputs
         # (loop_node.input[k] corresponds positionally to graph.input[k]).
         scale_stack = model.get_initializer(loop_node.input[scale_gid])
+        bias_gid = graph_input_names.index(bias_tensor)
         bias_stack = model.get_initializer(loop_node.input[bias_gid])
         scale_dtype = model.get_tensor_datatype(loop_node.input[scale_gid])
         bias_dtype = model.get_tensor_datatype(loop_node.input[bias_gid])
@@ -626,36 +625,32 @@ class FINNLoop(HWCustomOp, RTLBackend):
             loop_body.set_initializer(bias_tensor, bias_stack[iter])
             loop_body.set_tensor_datatype(bias_tensor, bias_dtype)
             inst.generate_params(loop_body, path, fpgapart)
-            for kind in ["scale", "bias"]:
-                src = "{}/{}_memblock.dat".format(path, kind)
-                dst = "{}/{}_memblock_{}.dat".format(path, kind, iter)
-                shutil.move(src, dst)
+            src = "{}/params_memblock.dat".format(path)
+            dst = "{}/params_memblock_{}.dat".format(path, iter)
+            shutil.move(src, dst)
 
-        # Concatenate per-iteration files into one memblock per param stream.
-        concat_files = {}
-        for kind, gid in [("scale", scale_gid), ("bias", bias_gid)]:
-            concat_file = "{}/{}_memblock_id_{}.dat".format(path, kind, gid)
-            with open(concat_file, "w") as outfile:
-                for iter in range(iteration):
-                    memblock_file = "{}/{}_memblock_{}.dat".format(path, kind, iter)
-                    with open(memblock_file, "r") as infile:
-                        for line in infile:
-                            outfile.write(line)
-                    os.remove(memblock_file)
-            concat_files[kind] = concat_file
+        # Concatenate per-iteration files into one memblock for the param stream.
+        # Use scale_gid as the canonical graph-input id for the unified stream.
+        concat_file = "{}/params_memblock_id_{}.dat".format(path, scale_gid)
+        with open(concat_file, "w") as outfile:
+            for iter in range(iteration):
+                memblock_file = "{}/params_memblock_{}.dat".format(path, iter)
+                with open(memblock_file, "r") as infile:
+                    for line in infile:
+                        outfile.write(line)
+                os.remove(memblock_file)
 
-        # Rewrite the memstream wrappers' $INIT_FILE$ paths (Elementwise-style).
+        # Rewrite the memstream wrapper's $INIT_FILE$ path (Elementwise-style).
         ipgen_path = inst.get_nodeattr("code_gen_dir_ipgen")
         if ipgen_path is not None and os.path.isdir(ipgen_path):
             for dname, dirs, files in os.walk(ipgen_path):
                 for fname in files:
-                    if fname.endswith("_memstream_wrapper.v"):
+                    if fname.endswith("_params_memstream_wrapper.v"):
                         fpath = os.path.join(dname, fname)
                         with open(fpath, "r") as f:
                             s = f.read()
-                        for kind in ["scale", "bias"]:
-                            old = os.path.join(ipgen_path, "%s_memblock.dat" % kind)
-                            s = s.replace(old, concat_files[kind])
+                        old = os.path.join(ipgen_path, "params_memblock.dat")
+                        s = s.replace(old, concat_file)
                         with open(fpath, "w") as f:
                             f.write(s)
 
@@ -686,18 +681,21 @@ class FINNLoop(HWCustomOp, RTLBackend):
                 ):
                     tap_rep = node_inst.calc_wmem_reps()
                 elif node.op_type == "Requant_rtl":
-                    # The decoupled Requant core consumes one scale + one bias
-                    # word per input beat, cycling through the CF stored words
-                    # (memstream DEPTH=CF). A multi-set memstream emits exactly
-                    # DEPTH words per set-select and does not auto-wrap, so the
-                    # set index must be replayed once per spatial position to
-                    # re-stream the CF-word block. folded_input_shape is
-                    # [*numInputVectors, CF, PE]; [:-2] drops CF and PE.
+                    # The decoupled Requant core consumes one packed param word
+                    # per input beat, cycling through CF stored words (memstream
+                    # DEPTH=CF). The set index must be replayed once per spatial
+                    # position to re-stream the CF-word block.
+                    # folded_input_shape is [*numInputVectors, CF, PE].
                     tap_rep = int(np.prod(node_inst.get_folded_input_shape(0)[:-2]))
                 # Emit one stream tap per parameter graph-input of this node.
-                # Single-param ops (MVAU/Thresholding/Elementwise) yield exactly
-                # one tap; multi-param ops (Requant: scale+bias) yield one each.
-                for pinp in node.input[1:]:
+                # Single-param ops (MVAU/Thresholding/Elementwise) yield one
+                # tap. Requant packs scale+bias into a single unified memstream
+                # driven by the tap for input[1]; input[2] (bias) is internal
+                # to the struct and does not get its own tap.
+                param_inputs = node.input[1:]
+                if node.op_type == "Requant_rtl":
+                    param_inputs = node.input[1:2]
+                for pinp in param_inputs:
                     if pinp not in graph_inputs:
                         continue
                     stname = "IN_%s" % graph_inputs.index(pinp)

--- a/src/finn/custom_op/fpgadataflow/rtl/finn_loop.py
+++ b/src/finn/custom_op/fpgadataflow/rtl/finn_loop.py
@@ -366,7 +366,7 @@ class FINNLoop(HWCustomOp, RTLBackend):
         # Generate params as part of IP preparation
         code_gen_dir = self.get_nodeattr("code_gen_dir_ipgen")
         self.generate_hdl_stream_tap()
-        self.generate_params(model, code_gen_dir)
+        self.generate_params(model, code_gen_dir, fpgapart)
         code_gen_dict = {}
         code_gen_dict["$LOOP_CONTROL_WRAPPER_NAME$"] = [f"{self.onnx_node.name}_loop_cont_wrapper"]
         code_gen_dict["$N_MAX_LAYERS$"] = (str(self.get_nodeattr("iteration")),)
@@ -400,10 +400,14 @@ class FINNLoop(HWCustomOp, RTLBackend):
         ) as f:
             f.write(template_wrapper)
 
-    def generate_params(self, model, path):
+    def generate_params(self, model, path, fpgapart=None):
         iteration = self.get_nodeattr("iteration")
         loop_node = self.onnx_node
         loop_body = self.get_nodeattr("body")
+        # Nodes with multiple parameter inputs (e.g. Requant: scale+bias) are
+        # handled once, across all their param inputs, and skipped on later
+        # passes of the per-graph-input loop below.
+        handled_nodes = set()
         for i, inp in enumerate(loop_node.input[1:]):
             params = model.get_initializer(inp)
             param_dtype = model.get_tensor_datatype(inp)
@@ -411,6 +415,14 @@ class FINNLoop(HWCustomOp, RTLBackend):
             # get node that initializer is attached to
             loop_tensor = loop_body.graph.input[i + 1].name
             param_node = loop_body.find_consumer(loop_tensor)
+            if param_node.name in handled_nodes:
+                continue
+            if param_node.op_type == "Requant_rtl":
+                self._generate_params_requant(
+                    model, path, loop_node, loop_body, param_node, fpgapart
+                )
+                handled_nodes.add(param_node.name)
+                continue
             for iter in range(iteration):
                 loop_body.set_initializer(loop_tensor, params[iter])
                 loop_body.set_tensor_datatype(loop_tensor, param_dtype)
@@ -535,6 +547,81 @@ class FINNLoop(HWCustomOp, RTLBackend):
                                 with open(fpath, "w") as f:
                                     f.write(s)
 
+    def _generate_params_requant(self, model, path, loop_node, loop_body, param_node, fpgapart):
+        """Generate per-iteration memstream init files for a Requant_rtl body node.
+
+        Requant is the first body op with two parameter inputs (scale=input[1],
+        bias=input[2]). Its fixed-point decomposition is *coupled*: the bias
+        alignment depends on the scale-derived per-channel tap of the SAME
+        iteration (see requant.py). Therefore both initializers must be set
+        together for each iteration before calling ``generate_params`` (the
+        generic one-param-per-pass flow would produce mismatched bias files).
+
+        Each iteration emits ``scale_memblock.dat``/``bias_memblock.dat``; these
+        are renamed per iteration, concatenated (set i at offset i*DEPTH) into
+        ``scale_memblock_id_{gid}.dat``/``bias_memblock_id_{gid}.dat``, and the
+        two memstream wrappers' ``$INIT_FILE$`` paths are rewritten to point at
+        the concatenated files.
+        """
+        iteration = self.get_nodeattr("iteration")
+        inst = getCustomOp(param_node)
+
+        # Map the Requant's scale/bias tensors to loop-body graph-input ids.
+        graph_input_names = [x.name for x in loop_body.graph.input]
+        scale_tensor = param_node.input[1]
+        bias_tensor = param_node.input[2]
+        scale_gid = graph_input_names.index(scale_tensor)
+        bias_gid = graph_input_names.index(bias_tensor)
+
+        # Stacked per-iteration params live on the matching FINNLoop inputs
+        # (loop_node.input[k] corresponds positionally to graph.input[k]).
+        scale_stack = model.get_initializer(loop_node.input[scale_gid])
+        bias_stack = model.get_initializer(loop_node.input[bias_gid])
+        scale_dtype = model.get_tensor_datatype(loop_node.input[scale_gid])
+        bias_dtype = model.get_tensor_datatype(loop_node.input[bias_gid])
+        assert scale_stack.shape[0] == iteration
+        assert bias_stack.shape[0] == iteration
+
+        for iter in range(iteration):
+            # Set BOTH initializers for this iteration (coupled decomposition).
+            loop_body.set_initializer(scale_tensor, scale_stack[iter])
+            loop_body.set_tensor_datatype(scale_tensor, scale_dtype)
+            loop_body.set_initializer(bias_tensor, bias_stack[iter])
+            loop_body.set_tensor_datatype(bias_tensor, bias_dtype)
+            inst.generate_params(loop_body, path, fpgapart)
+            for kind in ["scale", "bias"]:
+                src = "{}/{}_memblock.dat".format(path, kind)
+                dst = "{}/{}_memblock_{}.dat".format(path, kind, iter)
+                shutil.move(src, dst)
+
+        # Concatenate per-iteration files into one memblock per param stream.
+        concat_files = {}
+        for kind, gid in [("scale", scale_gid), ("bias", bias_gid)]:
+            concat_file = "{}/{}_memblock_id_{}.dat".format(path, kind, gid)
+            with open(concat_file, "w") as outfile:
+                for iter in range(iteration):
+                    memblock_file = "{}/{}_memblock_{}.dat".format(path, kind, iter)
+                    with open(memblock_file, "r") as infile:
+                        for line in infile:
+                            outfile.write(line)
+                    os.remove(memblock_file)
+            concat_files[kind] = concat_file
+
+        # Rewrite the memstream wrappers' $INIT_FILE$ paths (Elementwise-style).
+        ipgen_path = inst.get_nodeattr("code_gen_dir_ipgen")
+        if ipgen_path is not None and os.path.isdir(ipgen_path):
+            for dname, dirs, files in os.walk(ipgen_path):
+                for fname in files:
+                    if fname.endswith("_memstream_wrapper.v"):
+                        fpath = os.path.join(dname, fname)
+                        with open(fpath, "r") as f:
+                            s = f.read()
+                        for kind in ["scale", "bias"]:
+                            old = os.path.join(ipgen_path, "%s_memblock.dat" % kind)
+                            s = s.replace(old, concat_files[kind])
+                        with open(fpath, "w") as f:
+                            f.write(s)
+
     def generate_hdl_stream_tap(self):
         """Helper function to generate verilog code for stream tap components."""
         template_path = (
@@ -561,24 +648,39 @@ class FINNLoop(HWCustomOp, RTLBackend):
                     node_inst, "calc_wmem_reps"
                 ):
                     tap_rep = node_inst.calc_wmem_reps()
-                stname = "IN_%s" % graph_inputs.index(node.input[1])
-                code_gen_dict = {
-                    "$MODULE_NAME$": [stname],
-                    "$DATA_WIDTH$": [str(data_width)],
-                    "$TAP_REP$": [str(tap_rep)],
-                }
-                # apply code generation to template
-                with open(template_path, "r") as f:
-                    template_wrapper = f.read()
-                for key, value in code_gen_dict.items():
-                    # transform list into long string separated by '\n'
-                    code_gen_line = "\n".join(value)
-                    template_wrapper = template_wrapper.replace(key, code_gen_line)
-                with open(
-                    os.path.join(code_gen_dir, stname + "_stream_tap_wrapper.v"),
-                    "w",
-                ) as f:
-                    f.write(template_wrapper)
+                elif node.op_type == "Requant_rtl":
+                    # The decoupled Requant core consumes one scale + one bias
+                    # word per input beat, cycling through the CF stored words
+                    # (memstream DEPTH=CF). A multi-set memstream emits exactly
+                    # DEPTH words per set-select and does not auto-wrap, so the
+                    # set index must be replayed once per spatial position to
+                    # re-stream the CF-word block. folded_input_shape is
+                    # [*numInputVectors, CF, PE]; [:-2] drops CF and PE.
+                    tap_rep = int(np.prod(node_inst.get_folded_input_shape(0)[:-2]))
+                # Emit one stream tap per parameter graph-input of this node.
+                # Single-param ops (MVAU/Thresholding/Elementwise) yield exactly
+                # one tap; multi-param ops (Requant: scale+bias) yield one each.
+                for pinp in node.input[1:]:
+                    if pinp not in graph_inputs:
+                        continue
+                    stname = "IN_%s" % graph_inputs.index(pinp)
+                    code_gen_dict = {
+                        "$MODULE_NAME$": [stname],
+                        "$DATA_WIDTH$": [str(data_width)],
+                        "$TAP_REP$": [str(tap_rep)],
+                    }
+                    # apply code generation to template
+                    with open(template_path, "r") as f:
+                        template_wrapper = f.read()
+                    for key, value in code_gen_dict.items():
+                        # transform list into long string separated by '\n'
+                        code_gen_line = "\n".join(value)
+                        template_wrapper = template_wrapper.replace(key, code_gen_line)
+                    with open(
+                        os.path.join(code_gen_dir, stname + "_stream_tap_wrapper.v"),
+                        "w",
+                    ) as f:
+                        f.write(template_wrapper)
 
     def ipgen_singlenode_code(self, fpgapart=None):
         prjname = "MakeLoopIP"
@@ -760,33 +862,77 @@ class FINNLoop(HWCustomOp, RTLBackend):
             or (
                 node.op_type.startswith("Elementwise")
                 and any(attr.name == "mlo_max_iter" and attr.i > 0 for attr in node.attribute)
+            )
+            or (
+                node.op_type == "Requant_rtl"
+                and any(attr.name == "mlo_max_iter" and attr.i > 0 for attr in node.attribute)
             ),
         )
 
-        # create map that maps each stream tap to its param node
-        st_map = {}
-        for id, inp in enumerate(loop_body.graph.input[1:]):
+        # Map each parameter graph-input to its stream tap. A node may consume
+        # several parameter inputs (e.g. Requant: scale=input[1], bias=input[2]),
+        # so keep a per-graph-input tap list plus a node -> [tap ids] index.
+        # taps: list of (gid, tap_name, consumer_name); node_to_taps: name -> [gid]
+        taps = []
+        node_to_taps = {}
+        for id, inp in enumerate(loop_body.graph.input[1:], start=1):
             consumer = loop_body.find_consumer(inp.name)
-            st_map[consumer.name] = "IN_%d_stream_tap_wrapper" % (id + 1)
+            tap_name = "IN_%d_stream_tap_wrapper" % id
+            taps.append((id, tap_name, consumer.name))
+            node_to_taps.setdefault(consumer.name, []).append(id)
 
-        # instantiate all stream taps and connect their clk and rst
-        for id, st_name in enumerate(st_map.values()):
+        def node_entry(node_name):
+            # Entry tap (lowest gid) of a node: where the set index enters the
+            # node's param taps. A multi-param node chains its taps internally
+            # (below), so the index flows in here and out of node_exit.
+            return "IN_%d_stream_tap_wrapper" % min(node_to_taps[node_name])
+
+        def node_exit(node_name):
+            # Exit tap (highest gid) of a node: forwards the set index onward to
+            # the next node in the chain. For a single-param node entry == exit.
+            return "IN_%d_stream_tap_wrapper" % max(node_to_taps[node_name])
+
+        def dst_entry_taps(dsts):
+            # One entry tap per destination node. Intra-node params (e.g. Requant
+            # scale+bias) are chained in series internally, so a multi-param node
+            # contributes exactly one sink here -- fork duplication only applies
+            # across distinct destination nodes (branching dataflow).
+            return [node_entry(d) for d in dsts]
+
+        # instantiate all stream taps and connect their clk and rst; wire each
+        # tap's m_axis_1 to the stg output m_axis_<gid> by its true graph-input id
+        for gid, tap_name, _consumer in taps:
             cmd.append(
-                "create_bd_cell -type hier -reference %s /%s/%s" % (st_name, bd_name, st_name)
+                "create_bd_cell -type hier -reference %s /%s/%s" % (tap_name, bd_name, tap_name)
             )
             # connect
             cmd.append(
                 "connect_bd_net [get_bd_pins %s/%s] [get_bd_pins %s/%s/ap_clk]"
-                % (bd_name, clk_name, bd_name, st_name)
+                % (bd_name, clk_name, bd_name, tap_name)
             )
             cmd.append(
                 "connect_bd_net [get_bd_pins %s/%s] [get_bd_pins %s/%s/ap_rst_n]"
-                % (bd_name, rst_name, bd_name, st_name)
+                % (bd_name, rst_name, bd_name, tap_name)
             )
             cmd.append(
                 "connect_bd_intf_net [get_bd_intf_pins %s/m_axis_%s] "
-                "[get_bd_intf_pins %s/%s/m_axis_1]" % (bd_name, id + 1, bd_name, st_name)
+                "[get_bd_intf_pins %s/%s/m_axis_1]" % (bd_name, gid, bd_name, tap_name)
             )
+
+        # Chain a multi-param node's taps in series (e.g. Requant scale -> bias):
+        # each tap taps off its own m_axis_1 to its memstream and forwards the
+        # set index on m_axis_0 to the next param tap. This keeps every tap's
+        # forward output consumed (the stream_tap stalls if m_axis_0/ordy is left
+        # dangling) while still delivering the same index to all param memstreams.
+        for consumer_name, gids in node_to_taps.items():
+            ordered = sorted(gids)
+            for a, b in zip(ordered[:-1], ordered[1:]):
+                cmd.append(
+                    "connect_bd_intf_net "
+                    "[get_bd_intf_pins %s/IN_%d_stream_tap_wrapper/m_axis_0] "
+                    "[get_bd_intf_pins %s/IN_%d_stream_tap_wrapper/s_axis_0]"
+                    % (bd_name, a, bd_name, b)
+                )
 
         # prune adj_list to remove join duplicates
         pruned_adj_list = copy.deepcopy(adj_list)
@@ -839,12 +985,18 @@ class FINNLoop(HWCustomOp, RTLBackend):
                 src_inst_name = bd_name
                 src_intf_name = "s_axis_0"
             else:
-                src_inst_name = bd_name + "/" + st_map[src]
+                # A multi-param node forwards the set index from its exit (last)
+                # tap; its internal params were already chained in series above.
+                src_inst_name = bd_name + "/" + node_exit(src)
                 src_intf_name = "m_axis_0"
 
+            # One sink per destination node (its entry tap). A multi-param node
+            # is a single sink here -- fork duplication is only for branching to
+            # distinct downstream nodes.
+            sink_taps = dst_entry_taps(dsts)
             dst_intf_name = "s_axis_0"
-            if len(dsts) == 1:
-                dst_inst_name = st_map[dsts[0]]
+            if len(sink_taps) == 1:
+                dst_inst_name = sink_taps[0]
                 cmd.append(
                     "connect_bd_intf_net [get_bd_intf_pins %s/%s] "
                     "[get_bd_intf_pins %s/%s/%s]"
@@ -858,7 +1010,7 @@ class FINNLoop(HWCustomOp, RTLBackend):
                 )
             # if node is a fork connect data signals directly
             # and insert AND logic for rdy and vld signals
-            elif len(dsts) > 1:
+            elif len(sink_taps) > 1:
                 if "__INPUT0__" in src:
                     cmd.append(
                         "create_bd_cell -type ip "
@@ -867,7 +1019,7 @@ class FINNLoop(HWCustomOp, RTLBackend):
                     )
                     cmd.append(
                         "set_property CONFIG.NUM_MI {%d} [get_bd_cells %s/axi_broadcaster_0]"
-                        % (len(dsts), src_inst_name)
+                        % (len(sink_taps), src_inst_name)
                     )
                     # connect component to clk, rst and input
                     cmd.append(
@@ -886,8 +1038,7 @@ class FINNLoop(HWCustomOp, RTLBackend):
                         "[get_bd_intf_pins %s/axi_broadcaster_0/S_AXIS]"
                         % (src_inst_name, src_inst_name)
                     )
-                    for id, dst in enumerate(dsts):
-                        dst_inst_name = st_map[dst]
+                    for id, dst_inst_name in enumerate(sink_taps):
                         cmd.append(
                             "connect_bd_intf_net "
                             "[get_bd_intf_pins %s/axi_broadcaster_0/M0%s_AXIS] "
@@ -895,8 +1046,7 @@ class FINNLoop(HWCustomOp, RTLBackend):
                             % (src_inst_name, id, src_inst_name, dst_inst_name, dst_intf_name)
                         )
                 else:
-                    for id, dst in enumerate(dsts):
-                        dst_inst_name = st_map[dst]
+                    for id, dst_inst_name in enumerate(sink_taps):
                         cmd.append(
                             "connect_bd_net "
                             "[get_bd_pins %s/%s_TDATA] [get_bd_pins %s/%s/%s_TDATA]"
@@ -929,7 +1079,7 @@ class FINNLoop(HWCustomOp, RTLBackend):
                                     id,
                                 )
                             )
-                        elif id < len(dsts):
+                        elif id < len(sink_taps):
                             cmd.append(
                                 "connect_bd_net "
                                 "[get_bd_pins %s_util_vector_logic_%d/Res] "
@@ -949,13 +1099,12 @@ class FINNLoop(HWCustomOp, RTLBackend):
                         "[get_bd_pins %s_util_vector_logic_%d/Res] [get_bd_pins %s/%s_TREADY]"
                         % (
                             src_inst_name,
-                            len(dsts) - 1,
+                            len(sink_taps) - 1,
                             src_inst_name,
                             src_intf_name,
                         )
                     )
-                    for dst in dsts:
-                        dst_inst_name = st_map[dst]
+                    for dst_inst_name in sink_taps:
                         dst_intf_name = "s_axis_0"
                         cmd.append(
                             "connect_bd_net "
@@ -963,7 +1112,7 @@ class FINNLoop(HWCustomOp, RTLBackend):
                             "[get_bd_pins %s/%s/%s_TVALID]"
                             % (
                                 src_inst_name,
-                                len(dsts) - 1,
+                                len(sink_taps) - 1,
                                 bd_name,
                                 dst_inst_name,
                                 dst_intf_name,
@@ -977,7 +1126,7 @@ class FINNLoop(HWCustomOp, RTLBackend):
         ]
         cmd.append(
             "connect_bd_intf_net [get_bd_intf_pins %s/m_axis_0] "
-            "[get_bd_intf_pins %s/%s/m_axis_0]" % (bd_name, bd_name, st_map[last_nodes[0]])
+            "[get_bd_intf_pins %s/%s/m_axis_0]" % (bd_name, bd_name, node_exit(last_nodes[0]))
         )
 
         # connect stream tap graph to clk and reset

--- a/src/finn/custom_op/fpgadataflow/rtl/finn_loop.py
+++ b/src/finn/custom_op/fpgadataflow/rtl/finn_loop.py
@@ -871,10 +871,22 @@ class FINNLoop(HWCustomOp, RTLBackend):
             "create_bd_intf_pin -mode Slave "
             "-vlnv xilinx.com:interface:axis_rtl:1.0 /%s/s_axis_0" % bd_name
         )
-        for id, inp in enumerate(loop_body.graph.input[1:]):
+        # One tap per parameter graph-input, mirroring generate_hdl_stream_tap():
+        # Requant packs scale (input[1]) and bias (input[2]) into one memstream
+        # driven by the scale tap, so the bias gets no tap of its own.
+        taps = []
+        node_to_taps = {}
+        for gid, inp in enumerate(loop_body.graph.input[1:], start=1):
+            consumer = loop_body.find_consumer(inp.name)
+            if consumer.op_type == "Requant_rtl" and inp.name in consumer.input[2:]:
+                continue
+            taps.append((gid, "IN_%d_stream_tap_wrapper" % gid, consumer.name))
+            node_to_taps.setdefault(consumer.name, []).append(gid)
+        # number the master ports densely, to match the loop body IP's s_axis_1..N
+        for pid, _ in enumerate(taps, start=1):
             cmd.append(
                 "create_bd_intf_pin -mode Master "
-                "-vlnv xilinx.com:interface:axis_rtl:1.0 /%s/m_axis_%d" % (bd_name, id + 1)
+                "-vlnv xilinx.com:interface:axis_rtl:1.0 /%s/m_axis_%d" % (bd_name, pid)
             )
         # get stream tap (+ skid)  components
         skid_file = os.path.join(os.environ["FINN_ROOT"], "finn-rtllib/skid/skid.sv")
@@ -911,18 +923,6 @@ class FINNLoop(HWCustomOp, RTLBackend):
             ),
         )
 
-        # Map each parameter graph-input to its stream tap. A node may consume
-        # several parameter inputs (e.g. Requant: scale=input[1], bias=input[2]),
-        # so keep a per-graph-input tap list plus a node -> [tap ids] index.
-        # taps: list of (gid, tap_name, consumer_name); node_to_taps: name -> [gid]
-        taps = []
-        node_to_taps = {}
-        for id, inp in enumerate(loop_body.graph.input[1:], start=1):
-            consumer = loop_body.find_consumer(inp.name)
-            tap_name = "IN_%d_stream_tap_wrapper" % id
-            taps.append((id, tap_name, consumer.name))
-            node_to_taps.setdefault(consumer.name, []).append(id)
-
         def node_entry(node_name):
             # Entry tap (lowest gid) of a node: where the set index enters the
             # node's param taps. A multi-param node chains its taps internally
@@ -941,9 +941,8 @@ class FINNLoop(HWCustomOp, RTLBackend):
             # across distinct destination nodes (branching dataflow).
             return [node_entry(d) for d in dsts]
 
-        # instantiate all stream taps and connect their clk and rst; wire each
-        # tap's m_axis_1 to the stg output m_axis_<gid> by its true graph-input id
-        for gid, tap_name, _consumer in taps:
+        # instantiate all stream taps and connect their clk and rst
+        for pid, (_gid, tap_name, _consumer) in enumerate(taps, start=1):
             cmd.append(
                 "create_bd_cell -type hier -reference %s /%s/%s" % (tap_name, bd_name, tap_name)
             )
@@ -958,7 +957,7 @@ class FINNLoop(HWCustomOp, RTLBackend):
             )
             cmd.append(
                 "connect_bd_intf_net [get_bd_intf_pins %s/m_axis_%s] "
-                "[get_bd_intf_pins %s/%s/m_axis_1]" % (bd_name, gid, bd_name, tap_name)
+                "[get_bd_intf_pins %s/%s/m_axis_1]" % (bd_name, pid, bd_name, tap_name)
             )
 
         # Chain a multi-param node's taps in series (e.g. Requant scale -> bias):
@@ -1258,6 +1257,7 @@ class FINNLoop(HWCustomOp, RTLBackend):
         # connect components with each other
         # stream tap with finn ip
         connect_signals = loop_body_intf_names["s_axis"]
+        assert len(taps) == len(connect_signals) - 1, "stream tap / loop body param mismatch"
         for id, sig in enumerate(connect_signals[:-1]):
             cmd.append(
                 "connect_bd_intf_net "

--- a/src/finn/custom_op/fpgadataflow/rtl/requant_rtl.py
+++ b/src/finn/custom_op/fpgadataflow/rtl/requant_rtl.py
@@ -35,7 +35,7 @@ class Requant_rtl(Requant, RTLBackend):
             {
                 # memory mode for the scale/bias parameters
                 # internal_embedded: constant-folded into the datapath (default)
-                # internal_decoupled: streamed from two on-chip memstreams
+                # internal_decoupled: streamed from a unified on-chip memstream
                 "mem_mode": (
                     "s",
                     False,
@@ -54,9 +54,10 @@ class Requant_rtl(Requant, RTLBackend):
         constant-folds scale/bias into the SV datapath and therefore cannot vary
         per loop iteration. When LoopRolling flags this node for MLO (it sets
         ``mlo_max_iter`` on the consumer of each per-iteration PARAMETER input),
-        switch to ``internal_decoupled`` so scale+bias are streamed from the two
-        memstreams instead (mirrors MVAU_rtl's embedded->external_mem switch, but
-        with Requant's own decoupled target mode). Gate on the per-node
+        switch to ``internal_decoupled`` so scale+bias are streamed from the
+        unified param memstream instead (mirrors MVAU_rtl's
+        embedded->external_mem switch, but with Requant's own decoupled target
+        mode). Gate on the per-node
         ``mlo_max_iter`` signal rather than the positional ``input_types``.
         """
         if self.get_nodeattr("mlo_max_iter") > 0:
@@ -67,7 +68,7 @@ class Requant_rtl(Requant, RTLBackend):
 
         Must match the FINNLoop stream_tap ``$DATA_WIDTH$``
         (finn_loop.py:548-550) so that the tap's ``m_axis`` connects cleanly to
-        the ``in1_V``/``in2_V`` set-select slave pins.
+        the ``in1_V`` set-select slave pin.
         """
         iteration = self.get_nodeattr("mlo_max_iter")
         data_width = DataType.get_smallest_possible(iteration).bitwidth()
@@ -78,9 +79,9 @@ class Requant_rtl(Requant, RTLBackend):
 
         Base case exposes only the activation stream ``in0_V`` and output
         ``out0_V`` (scale/bias are internal to the decoupled hierarchy). In MLO
-        mode two extra set-select slave pins ``in1_V`` (scale) and ``in2_V``
-        (bias) are appended in graph-input order; each is driven by a FINNLoop
-        stream_tap and selects the active parameter set in its memstream.
+        mode one extra set-select slave pin ``in1_V`` is appended; it is driven
+        by a FINNLoop stream_tap and selects the active parameter set in the
+        unified param memstream.
         """
         intf_names = {"clk": ["ap_clk"], "rst": ["ap_rst_n"]}
         intf_names["s_axis"] = [("in0_V", self.get_instream_width_padded(0))]
@@ -91,7 +92,6 @@ class Requant_rtl(Requant, RTLBackend):
             set_bits_padded = self._mlo_set_bits_padded()
             intf_names["s_axis"] += [
                 ("in1_V", set_bits_padded),
-                ("in2_V", set_bits_padded),
             ]
         intf_names["m_axis"] = [("out0_V", self.get_outstream_width_padded(0))]
         intf_names["aximm"] = []
@@ -140,10 +140,10 @@ class Requant_rtl(Requant, RTLBackend):
             tap_min = 0
             tap_max = s_width + x_width + 1 - n
 
-        bias_w = s_width + x_width
+        bias_width = s_width + x_width
         tap_range = tap_max - tap_min + 1
-        tap_bits = max(1, _clog2(tap_range)) if tap_range > 1 else 1
-        scale_lane_w = s_width + tap_bits
+        tap_width = max(1, _clog2(tap_range)) if tap_range > 1 else 1
+        params_lane_width = s_width + tap_width + bias_width
 
         info = dict(params)
         info.update(
@@ -151,13 +151,12 @@ class Requant_rtl(Requant, RTLBackend):
                 "version": version,
                 "tap_min": tap_min,
                 "tap_max": tap_max,
-                "bias_w": bias_w,
-                "tap_bits": tap_bits,
-                "scale_lane_w": scale_lane_w,
+                "bias_width": bias_width,
+                "tap_width": tap_width,
+                "params_lane_width": params_lane_width,
                 "in_stream_width": roundup_to_integer_multiple(pe * k, 8),
                 "out_stream_width": roundup_to_integer_multiple(pe * n, 8),
-                "scale_stream_width": roundup_to_integer_multiple(pe * scale_lane_w, 8),
-                "bias_stream_width": roundup_to_integer_multiple(pe * bias_w, 8),
+                "params_stream_width": roundup_to_integer_multiple(pe * params_lane_width, 8),
             }
         )
         return info
@@ -165,9 +164,14 @@ class Requant_rtl(Requant, RTLBackend):
     def _pack_param_words(self, info):
         """Pack the decomposed params into per-fold stream words.
 
-        Lane 0 (pe=0) occupies the least significant bits, matching the RTL
-        ``s_scale_tdata[0+:PE*SCALE_LANE_W]`` / ``core_sdat`` unpacking. Returns
-        two lists (scale_words, bias_words) of ``CF`` Python integers each.
+        All three fields (scale, tap-offset, bias) are packed into a single
+        struct per PE lane. Lane 0 (pe=0) occupies the least significant bits.
+        Returns a single list of ``CF`` Python integers.
+
+        Per-lane layout (LSB to MSB):
+            [S_WIDTH-1 : 0]                                    = SCALE  (signed mantissa)
+            [S_WIDTH+TAP_WIDTH-1 : S_WIDTH]                    = T      (tap - TAP_MIN, unsigned)
+            [S_WIDTH+TAP_WIDTH+BIAS_WIDTH-1 : S_WIDTH+TAP_WIDTH] = BIAS (signed)
         """
         pe = self.get_nodeattr("PE")
         num_channels = self.get_nodeattr("NumChannels")
@@ -178,23 +182,24 @@ class Requant_rtl(Requant, RTLBackend):
         tap = info["tap"]
         tap_min = info["tap_min"]
         s_width = info["s_width"]
-        tap_bits = info["tap_bits"]
-        scale_lane_w = info["scale_lane_w"]
-        bias_w = info["bias_w"]
+        tap_width = info["tap_width"]
+        bias_width = info["bias_width"]
+        params_lane_width = info["params_lane_width"]
 
-        scale_words = []
-        bias_words = []
+        params_words = []
         for c in range(cf):
-            s_word = 0
-            b_word = 0
+            p_word = 0
             for p in range(pe):
                 t_off = int(tap[p][c]) - tap_min
-                s_lane = (_twos(t_off, tap_bits) << s_width) | _twos(scale[p][c], s_width)
-                s_word |= s_lane << (p * scale_lane_w)
-                b_word |= _twos(bias[p][c], bias_w) << (p * bias_w)
-            scale_words.append(s_word)
-            bias_words.append(b_word)
-        return scale_words, bias_words
+                # Pack: { BIAS[BIAS_WIDTH], T[TAP_WIDTH], SCALE[S_WIDTH] }
+                lane = (
+                    (_twos(bias[p][c], bias_width) << (s_width + tap_width))
+                    | (_twos(t_off, tap_width) << s_width)
+                    | _twos(scale[p][c], s_width)
+                )
+                p_word |= lane << (p * params_lane_width)
+            params_words.append(p_word)
+        return params_words
 
     @staticmethod
     def _write_memblock(path, words, stream_width):
@@ -205,30 +210,25 @@ class Requant_rtl(Requant, RTLBackend):
                 f.write("{:0{}x}\n".format(int(w), hex_digits))
 
     def generate_params(self, model, path, fpgapart=None):
-        """Emit the two decoupled memstream init files for the current params.
+        """Emit the unified decoupled memstream init file for the current params.
 
-        Writes ``scale_memblock.dat`` and ``bias_memblock.dat`` into ``path`` for
-        the scale/bias currently attached to this node in ``model``. Used both by
-        standalone decoupled generation and, per loop iteration, by
+        Writes ``params_memblock.dat`` into ``path`` for the scale/bias
+        currently attached to this node in ``model``. Used both by standalone
+        decoupled generation and, per loop iteration, by
         ``FINNLoop.generate_params`` (which sets the per-iteration initializers
         before calling this). ``fpgapart`` is required to resolve the DSP version
         so the fixed-point layout matches the elaborated core. Returns the packed
-        ``(scale_words, bias_words)`` for reuse by callers.
+        ``params_words`` list for reuse by callers.
         """
         assert fpgapart is not None, "Requant_rtl.generate_params requires fpgapart"
         info = self._derive_decoupled_widths(model, fpgapart)
-        scale_words, bias_words = self._pack_param_words(info)
+        params_words = self._pack_param_words(info)
         self._write_memblock(
-            os.path.join(path, "scale_memblock.dat"),
-            scale_words,
-            info["scale_stream_width"],
+            os.path.join(path, "params_memblock.dat"),
+            params_words,
+            info["params_stream_width"],
         )
-        self._write_memblock(
-            os.path.join(path, "bias_memblock.dat"),
-            bias_words,
-            info["bias_stream_width"],
-        )
-        return scale_words, bias_words
+        return params_words
 
     def generate_hdl(self, model, fpgapart, clk):
         """Generate RTL code for the requant operation."""
@@ -337,12 +337,13 @@ class Requant_rtl(Requant, RTLBackend):
         self.set_nodeattr("gen_top_module", top_module_name)
 
     def _generate_hdl_decoupled(self, model, fpgapart, clk, code_gen_dir):
-        """Decoupled mode: stream scale/bias from two memstreams.
+        """Decoupled mode: stream scale/tap/bias from a unified param memstream.
 
         The float->fixed-point decomposition is done in Python
-        (``decompose_params``); the resulting per-channel words are packed and
-        emitted as two memstream init files, and the compute core is elaborated
-        with the worst-case TAP_MIN/TAP_MAX window instead of embedded params.
+        (``decompose_params``); the resulting per-channel words are packed into
+        a single struct-based stream and emitted as one memstream init file, and
+        the compute core is elaborated with the worst-case TAP_MIN/TAP_MAX
+        window instead of embedded params.
         """
         info = self._derive_decoupled_widths(model, fpgapart)
 
@@ -364,10 +365,6 @@ class Requant_rtl(Requant, RTLBackend):
             "$PE$": str(pe),
             "$TAP_MIN$": str(info["tap_min"]),
             "$TAP_MAX$": str(info["tap_max"]),
-            "$IN_STREAM_WIDTH$": str(info["in_stream_width"]),
-            "$OUT_STREAM_WIDTH$": str(info["out_stream_width"]),
-            "$SCALE_STREAM_WIDTH$": str(info["scale_stream_width"]),
-            "$BIAS_STREAM_WIDTH$": str(info["bias_stream_width"]),
         }
 
         # Verilog wrapper (.v) for IP packaging
@@ -380,34 +377,22 @@ class Requant_rtl(Requant, RTLBackend):
 
         self.set_nodeattr("gen_top_module", top_module_name)
 
-        # Emit memstream init files (.dat) via the shared generate_params path,
+        # Emit memstream init file (.dat) via the shared generate_params path,
         # plus the packed words as .npy for standalone rtlsim.
-        scale_words, bias_words = self.generate_params(model, code_gen_dir, fpgapart)
+        params_words = self.generate_params(model, code_gen_dir, fpgapart)
         np.save(
-            os.path.join(code_gen_dir, "scale_words.npy"),
-            np.array(scale_words, dtype=object),
-        )
-        np.save(
-            os.path.join(code_gen_dir, "bias_words.npy"),
-            np.array(bias_words, dtype=object),
+            os.path.join(code_gen_dir, "params_words.npy"),
+            np.array(params_words, dtype=object),
         )
 
-        # Emit the two memstream wrappers (scale + bias)
+        # Emit the unified memstream wrapper (params = scale + tap + bias)
         node_name = self.onnx_node.name
         self.generate_hdl_memstream(
             fpgapart,
-            name=node_name + "_scale",
+            name=node_name + "_params",
             depth=cf,
-            width=info["scale_stream_width"],
-            init_file=os.path.join(code_gen_dir, "scale_memblock.dat"),
-            ram_style="auto",
-        )
-        self.generate_hdl_memstream(
-            fpgapart,
-            name=node_name + "_bias",
-            depth=cf,
-            width=info["bias_stream_width"],
-            init_file=os.path.join(code_gen_dir, "bias_memblock.dat"),
+            width=info["params_stream_width"],
+            init_file=os.path.join(code_gen_dir, "params_memblock.dat"),
             ram_style="auto",
         )
 
@@ -460,7 +445,7 @@ class Requant_rtl(Requant, RTLBackend):
         return cmd
 
     def _code_generation_ipi_decoupled(self):
-        """Instantiate the decoupled core plus the scale/bias memstreams."""
+        """Instantiate the decoupled core plus the unified param memstream."""
         node_name = self.onnx_node.name
         top_module = self.get_nodeattr("gen_top_module")
         code_gen_dir = self.get_nodeattr("code_gen_dir_ipgen")
@@ -481,16 +466,15 @@ class Requant_rtl(Requant, RTLBackend):
             "-vlnv xilinx.com:interface:axis_rtl:1.0 /%s/in0_V" % node_name
         )
 
-        # MLO: expose per-iteration set-select slave pins for scale (in1_V) and
-        # bias (in2_V). These carry the memstream set index driven by the
-        # FINNLoop stream-tap graph; standalone (SETS=1) leaves them absent.
+        # MLO: expose per-iteration set-select slave pin for the unified param
+        # memstream (in1_V). This carries the memstream set index driven by the
+        # FINNLoop stream-tap graph; standalone (SETS=1) leaves it absent.
         mlo = self.get_nodeattr("mlo_max_iter") > 0
         if mlo:
-            for ext_pin in ["in1_V", "in2_V"]:
-                cmd.append(
-                    "create_bd_intf_pin -mode Slave "
-                    "-vlnv xilinx.com:interface:axis_rtl:1.0 /%s/%s" % (node_name, ext_pin)
-                )
+            cmd.append(
+                "create_bd_intf_pin -mode Slave "
+                "-vlnv xilinx.com:interface:axis_rtl:1.0 /%s/in1_V" % node_name
+            )
 
         # Compute core
         for f in self.get_rtl_file_list(abspath=True):
@@ -521,56 +505,56 @@ class Requant_rtl(Requant, RTLBackend):
         for f in [axi_dir + "axilite.sv", ms_dir + "memstream_axi.sv", ms_dir + "memstream.sv"]:
             cmd.append("add_files -copy_to %s -norecurse %s" % (source_target, f))
 
-        # Scale + bias memstreamers, each feeding the matching core param port.
-        # In MLO mode the external set-select pin (in1_V/in2_V) drives the
+        # Unified param memstreamer feeding the core's s_params_V port.
+        # In MLO mode the external set-select pin (in1_V) drives the
         # memstreamer's s_axis_0; standalone leaves s_axis_0 unwired (SETS=1).
-        for suffix, core_port, ext_pin in [
-            ("_scale", "s_scale_V", "in1_V"),
-            ("_bias", "s_bias_V", "in2_V"),
-        ]:
-            # Discover the generated wrapper by suffix rather than reconstructing
-            # from node_name: inside a FINNLoop body the node is renamed between
-            # generate_hdl (files carry the loop-prefixed name) and ipi time, so
-            # the module name lives in gen_top_module / the filename, not in
-            # self.onnx_node.name (mirrors MVAU matrixvectoractivation.py:1176).
-            file_suffix = suffix + "_memstream_wrapper.v"
-            wrapper_fname = None
-            for fname in os.listdir(code_gen_dir):
-                if fname.endswith(file_suffix):
-                    wrapper_fname = fname
-            assert wrapper_fname is not None, "Requant decoupled: could not find %s in %s" % (
-                file_suffix,
-                code_gen_dir,
-            )
-            wrapper_file = os.path.join(code_gen_dir, wrapper_fname)
-            cmd.append("add_files -copy_to %s -norecurse %s" % (source_target, wrapper_file))
-            strm_mod = wrapper_fname[:-2]
-            strm_inst = node_name + suffix + "_wstrm"
+        suffix = "_params"
+        core_port = "s_params_V"
+        ext_pin = "in1_V"
+
+        # Discover the generated wrapper by suffix rather than reconstructing
+        # from node_name: inside a FINNLoop body the node is renamed between
+        # generate_hdl (files carry the loop-prefixed name) and ipi time, so
+        # the module name lives in gen_top_module / the filename, not in
+        # self.onnx_node.name (mirrors MVAU matrixvectoractivation.py:1176).
+        file_suffix = suffix + "_memstream_wrapper.v"
+        wrapper_fname = None
+        for fname in os.listdir(code_gen_dir):
+            if fname.endswith(file_suffix):
+                wrapper_fname = fname
+        assert wrapper_fname is not None, "Requant decoupled: could not find %s in %s" % (
+            file_suffix,
+            code_gen_dir,
+        )
+        wrapper_file = os.path.join(code_gen_dir, wrapper_fname)
+        cmd.append("add_files -copy_to %s -norecurse %s" % (source_target, wrapper_file))
+        strm_mod = wrapper_fname[:-2]
+        strm_inst = node_name + suffix + "_wstrm"
+        cmd.append(
+            "create_bd_cell -type hier -reference %s /%s/%s" % (strm_mod, node_name, strm_inst)
+        )
+        cmd.append(
+            "connect_bd_net [get_bd_pins %s/ap_clk] [get_bd_pins %s/%s/ap_clk]"
+            % (node_name, node_name, strm_inst)
+        )
+        cmd.append(
+            "connect_bd_net [get_bd_pins %s/ap_clk] [get_bd_pins %s/%s/ap_clk2x]"
+            % (node_name, node_name, strm_inst)
+        )
+        cmd.append(
+            "connect_bd_net [get_bd_pins %s/ap_rst_n] [get_bd_pins %s/%s/ap_rst_n]"
+            % (node_name, node_name, strm_inst)
+        )
+        cmd.append(
+            "connect_bd_intf_net [get_bd_intf_pins %s/%s/m_axis_0] "
+            "[get_bd_intf_pins %s/%s/%s]"
+            % (node_name, strm_inst, node_name, node_name, core_port)
+        )
+        if mlo:
             cmd.append(
-                "create_bd_cell -type hier -reference %s /%s/%s" % (strm_mod, node_name, strm_inst)
+                "connect_bd_intf_net [get_bd_intf_pins %s/%s] "
+                "[get_bd_intf_pins %s/%s/s_axis_0]" % (node_name, ext_pin, node_name, strm_inst)
             )
-            cmd.append(
-                "connect_bd_net [get_bd_pins %s/ap_clk] [get_bd_pins %s/%s/ap_clk]"
-                % (node_name, node_name, strm_inst)
-            )
-            cmd.append(
-                "connect_bd_net [get_bd_pins %s/ap_clk] [get_bd_pins %s/%s/ap_clk2x]"
-                % (node_name, node_name, strm_inst)
-            )
-            cmd.append(
-                "connect_bd_net [get_bd_pins %s/ap_rst_n] [get_bd_pins %s/%s/ap_rst_n]"
-                % (node_name, node_name, strm_inst)
-            )
-            cmd.append(
-                "connect_bd_intf_net [get_bd_intf_pins %s/%s/m_axis_0] "
-                "[get_bd_intf_pins %s/%s/%s]"
-                % (node_name, strm_inst, node_name, node_name, core_port)
-            )
-            if mlo:
-                cmd.append(
-                    "connect_bd_intf_net [get_bd_intf_pins %s/%s] "
-                    "[get_bd_intf_pins %s/%s/s_axis_0]" % (node_name, ext_pin, node_name, strm_inst)
-                )
 
         cmd.append("save_bd_design")
         return cmd
@@ -613,17 +597,13 @@ class Requant_rtl(Requant, RTLBackend):
                     "%s: standalone rtlsim cannot drive the set-select index; "
                     "a SETS>1 (MLO) Requant must be executed via FINNLoop." % node.name
                 )
-                # Feed the two decomposed parameter streams alongside the data.
+                # Feed the unified parameter stream alongside the data.
                 # The memstream cycles CF words; replicate per input vector.
-                scale_words = list(
-                    np.load(os.path.join(code_gen_dir, "scale_words.npy"), allow_pickle=True)
-                )
-                bias_words = list(
-                    np.load(os.path.join(code_gen_dir, "bias_words.npy"), allow_pickle=True)
+                params_words = list(
+                    np.load(os.path.join(code_gen_dir, "params_words.npy"), allow_pickle=True)
                 )
                 num_vectors = int(np.prod(self.get_nodeattr("numInputVectors")))
-                io_dict["inputs"]["s_scale"] = [int(w) for w in scale_words] * num_vectors
-                io_dict["inputs"]["s_bias"] = [int(w) for w in bias_words] * num_vectors
+                io_dict["inputs"]["s_params"] = [int(w) for w in params_words] * num_vectors
 
             sim = self.get_rtlsim()
             self.reset_rtlsim(sim)

--- a/src/finn/custom_op/fpgadataflow/rtl/requant_rtl.py
+++ b/src/finn/custom_op/fpgadataflow/rtl/requant_rtl.py
@@ -3,6 +3,7 @@
 
 import numpy as np
 import os
+from qonnx.core.datatype import DataType
 
 from finn.custom_op.fpgadataflow.requant import Requant
 from finn.custom_op.fpgadataflow.rtlbackend import RTLBackend
@@ -46,6 +47,58 @@ class Requant_rtl(Requant, RTLBackend):
         )
         return my_attrs
 
+    def adapt_for_loop_body(self, input_types):
+        """Adapt Requant_rtl for loop body (MLO) execution.
+
+        Requant's default ``mem_mode`` is ``internal_embedded``, which
+        constant-folds scale/bias into the SV datapath and therefore cannot vary
+        per loop iteration. When LoopRolling flags this node for MLO (it sets
+        ``mlo_max_iter`` on the consumer of each per-iteration PARAMETER input),
+        switch to ``internal_decoupled`` so scale+bias are streamed from the two
+        memstreams instead (mirrors MVAU_rtl's embedded->external_mem switch, but
+        with Requant's own decoupled target mode). Gate on the per-node
+        ``mlo_max_iter`` signal rather than the positional ``input_types``.
+        """
+        if self.get_nodeattr("mlo_max_iter") > 0:
+            self.set_nodeattr("mem_mode", "internal_decoupled")
+
+    def _mlo_set_bits_padded(self):
+        """Byte-padded width of the per-iteration set-select stream.
+
+        Must match the FINNLoop stream_tap ``$DATA_WIDTH$``
+        (finn_loop.py:548-550) so that the tap's ``m_axis`` connects cleanly to
+        the ``in1_V``/``in2_V`` set-select slave pins.
+        """
+        iteration = self.get_nodeattr("mlo_max_iter")
+        data_width = DataType.get_smallest_possible(iteration).bitwidth()
+        return roundup_to_integer_multiple(data_width, 8)
+
+    def get_verilog_top_module_intf_names(self):
+        """Interface names for the Requant top module.
+
+        Base case exposes only the activation stream ``in0_V`` and output
+        ``out0_V`` (scale/bias are internal to the decoupled hierarchy). In MLO
+        mode two extra set-select slave pins ``in1_V`` (scale) and ``in2_V``
+        (bias) are appended in graph-input order; each is driven by a FINNLoop
+        stream_tap and selects the active parameter set in its memstream.
+        """
+        intf_names = {"clk": ["ap_clk"], "rst": ["ap_rst_n"]}
+        intf_names["s_axis"] = [("in0_V", self.get_instream_width_padded(0))]
+        if (
+            self.get_nodeattr("mlo_max_iter") > 0
+            and self.get_nodeattr("mem_mode") == "internal_decoupled"
+        ):
+            set_bits_padded = self._mlo_set_bits_padded()
+            intf_names["s_axis"] += [
+                ("in1_V", set_bits_padded),
+                ("in2_V", set_bits_padded),
+            ]
+        intf_names["m_axis"] = [("out0_V", self.get_outstream_width_padded(0))]
+        intf_names["aximm"] = []
+        intf_names["axilite"] = []
+        intf_names["ap_none"] = []
+        return intf_names
+
     def _resolve_dsp_version(self, fpgapart):
         """Determine DSP version based on FPGA part."""
         dsp_block = get_dsp_block(fpgapart)
@@ -72,19 +125,32 @@ class Requant_rtl(Requant, RTLBackend):
         tap_min = params["tap_min"]
         tap_max = params["tap_max"]
 
+        pe = self.get_nodeattr("PE")
+        k = self.get_input_datatype(0).bitwidth()
+        n = self.get_output_datatype().bitwidth()
+
+        # In MLO mode the scale stream WIDTH and the core TAP_MIN/TAP_MAX are
+        # baked once at generate_hdl time but must cover *every* loop iteration's
+        # params. Since a valid tap is structurally bounded to
+        # 0 <= tap <= s_width + x_width + 1 - n (see decompose_params, purely
+        # datatype/version-derived), size the window to that worst case instead
+        # of the per-layer [min, max]. This makes the layout iteration-invariant
+        # and leaf-local (no cross-iteration knowledge needed).
+        if self.get_nodeattr("mlo_max_iter") > 0:
+            tap_min = 0
+            tap_max = s_width + x_width + 1 - n
+
         bias_w = s_width + x_width
         tap_range = tap_max - tap_min + 1
         tap_bits = max(1, _clog2(tap_range)) if tap_range > 1 else 1
         scale_lane_w = s_width + tap_bits
 
-        pe = self.get_nodeattr("PE")
-        k = self.get_input_datatype(0).bitwidth()
-        n = self.get_output_datatype().bitwidth()
-
         info = dict(params)
         info.update(
             {
                 "version": version,
+                "tap_min": tap_min,
+                "tap_max": tap_max,
                 "bias_w": bias_w,
                 "tap_bits": tap_bits,
                 "scale_lane_w": scale_lane_w,
@@ -137,6 +203,32 @@ class Requant_rtl(Requant, RTLBackend):
         with open(path, "w") as f:
             for w in words:
                 f.write("{:0{}x}\n".format(int(w), hex_digits))
+
+    def generate_params(self, model, path, fpgapart=None):
+        """Emit the two decoupled memstream init files for the current params.
+
+        Writes ``scale_memblock.dat`` and ``bias_memblock.dat`` into ``path`` for
+        the scale/bias currently attached to this node in ``model``. Used both by
+        standalone decoupled generation and, per loop iteration, by
+        ``FINNLoop.generate_params`` (which sets the per-iteration initializers
+        before calling this). ``fpgapart`` is required to resolve the DSP version
+        so the fixed-point layout matches the elaborated core. Returns the packed
+        ``(scale_words, bias_words)`` for reuse by callers.
+        """
+        assert fpgapart is not None, "Requant_rtl.generate_params requires fpgapart"
+        info = self._derive_decoupled_widths(model, fpgapart)
+        scale_words, bias_words = self._pack_param_words(info)
+        self._write_memblock(
+            os.path.join(path, "scale_memblock.dat"),
+            scale_words,
+            info["scale_stream_width"],
+        )
+        self._write_memblock(
+            os.path.join(path, "bias_memblock.dat"),
+            bias_words,
+            info["bias_stream_width"],
+        )
+        return scale_words, bias_words
 
     def generate_hdl(self, model, fpgapart, clk):
         """Generate RTL code for the requant operation."""
@@ -288,18 +380,9 @@ class Requant_rtl(Requant, RTLBackend):
 
         self.set_nodeattr("gen_top_module", top_module_name)
 
-        # Pack decomposed params and emit memstream init files + rtlsim words
-        scale_words, bias_words = self._pack_param_words(info)
-        self._write_memblock(
-            os.path.join(code_gen_dir, "scale_memblock.dat"),
-            scale_words,
-            info["scale_stream_width"],
-        )
-        self._write_memblock(
-            os.path.join(code_gen_dir, "bias_memblock.dat"),
-            bias_words,
-            info["bias_stream_width"],
-        )
+        # Emit memstream init files (.dat) via the shared generate_params path,
+        # plus the packed words as .npy for standalone rtlsim.
+        scale_words, bias_words = self.generate_params(model, code_gen_dir, fpgapart)
         np.save(
             os.path.join(code_gen_dir, "scale_words.npy"),
             np.array(scale_words, dtype=object),
@@ -398,6 +481,17 @@ class Requant_rtl(Requant, RTLBackend):
             "-vlnv xilinx.com:interface:axis_rtl:1.0 /%s/in0_V" % node_name
         )
 
+        # MLO: expose per-iteration set-select slave pins for scale (in1_V) and
+        # bias (in2_V). These carry the memstream set index driven by the
+        # FINNLoop stream-tap graph; standalone (SETS=1) leaves them absent.
+        mlo = self.get_nodeattr("mlo_max_iter") > 0
+        if mlo:
+            for ext_pin in ["in1_V", "in2_V"]:
+                cmd.append(
+                    "create_bd_intf_pin -mode Slave "
+                    "-vlnv xilinx.com:interface:axis_rtl:1.0 /%s/%s" % (node_name, ext_pin)
+                )
+
         # Compute core
         for f in self.get_rtl_file_list(abspath=True):
             cmd.append("add_files -copy_to %s -norecurse %s" % (source_target, f))
@@ -427,11 +521,30 @@ class Requant_rtl(Requant, RTLBackend):
         for f in [axi_dir + "axilite.sv", ms_dir + "memstream_axi.sv", ms_dir + "memstream.sv"]:
             cmd.append("add_files -copy_to %s -norecurse %s" % (source_target, f))
 
-        # Scale + bias memstreamers, each feeding the matching core param port
-        for suffix, core_port in [("_scale", "s_scale_V"), ("_bias", "s_bias_V")]:
-            wrapper_file = os.path.join(code_gen_dir, node_name + suffix + "_memstream_wrapper.v")
+        # Scale + bias memstreamers, each feeding the matching core param port.
+        # In MLO mode the external set-select pin (in1_V/in2_V) drives the
+        # memstreamer's s_axis_0; standalone leaves s_axis_0 unwired (SETS=1).
+        for suffix, core_port, ext_pin in [
+            ("_scale", "s_scale_V", "in1_V"),
+            ("_bias", "s_bias_V", "in2_V"),
+        ]:
+            # Discover the generated wrapper by suffix rather than reconstructing
+            # from node_name: inside a FINNLoop body the node is renamed between
+            # generate_hdl (files carry the loop-prefixed name) and ipi time, so
+            # the module name lives in gen_top_module / the filename, not in
+            # self.onnx_node.name (mirrors MVAU matrixvectoractivation.py:1176).
+            file_suffix = suffix + "_memstream_wrapper.v"
+            wrapper_fname = None
+            for fname in os.listdir(code_gen_dir):
+                if fname.endswith(file_suffix):
+                    wrapper_fname = fname
+            assert wrapper_fname is not None, "Requant decoupled: could not find %s in %s" % (
+                file_suffix,
+                code_gen_dir,
+            )
+            wrapper_file = os.path.join(code_gen_dir, wrapper_fname)
             cmd.append("add_files -copy_to %s -norecurse %s" % (source_target, wrapper_file))
-            strm_mod = node_name + suffix + "_memstream_wrapper"
+            strm_mod = wrapper_fname[:-2]
             strm_inst = node_name + suffix + "_wstrm"
             cmd.append(
                 "create_bd_cell -type hier -reference %s /%s/%s" % (strm_mod, node_name, strm_inst)
@@ -453,6 +566,11 @@ class Requant_rtl(Requant, RTLBackend):
                 "[get_bd_intf_pins %s/%s/%s]"
                 % (node_name, strm_inst, node_name, node_name, core_port)
             )
+            if mlo:
+                cmd.append(
+                    "connect_bd_intf_net [get_bd_intf_pins %s/%s] "
+                    "[get_bd_intf_pins %s/%s/s_axis_0]" % (node_name, ext_pin, node_name, strm_inst)
+                )
 
         cmd.append("save_bd_design")
         return cmd
@@ -487,6 +605,14 @@ class Requant_rtl(Requant, RTLBackend):
             }
 
             if decoupled:
+                # A SETS>1 (MLO) memstream needs a per-iteration set-select
+                # index on s_axis_0, which the standalone .npy streaming path
+                # cannot supply. Such nodes must be executed via the stitched
+                # FINNLoop rtlsim, which drives the set index in hardware.
+                assert self.get_nodeattr("mlo_max_iter") == 0, (
+                    "%s: standalone rtlsim cannot drive the set-select index; "
+                    "a SETS>1 (MLO) Requant must be executed via FINNLoop." % node.name
+                )
                 # Feed the two decomposed parameter streams alongside the data.
                 # The memstream cycles CF words; replicate per input vector.
                 scale_words = list(

--- a/src/finn/custom_op/fpgadataflow/rtl/requant_rtl.py
+++ b/src/finn/custom_op/fpgadataflow/rtl/requant_rtl.py
@@ -1,6 +1,4 @@
-# Copyright (C) 2026, Advanced Micro Devices, Inc.
-# All rights reserved.
-#
+# Copyright Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: BSD-3-Clause
 
 import numpy as np
@@ -8,8 +6,18 @@ import os
 
 from finn.custom_op.fpgadataflow.requant import Requant
 from finn.custom_op.fpgadataflow.rtlbackend import RTLBackend
-from finn.util.basic import get_dsp_block, make_build_dir
+from finn.util.basic import get_dsp_block, make_build_dir, roundup_to_integer_multiple
 from finn.util.data_packing import npy_to_rtlsim_input, rtlsim_output_to_npy
+
+
+def _twos(value, width):
+    """Return the ``width``-bit two's-complement representation of ``value``."""
+    return int(value) & ((1 << width) - 1)
+
+
+def _clog2(n):
+    """Ceil(log2(n)) matching Verilog ``$clog2`` for n >= 1."""
+    return (n - 1).bit_length()
 
 
 class Requant_rtl(Requant, RTLBackend):
@@ -22,6 +30,20 @@ class Requant_rtl(Requant, RTLBackend):
         my_attrs = {}
         my_attrs.update(Requant.get_nodeattr_types(self))
         my_attrs.update(RTLBackend.get_nodeattr_types(self))
+        my_attrs.update(
+            {
+                # memory mode for the scale/bias parameters
+                # internal_embedded: constant-folded into the datapath (default)
+                # internal_decoupled: streamed from two on-chip memstreams
+                "mem_mode": (
+                    "s",
+                    False,
+                    "internal_embedded",
+                    {"internal_embedded", "internal_decoupled"},
+                ),
+                "runtime_writeable_weights": ("i", False, 0, {0, 1}),
+            }
+        )
         return my_attrs
 
     def _resolve_dsp_version(self, fpgapart):
@@ -35,6 +57,87 @@ class Requant_rtl(Requant, RTLBackend):
             case _:
                 return 1
 
+    def _derive_decoupled_widths(self, model, fpgapart):
+        """Derive the fixed-point stream layout for decoupled mode.
+
+        Returns a dict with the decomposed params plus the per-lane and
+        byte-aligned stream widths for the scale and bias parameter streams and
+        the input/output data streams. All widths are consistent with the
+        localparam derivation in ``requant_axi_decoupled.sv``.
+        """
+        version = self._resolve_dsp_version(fpgapart)
+        params = self.decompose_params(model, version)
+        s_width = params["s_width"]
+        x_width = params["x_width"]
+        tap_min = params["tap_min"]
+        tap_max = params["tap_max"]
+
+        bias_w = s_width + x_width
+        tap_range = tap_max - tap_min + 1
+        tap_bits = max(1, _clog2(tap_range)) if tap_range > 1 else 1
+        scale_lane_w = s_width + tap_bits
+
+        pe = self.get_nodeattr("PE")
+        k = self.get_input_datatype(0).bitwidth()
+        n = self.get_output_datatype().bitwidth()
+
+        info = dict(params)
+        info.update(
+            {
+                "version": version,
+                "bias_w": bias_w,
+                "tap_bits": tap_bits,
+                "scale_lane_w": scale_lane_w,
+                "in_stream_width": roundup_to_integer_multiple(pe * k, 8),
+                "out_stream_width": roundup_to_integer_multiple(pe * n, 8),
+                "scale_stream_width": roundup_to_integer_multiple(pe * scale_lane_w, 8),
+                "bias_stream_width": roundup_to_integer_multiple(pe * bias_w, 8),
+            }
+        )
+        return info
+
+    def _pack_param_words(self, info):
+        """Pack the decomposed params into per-fold stream words.
+
+        Lane 0 (pe=0) occupies the least significant bits, matching the RTL
+        ``s_scale_tdata[0+:PE*SCALE_LANE_W]`` / ``core_sdat`` unpacking. Returns
+        two lists (scale_words, bias_words) of ``CF`` Python integers each.
+        """
+        pe = self.get_nodeattr("PE")
+        num_channels = self.get_nodeattr("NumChannels")
+        cf = num_channels // pe
+
+        scale = info["scale"]
+        bias = info["bias"]
+        tap = info["tap"]
+        tap_min = info["tap_min"]
+        s_width = info["s_width"]
+        tap_bits = info["tap_bits"]
+        scale_lane_w = info["scale_lane_w"]
+        bias_w = info["bias_w"]
+
+        scale_words = []
+        bias_words = []
+        for c in range(cf):
+            s_word = 0
+            b_word = 0
+            for p in range(pe):
+                t_off = int(tap[p][c]) - tap_min
+                s_lane = (_twos(t_off, tap_bits) << s_width) | _twos(scale[p][c], s_width)
+                s_word |= s_lane << (p * scale_lane_w)
+                b_word |= _twos(bias[p][c], bias_w) << (p * bias_w)
+            scale_words.append(s_word)
+            bias_words.append(b_word)
+        return scale_words, bias_words
+
+    @staticmethod
+    def _write_memblock(path, words, stream_width):
+        """Write memstream init .dat: one hex word per line, zero-padded."""
+        hex_digits = stream_width // 4
+        with open(path, "w") as f:
+            for w in words:
+                f.write("{:0{}x}\n".format(int(w), hex_digits))
+
     def generate_hdl(self, model, fpgapart, clk):
         """Generate RTL code for the requant operation."""
         code_gen_dir = self.get_nodeattr("code_gen_dir_ipgen")
@@ -42,6 +145,21 @@ class Requant_rtl(Requant, RTLBackend):
             code_gen_dir = make_build_dir("requant_rtl_ipgen_")
             self.set_nodeattr("code_gen_dir_ipgen", code_gen_dir)
 
+        mem_mode = self.get_nodeattr("mem_mode")
+        if mem_mode == "internal_embedded":
+            self._generate_hdl_embedded(model, fpgapart, clk, code_gen_dir)
+        elif mem_mode == "internal_decoupled":
+            self._generate_hdl_decoupled(model, fpgapart, clk, code_gen_dir)
+        else:
+            raise ValueError(f"{self.onnx_node.name}: unsupported mem_mode {mem_mode}.")
+
+        # set ipgen_path and ip_path so that HLS-Synth transformation
+        # and stitch ip transformation do not complain
+        self.set_nodeattr("ipgen_path", code_gen_dir)
+        self.set_nodeattr("ip_path", code_gen_dir)
+
+    def _generate_hdl_embedded(self, model, fpgapart, clk, code_gen_dir):
+        """Embedded mode: constant-fold scale/bias into the SV datapath."""
         # Get parameters
         pe = self.get_nodeattr("PE")
         num_channels = self.get_nodeattr("NumChannels")
@@ -126,28 +244,116 @@ class Requant_rtl(Requant, RTLBackend):
 
         self.set_nodeattr("gen_top_module", top_module_name)
 
-        # set ipgen_path and ip_path so that HLS-Synth transformation
-        # and stitch ip transformation do not complain
-        self.set_nodeattr("ipgen_path", code_gen_dir)
-        self.set_nodeattr("ip_path", code_gen_dir)
+    def _generate_hdl_decoupled(self, model, fpgapart, clk, code_gen_dir):
+        """Decoupled mode: stream scale/bias from two memstreams.
+
+        The float->fixed-point decomposition is done in Python
+        (``decompose_params``); the resulting per-channel words are packed and
+        emitted as two memstream init files, and the compute core is elaborated
+        with the worst-case TAP_MIN/TAP_MAX window instead of embedded params.
+        """
+        info = self._derive_decoupled_widths(model, fpgapart)
+
+        pe = self.get_nodeattr("PE")
+        num_channels = self.get_nodeattr("NumChannels")
+        cf = num_channels // pe
+        k = self.get_input_datatype(0).bitwidth()
+        n = self.get_output_datatype().bitwidth()
+
+        top_module_name = self.get_verilog_top_module_name()
+        rtllib_dir = os.environ["FINN_ROOT"] + "/finn-rtllib/requant/hdl/"
+
+        subst = {
+            "$TOP_MODULE_NAME$": top_module_name,
+            "$VERSION$": str(info["version"]),
+            "$K$": str(k),
+            "$N$": str(n),
+            "$C$": str(num_channels),
+            "$PE$": str(pe),
+            "$TAP_MIN$": str(info["tap_min"]),
+            "$TAP_MAX$": str(info["tap_max"]),
+            "$IN_STREAM_WIDTH$": str(info["in_stream_width"]),
+            "$OUT_STREAM_WIDTH$": str(info["out_stream_width"]),
+            "$SCALE_STREAM_WIDTH$": str(info["scale_stream_width"]),
+            "$BIAS_STREAM_WIDTH$": str(info["bias_stream_width"]),
+        }
+
+        # Verilog wrapper (.v) for IP packaging
+        with open(rtllib_dir + "requant_wrapper_decoupled_template.v", "r") as f:
+            v_code = f.read()
+        for key, val in subst.items():
+            v_code = v_code.replace(key, val)
+        with open(os.path.join(code_gen_dir, top_module_name + ".v"), "w") as f:
+            f.write(v_code)
+
+        self.set_nodeattr("gen_top_module", top_module_name)
+
+        # Pack decomposed params and emit memstream init files + rtlsim words
+        scale_words, bias_words = self._pack_param_words(info)
+        self._write_memblock(
+            os.path.join(code_gen_dir, "scale_memblock.dat"),
+            scale_words,
+            info["scale_stream_width"],
+        )
+        self._write_memblock(
+            os.path.join(code_gen_dir, "bias_memblock.dat"),
+            bias_words,
+            info["bias_stream_width"],
+        )
+        np.save(
+            os.path.join(code_gen_dir, "scale_words.npy"),
+            np.array(scale_words, dtype=object),
+        )
+        np.save(
+            os.path.join(code_gen_dir, "bias_words.npy"),
+            np.array(bias_words, dtype=object),
+        )
+
+        # Emit the two memstream wrappers (scale + bias)
+        node_name = self.onnx_node.name
+        self.generate_hdl_memstream(
+            fpgapart,
+            name=node_name + "_scale",
+            depth=cf,
+            width=info["scale_stream_width"],
+            init_file=os.path.join(code_gen_dir, "scale_memblock.dat"),
+            ram_style="auto",
+        )
+        self.generate_hdl_memstream(
+            fpgapart,
+            name=node_name + "_bias",
+            depth=cf,
+            width=info["bias_stream_width"],
+            init_file=os.path.join(code_gen_dir, "bias_memblock.dat"),
+            ram_style="auto",
+        )
 
     def get_rtl_file_list(self, abspath=False):
         """Return list of RTL files needed for this node."""
         rtllib_dir = os.environ["FINN_ROOT"] + "/finn-rtllib/requant/hdl/"
         code_gen_dir = self.get_nodeattr("code_gen_dir_ipgen")
 
-        rtl_files = [
-            rtllib_dir + "queue.sv",
-            rtllib_dir + "requant.sv",
-            rtllib_dir + "requant_axi.sv",
-        ]
-
-        # Add generated wrappers (Verilog stub + SystemVerilog impl)
         top_module = self.get_nodeattr("gen_top_module")
         if top_module == "":
             top_module = self.get_verilog_top_module_name()
-        rtl_files.append(os.path.join(code_gen_dir, top_module + "_impl.sv"))
-        rtl_files.append(os.path.join(code_gen_dir, top_module + ".v"))
+
+        if self.get_nodeattr("mem_mode") == "internal_decoupled":
+            rtl_files = [
+                rtllib_dir + "queue.sv",
+                rtllib_dir + "requant_decoupled.sv",
+                rtllib_dir + "requant_axi_decoupled.sv",
+                # generated Verilog wrapper (directly instantiates the SV core)
+                os.path.join(code_gen_dir, top_module + ".v"),
+            ]
+        else:
+            rtl_files = [
+                rtllib_dir + "queue.sv",
+                rtllib_dir + "requant.sv",
+                rtllib_dir + "requant_axi.sv",
+                # generated SystemVerilog impl + Verilog stub wrapper
+                os.path.join(code_gen_dir, top_module + "_impl.sv"),
+                os.path.join(code_gen_dir, top_module + ".v"),
+            ]
 
         if abspath:
             return rtl_files
@@ -155,6 +361,10 @@ class Requant_rtl(Requant, RTLBackend):
             return [os.path.basename(f) for f in rtl_files]
 
     def code_generation_ipi(self):
+        """Return the Vivado IPI Tcl commands that instantiate this node."""
+        if self.get_nodeattr("mem_mode") == "internal_decoupled":
+            return self._code_generation_ipi_decoupled()
+
         sourcefiles = self.get_rtl_file_list(abspath=True)
 
         cmd = []
@@ -166,16 +376,96 @@ class Requant_rtl(Requant, RTLBackend):
         ]
         return cmd
 
+    def _code_generation_ipi_decoupled(self):
+        """Instantiate the decoupled core plus the scale/bias memstreams."""
+        node_name = self.onnx_node.name
+        top_module = self.get_nodeattr("gen_top_module")
+        code_gen_dir = self.get_nodeattr("code_gen_dir_ipgen")
+        source_target = "./ip/verilog/rtl_ops/%s" % node_name
+
+        cmd = ["file mkdir %s" % source_target]
+
+        # Hierarchy with external data in/out pins (params are internal)
+        cmd.append("create_bd_cell -type hier %s" % node_name)
+        cmd.append("create_bd_pin -dir I -type clk /%s/ap_clk" % node_name)
+        cmd.append("create_bd_pin -dir I -type rst /%s/ap_rst_n" % node_name)
+        cmd.append(
+            "create_bd_intf_pin -mode Master "
+            "-vlnv xilinx.com:interface:axis_rtl:1.0 /%s/out0_V" % node_name
+        )
+        cmd.append(
+            "create_bd_intf_pin -mode Slave "
+            "-vlnv xilinx.com:interface:axis_rtl:1.0 /%s/in0_V" % node_name
+        )
+
+        # Compute core
+        for f in self.get_rtl_file_list(abspath=True):
+            cmd.append("add_files -copy_to %s -norecurse %s" % (source_target, f))
+        cmd.append(
+            "create_bd_cell -type module -reference %s /%s/%s" % (top_module, node_name, node_name)
+        )
+        cmd.append(
+            "connect_bd_net [get_bd_pins %s/ap_clk] [get_bd_pins %s/%s/ap_clk]"
+            % (node_name, node_name, node_name)
+        )
+        cmd.append(
+            "connect_bd_net [get_bd_pins %s/ap_rst_n] [get_bd_pins %s/%s/ap_rst_n]"
+            % (node_name, node_name, node_name)
+        )
+        cmd.append(
+            "connect_bd_intf_net [get_bd_intf_pins %s/in0_V] "
+            "[get_bd_intf_pins %s/%s/in0_V]" % (node_name, node_name, node_name)
+        )
+        cmd.append(
+            "connect_bd_intf_net [get_bd_intf_pins %s/out0_V] "
+            "[get_bd_intf_pins %s/%s/out0_V]" % (node_name, node_name, node_name)
+        )
+
+        # Shared memstream sources
+        axi_dir = os.path.join(os.environ["FINN_ROOT"], "finn-rtllib/axi/hdl/")
+        ms_dir = os.path.join(os.environ["FINN_ROOT"], "finn-rtllib/memstream/hdl/")
+        for f in [axi_dir + "axilite.sv", ms_dir + "memstream_axi.sv", ms_dir + "memstream.sv"]:
+            cmd.append("add_files -copy_to %s -norecurse %s" % (source_target, f))
+
+        # Scale + bias memstreamers, each feeding the matching core param port
+        for suffix, core_port in [("_scale", "s_scale_V"), ("_bias", "s_bias_V")]:
+            wrapper_file = os.path.join(code_gen_dir, node_name + suffix + "_memstream_wrapper.v")
+            cmd.append("add_files -copy_to %s -norecurse %s" % (source_target, wrapper_file))
+            strm_mod = node_name + suffix + "_memstream_wrapper"
+            strm_inst = node_name + suffix + "_wstrm"
+            cmd.append(
+                "create_bd_cell -type hier -reference %s /%s/%s" % (strm_mod, node_name, strm_inst)
+            )
+            cmd.append(
+                "connect_bd_net [get_bd_pins %s/ap_clk] [get_bd_pins %s/%s/ap_clk]"
+                % (node_name, node_name, strm_inst)
+            )
+            cmd.append(
+                "connect_bd_net [get_bd_pins %s/ap_clk] [get_bd_pins %s/%s/ap_clk2x]"
+                % (node_name, node_name, strm_inst)
+            )
+            cmd.append(
+                "connect_bd_net [get_bd_pins %s/ap_rst_n] [get_bd_pins %s/%s/ap_rst_n]"
+                % (node_name, node_name, strm_inst)
+            )
+            cmd.append(
+                "connect_bd_intf_net [get_bd_intf_pins %s/%s/m_axis_0] "
+                "[get_bd_intf_pins %s/%s/%s]"
+                % (node_name, strm_inst, node_name, node_name, core_port)
+            )
+
+        cmd.append("save_bd_design")
+        return cmd
+
     def execute_node(self, context, graph):
         """Execute the node, using RTL simulation if exec_mode is rtlsim."""
         mode = self.get_nodeattr("exec_mode")
         if mode == "rtlsim":
-            # Custom RTL sim that only passes input 0 (data), not scale/bias
-            # which are embedded as parameters in the generated HDL
             node = self.onnx_node
             code_gen_dir = self.get_nodeattr("code_gen_dir_ipgen")
+            decoupled = self.get_nodeattr("mem_mode") == "internal_decoupled"
 
-            # Only process input 0 (data tensor)
+            # Process input 0 (data tensor)
             inp = node.input[0]
             exp_ishape = tuple(self.get_normal_input_shape(0))
             folded_ishape = self.get_folded_input_shape(0)
@@ -195,6 +485,19 @@ class Requant_rtl(Requant, RTLBackend):
                 "inputs": {"in0": rtlsim_inp},
                 "outputs": {"out0": []},
             }
+
+            if decoupled:
+                # Feed the two decomposed parameter streams alongside the data.
+                # The memstream cycles CF words; replicate per input vector.
+                scale_words = list(
+                    np.load(os.path.join(code_gen_dir, "scale_words.npy"), allow_pickle=True)
+                )
+                bias_words = list(
+                    np.load(os.path.join(code_gen_dir, "bias_words.npy"), allow_pickle=True)
+                )
+                num_vectors = int(np.prod(self.get_nodeattr("numInputVectors")))
+                io_dict["inputs"]["s_scale"] = [int(w) for w in scale_words] * num_vectors
+                io_dict["inputs"]["s_bias"] = [int(w) for w in bias_words] * num_vectors
 
             sim = self.get_rtlsim()
             self.reset_rtlsim(sim)

--- a/src/finn/custom_op/fpgadataflow/rtl/requant_rtl.py
+++ b/src/finn/custom_op/fpgadataflow/rtl/requant_rtl.py
@@ -550,8 +550,7 @@ class Requant_rtl(Requant, RTLBackend):
         )
         cmd.append(
             "connect_bd_intf_net [get_bd_intf_pins %s/%s/m_axis_0] "
-            "[get_bd_intf_pins %s/%s/%s]"
-            % (node_name, strm_inst, node_name, node_name, core_port)
+            "[get_bd_intf_pins %s/%s/%s]" % (node_name, strm_inst, node_name, node_name, core_port)
         )
         if mlo:
             cmd.append(

--- a/src/finn/custom_op/fpgadataflow/rtl/requant_rtl.py
+++ b/src/finn/custom_op/fpgadataflow/rtl/requant_rtl.py
@@ -313,6 +313,7 @@ class Requant_rtl(Requant, RTLBackend):
         sv_code = sv_code.replace("$PE$", str(pe))
         sv_code = sv_code.replace("$SCALES$", scales_sv)
         sv_code = sv_code.replace("$BIASES$", biases_sv)
+        sv_code = sv_code.replace("$SIGNED_OUT$", str(int(odt.signed())))
         sv_code = sv_code.replace("$IN_STREAM_WIDTH$", str(in_stream_width))
         sv_code = sv_code.replace("$OUT_STREAM_WIDTH$", str(out_stream_width))
 
@@ -356,6 +357,7 @@ class Requant_rtl(Requant, RTLBackend):
         top_module_name = self.get_verilog_top_module_name()
         rtllib_dir = os.environ["FINN_ROOT"] + "/finn-rtllib/requant/hdl/"
 
+        odt = self.get_output_datatype()
         subst = {
             "$TOP_MODULE_NAME$": top_module_name,
             "$VERSION$": str(info["version"]),
@@ -365,6 +367,7 @@ class Requant_rtl(Requant, RTLBackend):
             "$PE$": str(pe),
             "$TAP_MIN$": str(info["tap_min"]),
             "$TAP_MAX$": str(info["tap_max"]),
+            "$SIGNED_OUT$": str(int(odt.signed())),
         }
 
         # Verilog wrapper (.v) for IP packaging

--- a/src/finn/transformation/fpgadataflow/specialize_layers.py
+++ b/src/finn/transformation/fpgadataflow/specialize_layers.py
@@ -203,7 +203,7 @@ def _determine_impl_style(node, fpgapart, model):
             else:
                 warn_str = """There is no RTL variant for %s. The node will automatically be
                         set to HLS variant. The RTL Requant layers currently only supports
-                        integer inputs, unsigned outputs and non-narrow quantization.""" % (
+                        integer inputs and non-narrow quantization.""" % (
                     node.name,
                 )
                 warnings.warn(warn_str)
@@ -386,14 +386,12 @@ def _requant_rtl_possible(n, fpgapart):
     # Checks whether RTL-based Requant is supported
     # RTL Requant requires:
     # - Integer input (not float)
-    # - Unsigned output (RTL clips to [0, 2^N-1])
     # - Full range (narrow=0)
     node_inst = getCustomOp(n)
     idt = node_inst.get_input_datatype(0)
-    odt = node_inst.get_output_datatype(0)
     narrow = node_inst.get_nodeattr("narrow")
-    # RTL backend works with integer inputs, unsigned outputs, and full range
-    return idt.is_integer() and not odt.signed() and narrow == 0
+    # RTL backend works with integer inputs and full range
+    return idt.is_integer() and narrow == 0
 
 
 class SpecializeLayers(Transformation):

--- a/tests/fpgadataflow/test_fpgadataflow_finnloop.py
+++ b/tests/fpgadataflow/test_fpgadataflow_finnloop.py
@@ -917,12 +917,12 @@ def create_chained_requant_loop_bodies(
 @pytest.mark.vivado
 @pytest.mark.slow
 def test_finnloop_end2end_mlo_requant(mvau_cfg, iteration, per_channel):
-    """End-to-end MLO rtlsim for a Requant_rtl body node (two-param memstreams).
+    """End-to-end MLO rtlsim for a Requant_rtl body node (unified param memstream).
 
     A Requant inside the loop body is rolled up by LoopRolling; its scale and
-    bias become per-iteration PARAMETER inputs, each fed from its own memstream
-    (storing ``iteration`` sets) via a dedicated stream tap. Exercises the
-    N-taps-per-node generalization in finn_loop.py next to a single-tap MVAU.
+    bias become per-iteration PARAMETER inputs, packed into a single struct-based
+    memstream (storing ``iteration`` sets) via a dedicated stream tap. Exercises
+    the coupled scale+bias decomposition in finn_loop.py next to a single-tap MVAU.
     """
     dim, mvau_pe, mvau_simd, mvau_th, helper_pe = mvau_cfg
     # Vivado 2024.2+ required for MLO

--- a/tests/fpgadataflow/test_fpgadataflow_finnloop.py
+++ b/tests/fpgadataflow/test_fpgadataflow_finnloop.py
@@ -751,3 +751,261 @@ def test_finnloop_end2end_mlo(
         assert os.path.isfile(
             tmp_output_dir + "/stitched_ip/finn_design.dcp"
         ), f"Check vivado.log in {tmp_output_dir}/stitched_ip"
+
+
+def make_mvau_requant_loop_body(
+    mw,
+    mh,
+    dtype=DataType["UINT8"],
+    name_suffix="",
+    mvau_pe=2,
+    mvau_simd=2,
+    mvau_th=1,
+    helper_pe=2,
+    per_channel=False,
+):
+    """Create a minimal loop body: MVAU_rtl -> Requant_rtl.
+
+    Requant is the first body op with two PARAMETER inputs (scale=input[1],
+    bias=input[2]), so this body exercises the two-tap fan-out in the FINNLoop
+    stream-tap graph right next to the single-tap MVAU. scale/bias are FLOAT32
+    graph inputs (per-tensor or per-channel), so LoopRolling stacks a distinct
+    set per iteration and both memstreams store ``iteration`` sets.
+
+    The activation path is UNSIGNED (UINT8): RTL Requant only emits unsigned
+    outputs, and the FINNLoop body requires its activation input datatype to
+    equal its output datatype (the output feeds the next iteration's input).
+    Weights stay INT8.
+    """
+    W0 = gen_finn_dt_tensor(DataType["INT8"], (mw, mh))
+    # FLOAT32 scale/bias, per-channel [mh] or per-tensor [1]. The magnitudes are
+    # kept in a range that keeps every per-channel tap within the structural
+    # window (0 <= tap <= s_width+x_width+1-n) that decompose_params asserts.
+    param_shape = [mh] if per_channel else [1]
+    scale = np.random.uniform(2**-10, 2**-8, param_shape).astype(np.float32)
+    bias = np.random.uniform(-4.0, 4.0, param_shape).astype(np.float32)
+
+    nodes = [
+        create_node(
+            "MVAU_rtl",
+            [f"ifm{name_suffix}", f"weights0{name_suffix}"],
+            [f"mm0_out{name_suffix}"],
+            f"MVAU_rtl_0{name_suffix}",
+            {
+                "MW": mw,
+                "MH": mh,
+                "SIMD": mvau_simd,
+                "PE": mvau_pe,
+                "TH": mvau_th,
+                "inputDataType": "UINT8",
+                "weightDataType": "INT8",
+                "outputDataType": "INT32",
+                "ActVal": 0,
+                "binaryXnorMode": 0,
+                "noActivation": 1,
+            },
+        ),
+        create_node(
+            "Requant_rtl",
+            [f"mm0_out{name_suffix}", f"scale{name_suffix}", f"bias{name_suffix}"],
+            [f"ofm{name_suffix}"],
+            f"Requant_rtl_0{name_suffix}",
+            {
+                "NumChannels": mh,
+                "PE": helper_pe,
+                "inputDataType": "INT32",
+                "outputDataType": "UINT8",
+                "narrow": 0,
+                "numInputVectors": [1, 3, 3],
+            },
+        ),
+    ]
+
+    loop_body = helper.make_graph(
+        nodes=nodes,
+        name=f"mvau_requant_graph{name_suffix}",
+        inputs=[
+            create_tensor_info(f"ifm{name_suffix}", [1, 3, 3, mw]),
+            create_tensor_info(f"scale{name_suffix}", param_shape),
+            create_tensor_info(f"bias{name_suffix}", param_shape),
+        ],
+        outputs=[create_tensor_info(f"ofm{name_suffix}", (1, 3, 3, mh))],
+        value_info=[
+            create_tensor_info(f"mm0_out{name_suffix}", [1, 3, 3, mh]),
+        ],
+    )
+
+    loop_body_model = qonnx_make_model(loop_body, producer_name=f"mvau-requant-body{name_suffix}")
+    loop_body_model = ModelWrapper(loop_body_model)
+
+    loop_body_model.set_initializer(f"weights0{name_suffix}", W0)
+    loop_body_model.set_initializer(f"scale{name_suffix}", scale)
+    loop_body_model.set_initializer(f"bias{name_suffix}", bias)
+
+    loop_body_model.set_tensor_datatype(f"weights0{name_suffix}", DataType["INT8"])
+    loop_body_model.set_tensor_datatype(f"ifm{name_suffix}", dtype)
+    loop_body_model.set_tensor_datatype(f"mm0_out{name_suffix}", DataType["INT32"])
+    loop_body_model.set_tensor_datatype(f"scale{name_suffix}", DataType["FLOAT32"])
+    loop_body_model.set_tensor_datatype(f"bias{name_suffix}", DataType["FLOAT32"])
+    loop_body_model.set_tensor_datatype(f"ofm{name_suffix}", DataType["UINT8"])
+
+    return loop_body_model
+
+
+def create_chained_requant_loop_bodies(
+    mw,
+    mh,
+    num_copies,
+    mvau_pe=2,
+    mvau_simd=2,
+    mvau_th=1,
+    helper_pe=2,
+    per_channel=False,
+):
+    """Build ``num_copies`` structurally-identical MVAU_rtl -> Requant_rtl bodies.
+
+    Each copy carries distinct weights/scale/bias so LoopRolling produces a real
+    per-iteration parameter stack for both memstreams.
+    """
+    loop_body_models = []
+    for i in range(num_copies):
+        name_suffix = f"_{i}"
+        loop_body_models.append(
+            make_mvau_requant_loop_body(
+                mw=mw,
+                mh=mh,
+                dtype=DataType["UINT8"],
+                name_suffix=name_suffix,
+                mvau_pe=mvau_pe,
+                mvau_simd=mvau_simd,
+                mvau_th=mvau_th,
+                helper_pe=helper_pe,
+                per_channel=per_channel,
+            )
+        )
+    return loop_body_models
+
+
+# (dim, mvau_pe, mvau_simd, mvau_th, helper_pe); TH=1 -> standard MVAU.
+@pytest.mark.parametrize(
+    "mvau_cfg",
+    [
+        (16, 2, 2, 1, 2),
+        (12, 6, 3, 1, 6),
+    ],
+)
+@pytest.mark.parametrize("iteration", [3])
+@pytest.mark.parametrize("per_channel", [False, True])
+@pytest.mark.fpgadataflow
+@pytest.mark.vivado
+@pytest.mark.slow
+def test_finnloop_end2end_mlo_requant(mvau_cfg, iteration, per_channel):
+    """End-to-end MLO rtlsim for a Requant_rtl body node (two-param memstreams).
+
+    A Requant inside the loop body is rolled up by LoopRolling; its scale and
+    bias become per-iteration PARAMETER inputs, each fed from its own memstream
+    (storing ``iteration`` sets) via a dedicated stream tap. Exercises the
+    N-taps-per-node generalization in finn_loop.py next to a single-tap MVAU.
+    """
+    dim, mvau_pe, mvau_simd, mvau_th, helper_pe = mvau_cfg
+    # Vivado 2024.2+ required for MLO
+    vivado_path = os.environ.get("XILINX_VIVADO")
+    match = re.search(r"\b(20\d{2})\.(1|2)\b", vivado_path)
+    year, minor = int(match.group(1)), int(match.group(2))
+    if (year, minor) < (2024, 2):
+        pytest.skip("""At least Vivado version 2024.2 needed for MLO.""")
+
+    loop_body_models = create_chained_requant_loop_bodies(
+        dim,
+        dim,
+        iteration,
+        mvau_pe=mvau_pe,
+        mvau_simd=mvau_simd,
+        mvau_th=mvau_th,
+        helper_pe=helper_pe,
+        per_channel=per_channel,
+    )
+    nodes_per_body = len(loop_body_models[0].graph.node)
+    model = loop_body_models[0]
+    for m in loop_body_models[1:]:
+        model = model.transform(MergeONNXModels(m))
+
+    # cleanup
+    model = model.transform(RemoveUnusedTensors())
+    model = model.transform(InferShapes())
+    model = model.transform(InferDataTypes())
+
+    # Generate cppsim reference output on the unrolled model. The activation path
+    # is unsigned so the loop body input/output datatypes match (see body helper).
+    input_dtype = DataType["UINT8"]
+    x = gen_finn_dt_tensor(input_dtype, (1, 3, 3, dim))
+    model_ref = model.transform(PrepareCppSim())
+    model_ref = model_ref.transform(CompileCppSim())
+    model_ref = model_ref.transform(SetExecMode("cppsim"))
+    io_dict = {model_ref.graph.input[0].name: x}
+    y_dict = oxe.execute_onnx(model_ref, io_dict)
+    y_ref = y_dict[model_ref.graph.output[0].name]
+
+    tmp_output_dir = make_build_dir("build_mlo_requant")
+    np.save(tmp_output_dir + "/input.npy", x)
+    np.save(tmp_output_dir + "/expected_output.npy", y_ref)
+    model.save(tmp_output_dir + "/mlo_model.onnx")
+
+    steps = [
+        "step_create_dataflow_partition",
+        "phase_convert_to_hardware",  # includes loop rolling
+        "phase_optimize_hardware",
+        "phase_build_hardware",
+        "phase_generate_outputs",
+    ]
+
+    cfg = build_cfg.DataflowBuildConfig(
+        output_dir=tmp_output_dir,
+        steps=steps,
+        synth_clk_period_ns=10.0,
+        board="V80",
+        rtlsim_batch_size=100,
+        mlo=True,
+        loop_body_hierarchy=[["", "layers.0"]],
+        loop_body_range=(model.graph.node[0], model.graph.node[nodes_per_body - 1]),
+        verify_steps=verif_steps,
+        verify_input_npy=tmp_output_dir + "/input.npy",
+        verify_expected_output_npy=tmp_output_dir + "/expected_output.npy",
+        verify_save_full_context=True,
+        generate_outputs=[
+            build_cfg.DataflowOutputType.ESTIMATE_REPORTS,
+            build_cfg.DataflowOutputType.STITCHED_IP,
+        ],
+    )
+    build.build_dataflow_cfg(tmp_output_dir + "/mlo_model.onnx", cfg)
+
+    # loop body template + stitched IP produced
+    assert os.path.isfile(tmp_output_dir + "/loop-body-template.onnx")
+    assert os.path.isfile(tmp_output_dir + "/stitched_ip/ip/component.xml")
+
+    # all three verification steps matched the cppsim reference exactly
+    verif_dir = tmp_output_dir + "/verification_output"
+    assert os.path.isfile(
+        verif_dir + "/verify_folded_hls_cppsim_0_SUCCESS.npz"
+    ), f"Check npz files in {verif_dir}"
+    assert os.path.isfile(
+        verif_dir + "/verify_node_by_node_rtlsim_0_SUCCESS.npz"
+    ), f"Check npz files in {verif_dir}"
+    assert os.path.isfile(
+        verif_dir + "/verify_stitched_ip_rtlsim_0_SUCCESS.npy"
+    ), f"Check npy files in {verif_dir}"
+
+    # per-iteration context captured for all iterations
+    iteration_context_files = [
+        f for f in os.listdir(verif_dir) if f.startswith("iteration_context_")
+    ]
+    assert len(iteration_context_files) > 0, f"No iteration context files found in {verif_dir}"
+    ctx_data = np.load(os.path.join(verif_dir, iteration_context_files[0]))
+    iter_indices = set()
+    for key in [k for k in ctx_data.files if k.startswith("iter_")]:
+        parts = key.split("_", 2)
+        if len(parts) >= 2:
+            iter_indices.add(int(parts[1]))
+    assert (
+        len(iter_indices) == iteration
+    ), f"Expected {iteration} iterations in context, found {len(iter_indices)}"

--- a/tests/fpgadataflow/test_fpgadataflow_requant.py
+++ b/tests/fpgadataflow/test_fpgadataflow_requant.py
@@ -52,6 +52,10 @@ from finn.transformation.fpgadataflow.prepare_rtlsim import PrepareRTLSim
 from finn.transformation.fpgadataflow.set_exec_mode import SetExecMode
 from finn.transformation.fpgadataflow.set_fifo_depths import InsertAndSetFIFODepths
 from finn.transformation.fpgadataflow.specialize_layers import SpecializeLayers
+from finn.transformation.fpgadataflow.transpose_decomposition import (
+    InferInnerOuterShuffles,
+    ShuffleDecomposition,
+)
 from finn.transformation.qonnx.convert_qonnx_to_finn import ConvertQONNXtoFINN
 from finn.transformation.qonnx.quant_act_to_multithreshold import (
     default_filter_function_generator,
@@ -115,11 +119,14 @@ def create_requant_model(abits, max_val, ishape, per_channel):
     "part", ["xcvc1902-vsva2197-2MP-e-S", "xczu7ev-ffvc1156-2-e", "xc7z020clg400-1"]
 )
 @pytest.mark.parametrize("pe", [1, 16])
-@pytest.mark.parametrize("exec_mode", ["cppsim", "rtlsim"])
+@pytest.mark.parametrize("sim_style", ["cppsim", "node_by_node", "stitched_ip"])
+@pytest.mark.parametrize(
+    "mem_mode", ["internal_decoupled"]
+)  # "internal_embedded", "internal_decoupled"])
 @pytest.mark.fpgadataflow
 @pytest.mark.slow
 @pytest.mark.vivado
-def test_requant_rtl(abits, ishape, per_channel, part, pe, exec_mode):
+def test_requant_rtl(abits, ishape, per_channel, part, pe, sim_style, mem_mode):
     """Test Requant RTL backend with different devices (DSP variants).
 
     Tests integer input which uses the RTL backend.
@@ -169,29 +176,51 @@ def test_requant_rtl(abits, ishape, per_channel, part, pe, exec_mode):
     requant_rtl_nodes = model.get_nodes_by_op_type("Requant_rtl")
     assert len(requant_rtl_nodes) == 1, "Expected Requant_rtl for INT8 input"
     getCustomOp(requant_rtl_nodes[0]).set_nodeattr("PE", pe)
+    getCustomOp(requant_rtl_nodes[0]).set_nodeattr("mem_mode", mem_mode)
 
     # Prepare and run simulation
-    model = model.transform(SetExecMode(exec_mode))
-
-    if exec_mode == "cppsim":
+    #  - cppsim / node_by_node feed the decomposed scale/bias words directly into
+    #    the core, so they exercise the datapath + param decomposition/packing.
+    #  - stitched_ip instantiates the two memstreams and free-runs them from the
+    #    generated .dat files, which is the only path that exercises the
+    #    memstreamers (and their fold-address cycling when CF > 1).
+    if sim_style == "cppsim":
+        model = model.transform(SetExecMode("cppsim"))
         model = model.transform(PrepareCppSim())
         model = model.transform(CompileCppSim())
-        y_sim = oxe.execute_onnx(model, input_dict)[model.graph.output[0].name]
-        assert np.allclose(
-            y_golden, y_sim, atol=quant_step
-        ), f"cppsim mismatch: max diff = {np.max(np.abs(y_golden - y_sim))}"
-    else:
-        # Node-by-node rtlsim
+    elif sim_style == "node_by_node":
+        model = model.transform(SetExecMode("rtlsim"))
         model = model.transform(PrepareIP(part, target_clk_ns))
         model = model.transform(HLSSynthIP())
         model = model.transform(PrepareRTLSim())
+    elif sim_style == "stitched_ip":
+        # Convert any remaining Mul nodes to HW for stitched IP
+        model = model.transform(to_hw.InferElementwiseBinaryOperation())
+        # 4D inputs carry a layout Transpose (NCHW<->NHWC) with no HW op yet.
+        # Only when such a Transpose is present, convert it to a HW Shuffle and
+        # decompose it into inner/outer shuffles so the whole graph becomes
+        # fpgadataflow. _filter=lambda *_: True also converts a leading input
+        # transpose (the default filter skips graph.node[0]).
+        if len(model.get_nodes_by_op_type("Transpose")) > 0:
+            model = model.transform(to_hw.InferShuffle(_filter=lambda *_: True))
+            model = model.transform(SpecializeLayers(part))
+            model = model.transform(ShuffleDecomposition())
+            model = model.transform(InferInnerOuterShuffles())
+        model = model.transform(SpecializeLayers(part))
+        model = model.transform(GiveUniqueNodeNames())
+        model = model.transform(InsertAndSetFIFODepths(part, target_clk_ns))
+        model = model.transform(PrepareIP(part, target_clk_ns))
+        model = model.transform(HLSSynthIP())
+        model = model.transform(CreateStitchedIP(part, target_clk_ns))
+        model.set_metadata_prop("exec_mode", "rtlsim")
 
-        y_sim = oxe.execute_onnx(model, input_dict)[model.graph.output[0].name]
-        assert np.allclose(
-            y_golden, y_sim, atol=quant_step
-        ), f"rtlsim mismatch: max diff = {np.max(np.abs(y_golden - y_sim))}"
+    y_sim = oxe.execute_onnx(model, input_dict)[model.graph.output[0].name]
+    assert np.allclose(
+        y_golden, y_sim, atol=quant_step
+    ), f"{sim_style} mismatch: max diff = {np.max(np.abs(y_golden - y_sim))}"
 
-        # Verify cycle estimation
+    # Verify cycle estimation (node-by-node rtlsim only)
+    if sim_style == "node_by_node":
         node = model.get_nodes_by_op_type("Requant_rtl")[0]
         inst = getCustomOp(node)
         cycles_rtlsim = inst.get_nodeattr("cycles_rtlsim")
@@ -199,29 +228,6 @@ def test_requant_rtl(abits, ishape, per_channel, part, pe, exec_mode):
         exp_cycles = exp_cycles_dict[node.name]
         assert np.isclose(exp_cycles, cycles_rtlsim, atol=15)
         assert exp_cycles != 0
-
-        # Stitched IP rtlsim - only for one specific config to save time
-        if (
-            abits == 8
-            and ishape == (1, 16)
-            and not per_channel
-            and pe == 16
-            and part == "xczu7ev-ffvc1156-2-e"
-        ):
-            # Convert any remaining Mul nodes to HW for stitched IP
-            model = model.transform(to_hw.InferElementwiseBinaryOperation())
-            model = model.transform(SpecializeLayers(part))
-            model = model.transform(GiveUniqueNodeNames())
-            model = model.transform(InsertAndSetFIFODepths(part, target_clk_ns))
-            model = model.transform(PrepareIP(part, target_clk_ns))
-            model = model.transform(HLSSynthIP())
-            model = model.transform(CreateStitchedIP(part, target_clk_ns))
-
-            model.set_metadata_prop("exec_mode", "rtlsim")
-            y_stitched = oxe.execute_onnx(model, input_dict)[model.graph.output[0].name]
-            assert np.allclose(
-                y_golden, y_stitched, atol=quant_step
-            ), f"stitched rtlsim mismatch: max diff = {np.max(np.abs(y_golden - y_stitched))}"
 
 
 # =============================================================================


### PR DESCRIPTION
Extends Requant_rtl with two enhancements:

1. Signed output support: Requant_rtl now supports both signed and unsigned output clipping based on the output datatype. Previously only unsigned outputs were supported. 
2. Decoupled parameter mode: New mem_mode="internal_decoupled" option streams scale/bias/tap parameters from a unified memstream instead of constant-folding them into the RTL. This can be used standalone for runtime-updateable parameters, and is also a prerequisite for MLO support.

MLO Support

Building on decoupled mode, Requant can now be used inside FINNLoop bodies where parameters vary per loop iteration:
  - adapt_for_loop_body() auto-switches to decoupled mode when LoopRolling flags the node
  - Parameters are served by an indexed memstream with set-select driven by FINNLoop's stream tap graph
