### PR TITLE
Allow for MLO model to be execute with parent

### DIFF
--- a/src/finn/builder/build_dataflow_steps.py
+++ b/src/finn/builder/build_dataflow_steps.py
@@ -204,7 +204,6 @@ def verify_step(
     cfg: DataflowBuildConfig,
     step_name: str,
     need_parent: bool,
-    batched: bool = False,
 ):
     print("Running verification for " + step_name)
     verify_out_dir = cfg.output_dir + "/verification_output"
@@ -215,13 +214,13 @@ def verify_step(
     bsize_out = exp_out_npy_all.shape[0]
     assert bsize_in == bsize_out, "Batch sizes don't match for verification IO pair"
     all_res = True
-    if batched:
-        chunks = [(in_npy_all, exp_out_npy_all, 0)]
-    else:
-        chunks = [
-            (np.expand_dims(in_npy_all[b], axis=0), np.expand_dims(exp_out_npy_all[b], axis=0), b)
-            for b in range(bsize_in)
-        ]
+    # Verification runs one frame at a time (execute_onnx only accepts a single
+    # frame), so split the batched IO array into single-frame chunks. Batched
+    # multi-frame rtlsim is still possible by calling rtlsim_exec directly.
+    chunks = [
+        (np.expand_dims(in_npy_all[b], axis=0), np.expand_dims(exp_out_npy_all[b], axis=0), b)
+        for b in range(bsize_in)
+    ]
     for in_npy, exp_out_npy, index in chunks:
         if need_parent:
             assert cfg.save_intermediate_models, "Enable save_intermediate_models for verification"
@@ -1163,14 +1162,13 @@ def step_create_stitched_ip(model: ModelWrapper, cfg: DataflowBuildConfig):
                 verify_model.set_metadata_prop("rtlsim_trace", abspath + "/verify_rtlsim.wdb")
             if cfg.verify_rtlsim_behavioral:
                 verify_model.set_metadata_prop("rtlsim_behavioral", "1")
-            # MLO verification uses batched=True; the stitched child self-derives its
-            # FINNLoop memory-init pre-hook, so both paths route through the parent.
+            # MLO and non-MLO both route through the parent (need_parent=True); the
+            # stitched child self-derives its FINNLoop memory-init pre-hook.
             verify_step(
                 verify_model,
                 cfg,
                 "stitched_ip_rtlsim",
                 need_parent=True,
-                batched=is_mlo(model),
             )
             if is_mlo(model):
                 for loop_node in verify_model.get_nodes_by_op_type("FINNLoop"):

--- a/src/finn/builder/build_dataflow_steps.py
+++ b/src/finn/builder/build_dataflow_steps.py
@@ -92,7 +92,6 @@ from finn.builder.build_dataflow_config import (
     VerificationStepType,
 )
 from finn.core.onnx_exec import execute_onnx
-from finn.core.rtlsim_exec import rtlsim_exec
 from finn.transformation.fpgadataflow.absorb_into_requant import (
     AbsorbElementwiseOpsIntoRequant,
 )
@@ -161,7 +160,7 @@ from finn.util.config import (
     extract_model_config_to_json,
 )
 from finn.util.fpgadataflow import is_mlo, warn_hls_rtl_dsp_conflict
-from finn.util.rtlsim import annotate_rtlsim_performance, mlo_prehook_func_factory
+from finn.util.rtlsim import annotate_rtlsim_performance
 from finn.util.test import execute_parent
 from finn.util.vivado import parse_ooc_synth_results
 
@@ -205,7 +204,6 @@ def verify_step(
     cfg: DataflowBuildConfig,
     step_name: str,
     need_parent: bool,
-    rtlsim_pre_hook=None,
     batched: bool = False,
 ):
     print("Running verification for " + step_name)
@@ -256,12 +254,8 @@ def verify_step(
                 print("Attempting to force model shape on verification input")
                 in_npy = in_npy.reshape(target_ishape)
             inp_dict = {inp_tensor_name: in_npy}
-            if rtlsim_pre_hook is not None:
-                rtlsim_exec(model, inp_dict, pre_hook=rtlsim_pre_hook)
-                out_npy = inp_dict[out_tensor_name]
-            else:
-                out_dict = execute_onnx(model, inp_dict, True)
-                out_npy = out_dict[out_tensor_name]
+            out_dict = execute_onnx(model, inp_dict, True)
+            out_npy = out_dict[out_tensor_name]
         exp_oshape = exp_out_npy.shape
         if out_npy.shape != exp_oshape:
             print(
@@ -279,7 +273,7 @@ def verify_step(
         all_res = all_res and res
         res_to_str = {True: "SUCCESS", False: "FAIL"}
         res_str = res_to_str[res]
-        if cfg.verify_save_full_context and (rtlsim_pre_hook is None):
+        if cfg.verify_save_full_context:
             verification_output_fn = verify_out_dir + "/verify_%s_%d_%s.npz" % (
                 step_name,
                 index,
@@ -287,8 +281,6 @@ def verify_step(
             )
             np.savez(verification_output_fn, **out_dict)
         else:
-            if cfg.verify_save_full_context:
-                print("Warning: Unable to save the full context when using MLO")
             verification_output_fn = verify_out_dir + "/verify_%s_%d_%s.npy" % (
                 step_name,
                 index,
@@ -1095,20 +1087,6 @@ def step_set_fifo_depths(model: ModelWrapper, cfg: DataflowBuildConfig):
     return model
 
 
-def verify_mlo(model: ModelWrapper, cfg: DataflowBuildConfig, step: str):
-    finn_loop = model.get_nodes_by_op_type("FINNLoop")
-    # TODO: allow for multiple FINNLoops
-    mlo_prehook = mlo_prehook_func_factory(finn_loop[0])
-    verify_step(
-        model,
-        cfg,
-        "stitched_ip_rtlsim",
-        need_parent=False,
-        rtlsim_pre_hook=mlo_prehook,
-        batched=True,
-    )
-
-
 def step_create_stitched_ip(model: ModelWrapper, cfg: DataflowBuildConfig):
     """Create stitched IP for a graph after all HLS IP blocks have been generated.
     Depends on the DataflowOutputType.STITCHED_IP output product."""
@@ -1183,14 +1161,19 @@ def step_create_stitched_ip(model: ModelWrapper, cfg: DataflowBuildConfig):
                 verify_model.set_metadata_prop("rtlsim_trace", abspath + "/verify_rtlsim.wdb")
             if cfg.verify_rtlsim_behavioral:
                 verify_model.set_metadata_prop("rtlsim_behavioral", "1")
+            # MLO verification uses batched=True; the stitched child self-derives its
+            # FINNLoop memory-init pre-hook, so both paths route through the parent.
+            verify_step(
+                verify_model,
+                cfg,
+                "stitched_ip_rtlsim",
+                need_parent=True,
+                batched=is_mlo(model),
+            )
             if is_mlo(model):
-                verify_mlo(verify_model, cfg, "stitched_ip_rtlsim")
                 for loop_node in verify_model.get_nodes_by_op_type("FINNLoop"):
                     snapshot_fifo_logs(cfg, "stitched_ip_rtlsim", loop_context=loop_node.name)
-                snapshot_fifo_logs(cfg, "stitched_ip_rtlsim")
-            else:
-                verify_step(verify_model, cfg, "stitched_ip_rtlsim", need_parent=True)
-                snapshot_fifo_logs(cfg, "stitched_ip_rtlsim")
+            snapshot_fifo_logs(cfg, "stitched_ip_rtlsim")
     return model
 
 

--- a/src/finn/core/rtlsim_exec.py
+++ b/src/finn/core/rtlsim_exec.py
@@ -41,7 +41,7 @@ from finn.util.basic import (
     make_build_dir,
 )
 from finn.util.data_packing import npy_to_rtlsim_input, rtlsim_output_to_npy
-from finn.util.rtlsim import dat_file_to_numpy_array
+from finn.util.rtlsim import dat_file_to_numpy_array, mlo_prehook_func_factory
 
 finnxsi = xsi if xsi.is_available() else None
 
@@ -391,6 +391,15 @@ def rtlsim_exec_finnxsi(model, execution_context, pre_hook=None, post_hook=None)
             weight_data = dat_file_to_numpy_array(dat_path)
             sim.aximm_ro_image(aximm_name, 0, weight_data.flatten())
 
+    if pre_hook is None:
+        # FINNLoop (MLO) models need their weight memories initialized via a pre-hook
+        finnloop_nodes = model.get_nodes_by_op_type("FINNLoop")
+        if len(finnloop_nodes) == 1:
+            pre_hook = mlo_prehook_func_factory(finnloop_nodes[0])
+        elif len(finnloop_nodes) > 1:
+            raise NotImplementedError(
+                "rtlsim of models with multiple FINNLoop nodes is not supported"
+            )
     if pre_hook is not None:
         pre_hook(sim)
     liveness_estimate = model.get_metadata_prop("rtlsim_liveness_estimate")

--- a/tests/fpgadataflow/test_fpgadataflow_finnloop.py
+++ b/tests/fpgadataflow/test_fpgadataflow_finnloop.py
@@ -742,12 +742,10 @@ def test_finnloop_end2end_mlo(
 
     model.save(tmp_output_dir + "/mlo_model.onnx")
 
-    # Use phase-based pipeline.
-    # phase_convert_to_hardware already runs step_create_dataflow_partition
-    # internally, so it must NOT be listed separately here: doing so partitions
-    # twice, and the second partition (fed the child, whose non-HW parent nodes
-    # have already been split off) re-derives and overwrites dataflow_parent.onnx
-    # with a parent that has lost those non-HW nodes.
+    # Use phase-based pipeline. phase_convert_to_hardware already partitions
+    # internally, so step_create_dataflow_partition must not be listed separately:
+    # a second partition would re-derive dataflow_parent.onnx off the child and
+    # drop the non-HW parent nodes.
     steps = [
         "phase_convert_to_hardware",  # Phase (includes partition + loop rolling)
         "phase_optimize_hardware",  # Phase (includes folding, bit-width, reports)
@@ -1000,11 +998,10 @@ def test_finnloop_end2end_mlo_ddr(
 
     model.save(tmp_output_dir + "/mlo_model.onnx")
 
-    # Use phase-based pipeline
-    # Steps are adjusted because test model already has HLS and RTL layers
+    # Use phase-based pipeline. phase_convert_to_hardware already partitions
+    # internally, so step_create_dataflow_partition must not be listed separately.
     steps = [
-        "step_create_dataflow_partition",  # Fine-grained (model already specialized)
-        "phase_convert_to_hardware",  # Phase (includes loop rolling)
+        "phase_convert_to_hardware",  # Phase (includes partition + loop rolling)
         "phase_optimize_hardware",  # Phase (includes folding, bit-width, reports)
         "phase_build_hardware",  # Phase (includes codegen, ipgen, FIFOs)
         "phase_generate_outputs",  # Phase (stitched IP, bitfile synth, driver, deployment)

--- a/tests/fpgadataflow/test_fpgadataflow_finnloop.py
+++ b/tests/fpgadataflow/test_fpgadataflow_finnloop.py
@@ -989,12 +989,8 @@ def test_finnloop_end2end_mlo_ddr(
     test_id = re.sub(r"[^0-9A-Za-z_]+", "_", request.node.name)
     tmp_output_dir = make_build_dir(f"build_mlo_{test_id}_")
 
-    batch_size = 16
-    np.save(tmp_output_dir + "/input.npy", np.broadcast_to(x, (batch_size, 3, 3, dim)))
-    np.save(
-        tmp_output_dir + "/expected_output.npy",
-        np.broadcast_to(y_ref, (batch_size, 3, 3, dim)),
-    )
+    np.save(tmp_output_dir + "/input.npy", x)
+    np.save(tmp_output_dir + "/expected_output.npy", y_ref)
 
     model.save(tmp_output_dir + "/mlo_model.onnx")
 

--- a/tests/fpgadataflow/test_fpgadataflow_finnloop.py
+++ b/tests/fpgadataflow/test_fpgadataflow_finnloop.py
@@ -589,24 +589,25 @@ def assert_finnloop_cycle_estimate(build_dir, x, rtol=0.35, atol=50):
 @pytest.mark.parametrize("rhs_shape", [[1], [16]])
 # eltwise param dtype
 @pytest.mark.parametrize("eltw_param_dtype", ["INT8", "FLOAT32"])
-# tail node
-@pytest.mark.parametrize("tail_node", [False, True])
+# insert non-MLO head/tail nodes (and a non-HW parent node) around the FINNLoop
+@pytest.mark.parametrize("non_mlo_nodes", [False, True])
 @pytest.mark.fpgadataflow
 @pytest.mark.vivado
 @pytest.mark.slow
 def test_finnloop_end2end_mlo(
-    mvau_cfg, iteration, elemwise_optype, rhs_shape, eltw_param_dtype, tail_node
+    mvau_cfg, iteration, elemwise_optype, rhs_shape, eltw_param_dtype, non_mlo_nodes
 ):
     dim, mvau_pe, mvau_simd, mvau_th, helper_pe = mvau_cfg
     # The tiled MVAU (TH>1) is only exercised on selected elementwise configs to
     # avoid a combinatorial explosion of long Vivado builds. rhs_shape is pinned to
     # [1] since [16] is incompatible with the tiled config's dim. Within that, we
-    # cover INT8/no-tail (canonical), FLOAT32/no-tail (float path) and INT8/tail
-    # (tail-node integration), skipping the redundant FLOAT32+tail combination.
+    # cover INT8/no-extra-nodes (canonical), FLOAT32/no-extra-nodes (float path) and
+    # INT8/extra-nodes (head/tail/parent integration), skipping the redundant
+    # FLOAT32+extra-nodes combination.
     if mvau_th > 1 and not (
         elemwise_optype == "ElementwiseMul_hls"
         and rhs_shape == [1]
-        and not (eltw_param_dtype == "FLOAT32" and tail_node)
+        and not (eltw_param_dtype == "FLOAT32" and non_mlo_nodes)
     ):
         pytest.skip("Tiled MVAU only exercised on selected elementwise configs")
     # Check vivado version
@@ -632,7 +633,8 @@ def test_finnloop_end2end_mlo(
     for m in loop_body_models[1:]:
         model = model.transform(MergeONNXModels(m))
 
-    if tail_node:
+    if non_mlo_nodes:
+        # tail node on the output side
         tail_outp = create_tensor_info("tail_outp", [1, 3, 3, dim])
         tr_node = create_node(
             "ElementwiseAdd_hls",
@@ -656,6 +658,68 @@ def test_finnloop_end2end_mlo(
         model.set_initializer("tail_add", AddtailParam)
         model.set_tensor_datatype("tail_add", DataType["INT8"])
 
+        # head node on the input side, symmetric with the tail node, kept inside the
+        # partition ahead of the FINNLoop. A zero-crop preserves shape and datatype so
+        # the loop-carried datatype (loop input dtype == loop output dtype) is intact.
+        loop_in_name = model.graph.input[0].name
+        first_body_node = model.find_consumer(loop_in_name)
+        head_node = create_node(
+            "Crop_hls",
+            [loop_in_name],
+            ["head_out"],
+            "Crop_head",
+            {
+                "DataType": "INT8",
+                "ImgDim": [3, 3],
+                "NumChannels": dim,
+                "CropNorth": 0,
+                "CropSouth": 0,
+                "CropWest": 0,
+                "CropEast": 0,
+                "SIMD": 1,
+                "numInputVectors": [1],
+                "cpp_interface": "hls_vector",
+                "hls_style": "freerunning",
+            },
+        )
+        for i, inp in enumerate(first_body_node.input):
+            if inp == loop_in_name:
+                first_body_node.input[i] = "head_out"
+        model.graph.node.insert(0, head_node)
+        model.graph.value_info.append(create_tensor_info("head_out", [1, 3, 3, dim]))
+        model.set_tensor_datatype("head_out", DataType["INT8"])
+
+    # A non-HW parent node (single config): prepended ahead of the head node so it
+    # lands in dataflow_parent.onnx, outside the SDP, exercising parent-routed
+    # stitched-IP verification. Shape-preserving Transpose over the two size-3 axes
+    # keeps (1, 3, 3, dim) but permutes values, so the hardware must reproduce it.
+    insert_parent_node = (
+        non_mlo_nodes
+        and mvau_cfg == (16, 2, 2, 1, 2)
+        and elemwise_optype == "ElementwiseMul_hls"
+        and rhs_shape == [1]
+        and eltw_param_dtype == "INT8"
+    )
+    if insert_parent_node:
+        parent_in = model.graph.input[0].name
+        parent_consumer = model.find_consumer(parent_in)
+        parent_tr = helper.make_node(
+            "Transpose",
+            [parent_in],
+            ["parent_transpose_out"],
+            name="Parent_Transpose",
+            perm=[0, 2, 1, 3],
+        )
+        for i, inp in enumerate(parent_consumer.input):
+            if inp == parent_in:
+                parent_consumer.input[i] = "parent_transpose_out"
+        model.graph.node.insert(0, parent_tr)
+        model.graph.value_info.append(create_tensor_info("parent_transpose_out", [1, 3, 3, dim]))
+        model.set_tensor_datatype("parent_transpose_out", DataType["INT8"])
+
+    # number of nodes prepended ahead of the first loop body (head + parent node)
+    n_prepended = int(non_mlo_nodes) + int(insert_parent_node)
+
     # cleanup
     model = model.transform(RemoveUnusedTensors())
     model = model.transform(InferShapes())
@@ -678,11 +742,14 @@ def test_finnloop_end2end_mlo(
 
     model.save(tmp_output_dir + "/mlo_model.onnx")
 
-    # Use phase-based pipeline
-    # Steps are adjusted because test model already has HLS and RTL layers
+    # Use phase-based pipeline.
+    # phase_convert_to_hardware already runs step_create_dataflow_partition
+    # internally, so it must NOT be listed separately here: doing so partitions
+    # twice, and the second partition (fed the child, whose non-HW parent nodes
+    # have already been split off) re-derives and overwrites dataflow_parent.onnx
+    # with a parent that has lost those non-HW nodes.
     steps = [
-        "step_create_dataflow_partition",  # Fine-grained (model already specialized)
-        "phase_convert_to_hardware",  # Phase (includes loop rolling)
+        "phase_convert_to_hardware",  # Phase (includes partition + loop rolling)
         "phase_optimize_hardware",  # Phase (includes folding, bit-width, reports)
         "phase_build_hardware",  # Phase (includes codegen, ipgen, FIFOs)
         "phase_generate_outputs",  # Phase (only stitched IP requested, so no full synth)
@@ -695,7 +762,7 @@ def test_finnloop_end2end_mlo(
         and elemwise_optype == "ElementwiseMul_hls"
         and rhs_shape == [1]
         and eltw_param_dtype == "INT8"
-        and not tail_node
+        and not non_mlo_nodes
     )
 
     cfg = build_cfg.DataflowBuildConfig(
@@ -707,7 +774,10 @@ def test_finnloop_end2end_mlo(
         standalone_thresholds=True,
         mlo=True,
         loop_body_hierarchy=[["", "layers.0"]],
-        loop_body_range=(model.graph.node[0], model.graph.node[nodes_per_body - 1]),
+        loop_body_range=(
+            model.graph.node[n_prepended],
+            model.graph.node[n_prepended + nodes_per_body - 1],
+        ),
         verify_steps=verif_steps,
         verify_input_npy=tmp_output_dir + "/input.npy",
         verify_expected_output_npy=tmp_output_dir + "/expected_output.npy",
@@ -719,6 +789,16 @@ def test_finnloop_end2end_mlo(
         ],
     )
     build.build_dataflow_cfg(tmp_output_dir + "/mlo_model.onnx", cfg)
+
+    if insert_parent_node:
+        # The prepended non-HW node must stay outside the StreamingDataflowPartition,
+        # i.e. it lands in dataflow_parent.onnx. This ensures stitched_ip_rtlsim
+        # verification actually routes the input through the parent graph.
+        parent_model = ModelWrapper(tmp_output_dir + "/intermediate_models/dataflow_parent.onnx")
+        non_sdp_nodes = [
+            n for n in parent_model.graph.node if n.op_type != "StreamingDataflowPartition"
+        ]
+        assert len(non_sdp_nodes) > 0, "Parent model has no non-SDP node to run"
 
     # check if expected files are there
     assert os.path.isfile(tmp_output_dir + "/loop-body-template.onnx")
@@ -734,8 +814,9 @@ def test_finnloop_end2end_mlo(
     assert os.path.isfile(tmp_output_dir + "/stitched_ip/ip/component.xml")
 
     verif_dir = tmp_output_dir + "/verification_output"
-    # With verify_save_full_context=True, cppsim and node_by_node_rtlsim save as .npz
-    # stitched_ip_rtlsim with MLO uses rtlsim_pre_hook so it saves as .npy
+    # With verify_save_full_context=True, all verification steps save the full
+    # context as .npz. MLO stitched_ip_rtlsim now routes through the parent model
+    # (need_parent=True), so it also saves the full context as .npz.
     assert os.path.isfile(
         verif_dir + "/verify_folded_hls_cppsim_0_SUCCESS.npz"
     ), f"Check npz files in {verif_dir}"
@@ -743,8 +824,8 @@ def test_finnloop_end2end_mlo(
         verif_dir + "/verify_node_by_node_rtlsim_0_SUCCESS.npz"
     ), f"Check npz files in {verif_dir}"
     assert os.path.isfile(
-        verif_dir + "/verify_stitched_ip_rtlsim_0_SUCCESS.npy"
-    ), f"Check npy files in {verif_dir}"
+        verif_dir + "/verify_stitched_ip_rtlsim_0_SUCCESS.npz"
+    ), f"Check npz files in {verif_dir}"
 
     # Verify that the per-iteration context file was created for FINNLoop
     iteration_context_files = [
@@ -969,8 +1050,9 @@ def test_finnloop_end2end_mlo_ddr(
     assert os.path.isfile(tmp_output_dir + "/stitched_ip/ip/component.xml")
 
     verif_dir = tmp_output_dir + "/verification_output"
-    # With verify_save_full_context=True, cppsim and node_by_node_rtlsim save as .npz
-    # stitched_ip_rtlsim with MLO uses rtlsim_pre_hook so it saves as .npy
+    # With verify_save_full_context=True, all verification steps save the full
+    # context as .npz. MLO stitched_ip_rtlsim now routes through the parent model
+    # (need_parent=True), so it also saves the full context as .npz.
     assert os.path.isfile(
         verif_dir + "/verify_folded_hls_cppsim_0_SUCCESS.npz"
     ), f"Check npz files in {verif_dir}"
@@ -978,8 +1060,8 @@ def test_finnloop_end2end_mlo_ddr(
         verif_dir + "/verify_node_by_node_rtlsim_0_SUCCESS.npz"
     ), f"Check npz files in {verif_dir}"
     assert os.path.isfile(
-        verif_dir + "/verify_stitched_ip_rtlsim_0_SUCCESS.npy"
-    ), f"Check npy files in {verif_dir}"
+        verif_dir + "/verify_stitched_ip_rtlsim_0_SUCCESS.npz"
+    ), f"Check npz files in {verif_dir}"
 
     # Verify that the per-iteration context file was created for FINNLoop
     iteration_context_files = [


### PR DESCRIPTION
- MLO (FINNLoop) stitched-IP verification fed the raw verification input straight into the stitched child, bypassing dataflow_parent.onnx. When the parent holds real pre/post-processing nodes, they were never executed, so the child got un-preprocessed input and verification produced wrong results. 
- Route MLO stitched-IP verification through the parent graph (need_parent=True), identical to the non-MLO path. The stitched child's rtlsim now self-initializes its FINNLoop weight memories: rtlsim_exec auto-derives the memory-init pre-hook when none is supplied and the model has exactly one FINNLoop (raises on multiple, skips on none), so no pre-hook has to be threaded through the parent route.
- Remove the now-dead rtlsim_pre_hook parameter/plumbing from verify_step; as a side effect, full-context .npz saving now also works for MLO.

Test changes (test_finnloop_end2end_mlo)

- Add a HW head (Crop) node paired with the existing tail node.
- Add a non-HW parent Transpose in one config so it lands in dataflow_parent.onnx, directly exercising parent-routed verification (fails pre-fix, passes post-fix).
