### PR TITLE
[FINN XSI] Fix waveform corruption on rtlsim timeout

### DIFF
--- a/finn_xsi/finn_xsi/adapter.py
+++ b/finn_xsi/finn_xsi/adapter.py
@@ -169,6 +169,13 @@ def close_rtlsim(sim):
     if sim_finish is not None:
         sim_finish.set(1).write_back()
         sim.cycle({})
+    # Explicitly finalize the design (calls xsi_close -> flushes+closes the .wdb)
+    # instead of relying on GC of sim.top. Port back-refs and the pybind use_map
+    # can keep the Design alive past `del sim`, so without this the waveform can
+    # be left unflushed on a timeout/pdb exit, corrupting its trace tail.
+    close = getattr(sim.top, "close", None)
+    if close is not None:
+        close()
     del sim
 
 

--- a/finn_xsi/xsi_bind.cpp
+++ b/finn_xsi/xsi_bind.cpp
@@ -49,6 +49,7 @@ PYBIND11_MODULE(xsi, m) {
 			return  d;
 		}))
 		.def("trace_all", &Design::trace_all)
+		.def("close",     &Design::close)
 		.def("run",       &Design::run)
 		.def("restart",   &Design::restart)
 		.def("get_status",     &Design::get_status)

--- a/finn_xsi/xsi_finn.hpp
+++ b/finn_xsi/xsi_finn.hpp
@@ -216,6 +216,7 @@ public:
 class Design {
 	using  Xsi = Kernel::Xsi;
 	Kernel &_kernel;
+	bool    _closed = false;
 
 public:
 	Design(
@@ -231,7 +232,21 @@ public:
 		.logFileName = const_cast<char*>(log_file),
 		.wdbFileName = const_cast<char*>(wdb_file)
 	}) {}
-	~Design() { _kernel.close(); }
+	~Design() { close(); }
+
+	// Explicitly finalize the design: _kernel.close() calls xsi_close, which
+	// flushes and closes the waveform database. Idempotent (guarded by _closed)
+	// so the destructor can also call it safely. Exposed to Python so callers
+	// can deterministically finalize the .wdb instead of relying on garbage
+	// collection of this object -- Port back-refs and the pybind use_map can
+	// keep it alive past `del`, leaving the wdb unflushed and its trace tail
+	// corrupt on a timeout/pdb exit.
+	void close() noexcept {
+		if(!_closed) {
+			_closed = true;
+			_kernel.close();
+		}
+	}
 
 private:
 	Design(Design const&) = delete;


### PR DESCRIPTION
 On a timeout/pdb exit, the XSI waveform database could be left unflushed, corrupting the tail of the trace. Port back-refs and the pybind `use_map` keep the `Design` alive past `del sim`, so relying on garbage collection to close the `.wdb` was unreliable.

This adds an explicit, idempotent `Design::close()` (calls `xsi_close` to flush+close the `.wdb`), exposes it to Python, and calls it from `close_rtlsim()` so the waveform is finalized deterministically.

Authored by @STFleming.