### PR TITLE
[Builder] Check that folding is configured for HW build outputs

### DIFF
--- a/src/finn/builder/build_dataflow_checks.py
+++ b/src/finn/builder/build_dataflow_checks.py
@@ -266,6 +266,25 @@ def run_all_config_checks(cfg: DataflowBuildConfig) -> Report:
                 )
             )
 
+    needs_folding = cfg.generate_outputs and any(
+        o != DataflowOutputType.ESTIMATE_REPORTS for o in cfg.generate_outputs
+    )
+    if needs_folding and cfg.target_fps is None and cfg.folding_config_file is None:
+        checks.append(
+            _check(
+                "folding_missing",
+                Severity.ERROR,
+                False,
+                "Neither target_fps nor folding_config_file is set. Nodes stay at "
+                "their creation-time PE=1/SIMD=1, the most folded and slowest "
+                "implementation, and the build will silently run to completion "
+                "with it instead of failing fast",
+                "Set target_fps for automatic folding, or provide folding_config_file "
+                "for manual PE/SIMD settings, so a slow build isn't mistaken for "
+                "a deliberate choice",
+            )
+        )
+
     # === Environment Variables ===
     if has_bitfile and cfg.shell_flow_type == ShellFlowType.VITIS_ALVEO:
         missing = [

--- a/tests/util/test_build_dataflow_checks.py
+++ b/tests/util/test_build_dataflow_checks.py
@@ -166,6 +166,7 @@ class TestConfigCheckIntegration:
                             board=board,
                             shell_flow_type=flow,
                             generate_outputs=[DataflowOutputType.BITFILE],
+                            target_fps=1000,
                         ),
                     )
             else:
@@ -176,6 +177,7 @@ class TestConfigCheckIntegration:
                         board=board,
                         shell_flow_type=flow,
                         generate_outputs=[DataflowOutputType.BITFILE],
+                        target_fps=1000,
                     ),
                 )
                 assert os.path.exists(os.path.join(output_dir, "config_check_report.txt"))
@@ -232,3 +234,63 @@ class TestConfigCheckIntegration:
             c["name"] for c in report["checks"] if not c["passed"] and c["severity"] == "ERROR"
         ]
         assert "zynq7000_retired" in error_names
+
+    def test_folding_missing_errors(self):
+        """A non-estimate output with neither target_fps nor folding_config_file
+        should error, instead of silently building at PE=1/SIMD=1."""
+        build_dir = make_build_dir("test_config_check_")
+        model_path = make_test_model(build_dir)
+        output_dir = os.path.join(build_dir, "output")
+
+        with patch.dict("os.environ", {"XILINX_VIVADO": "/tools/Vivado/2024.2"}):
+            with pytest.raises(AssertionError, match="Configuration check failed"):
+                build_dataflow_cfg(
+                    model_path,
+                    cfg(
+                        output_dir,
+                        board="AUP-ZU3_8GB",
+                        shell_flow_type=ShellFlowType.VIVADO_ZYNQ,
+                        generate_outputs=[DataflowOutputType.BITFILE],
+                    ),
+                )
+
+    def test_folding_missing_estimate_only_ok(self):
+        """ESTIMATE_REPORTS alone doesn't require target_fps or folding_config_file."""
+        build_dir = make_build_dir("test_config_check_")
+        model_path = make_test_model(build_dir)
+        output_dir = os.path.join(build_dir, "output")
+
+        with patch.dict("os.environ", {"XILINX_VIVADO": "/tools/Vivado/2024.2"}):
+            build_dataflow_cfg(model_path, cfg(output_dir))
+
+        with open(os.path.join(output_dir, "config_check_report.json")) as f:
+            report = json.load(f)
+        error_names = [
+            c["name"] for c in report["checks"] if not c["passed"] and c["severity"] == "ERROR"
+        ]
+        assert "folding_missing" not in error_names
+
+    def test_folding_target_fps_satisfies_check(self):
+        """Setting target_fps clears the folding_missing check."""
+        build_dir = make_build_dir("test_config_check_")
+        model_path = make_test_model(build_dir)
+        output_dir = os.path.join(build_dir, "output")
+
+        with patch.dict("os.environ", {"XILINX_VIVADO": "/tools/Vivado/2024.2"}):
+            build_dataflow_cfg(
+                model_path,
+                cfg(
+                    output_dir,
+                    board="AUP-ZU3_8GB",
+                    shell_flow_type=ShellFlowType.VIVADO_ZYNQ,
+                    generate_outputs=[DataflowOutputType.BITFILE],
+                    target_fps=1000,
+                ),
+            )
+
+        with open(os.path.join(output_dir, "config_check_report.json")) as f:
+            report = json.load(f)
+        error_names = [
+            c["name"] for c in report["checks"] if not c["passed"] and c["severity"] == "ERROR"
+        ]
+        assert "folding_missing" not in error_names


### PR DESCRIPTION
Fix #1430.

## Problem

Building any hardware output (STITCHED_IP, BITFILE, OOC_SYNTH, RTLSIM_PERFORMANCE, PYNQ_DRIVER, DEPLOYMENT_PACKAGE) with neither `target_fps` nor `folding_config_file` set leaves every node at its creation-time `PE=1`/`SIMD=1` (`convert_to_hw_layers` sets this at node creation; `SetFolding` is what normally raises it toward a target). Nothing fails: the build just completes with the most folded, slowest possible implementation, and the misconfiguration only becomes obvious once the resulting accelerator turns out to be far slower than expected - after a full synthesis run.

I traced this through `SpecializeLayers` and `PrepareIP` with a minimal `PE=1`/`SIMD=1` MVAU model to confirm neither step raises on its own; the build genuinely proceeds silently rather than crashing.

## Fix

Add a `folding_missing` check to `run_all_config_checks` in `build_dataflow_checks.py`, following the same pattern already used for `zynq_board` and `vitis_platform` (pre-empting a known footgun with a clear message at config-check time, before the build reaches `step_hw_ipgen`). The check only fires when `generate_outputs` requests something beyond `ESTIMATE_REPORTS`, since estimate-only builds don't need folding to be explicitly configured.

Also updated `test_board_shell_compatibility`'s two success cases in `test_build_dataflow_checks.py`, which build `BITFILE` without `target_fps` - these were previously only exercising the board/shell check and would now (correctly) trip the new check too.

## Testing

Ran the full `test_build_dataflow_checks.py` suite locally (`setup-local.sh`-style venv, no Docker/Vivado) - all 15 tests pass, including 3 new ones covering the error case, the estimate-only pass-through case, and the target_fps pass-through case. `isort`/`black`/`ruff` (pinned versions from `.pre-commit-config.yaml`) pass on both changed files.