### PR TITLE
Bug fixes for requant_decoupled pr.

### DIFF
--- a/src/finn/core/rtlsim_exec.py
+++ b/src/finn/core/rtlsim_exec.py
@@ -45,16 +45,33 @@ from finn.util.rtlsim import dat_file_to_numpy_array
 finnxsi = xsi if xsi.is_available() else None
 
 
+def has_s_axis_port(node_onnx, node_inp_ind):
+    """Whether input `node_inp_ind` of `node_onnx` is backed by an s_axis port.
+
+    Mirrors the skip rule in CreateStitchedIP.connect_s_axis_external: an input
+    beyond the node's declared s_axis interfaces gets no external port and does
+    not consume an s_axis_<n> index. Requant_rtl in MLO mode is such a case, as
+    it packs its bias (input[2]) into the input[1] parameter memstream.
+    """
+    s_axis_names = getCustomOp(node_onnx).get_verilog_top_module_intf_names()["s_axis"]
+    return node_inp_ind < len(s_axis_names)
+
+
 def prep_rtlsim_io_dict(model, execution_context):
     # extract i/o info to prepare io_dict
     io_dict = {"inputs": {}, "outputs": {}}
     if_dict = eval(model.get_metadata_prop("vivado_stitch_ifnames"))
-    # go over and prepare inputs
-    for i, i_vi in enumerate(model.graph.input):
+    # go over and prepare inputs, skipping those without an s_axis port so that
+    # the rest stay aligned with if_dict
+    i = -1
+    for i_vi in model.graph.input:
         i_name = i_vi.name
+        first_node_onnx = model.find_consumer(i_name)
+        if not has_s_axis_port(first_node_onnx, list(first_node_onnx.input).index(i_name)):
+            continue
+        i += 1
         i_tensor = execution_context[i_name]
         i_dt = model.get_tensor_datatype(i_name)
-        first_node_onnx = model.find_consumer(i_name)
         first_node = getCustomOp(first_node_onnx)
         node_inp_ind = list(first_node_onnx.input).index(i_name)
         if node_inp_ind == 0:
@@ -211,6 +228,9 @@ def rtlsim_exec_cppxsi(
         assert first_node is not None, "Failed to find consumer for " + iname
         fnode_inst = getCustomOp(first_node)
         top_ind = list(first_node.input).index(iname)
+        # skip inputs without an s_axis port to stay aligned with ifnames below
+        if not has_s_axis_port(first_node, top_ind):
+            continue
         ishape_folded = fnode_inst.get_folded_input_shape(ind=top_ind)
         instream_iters.append(np.prod(ishape_folded[:-1]))
     for top_out in model.graph.output:
@@ -235,6 +255,10 @@ def rtlsim_exec_cppxsi(
         ), f"cppxsi sim doesn't know how to handle full AXI MM interfaces: {ifnames['aximm']}"
     instream_names = [x[0] for x in ifnames["s_axis"]]
     outstream_names = [x[0] for x in ifnames["m_axis"]]
+    assert len(instream_names) == len(instream_iters), (
+        "stitched-IP s_axis ports (%d) don't match streamed graph inputs (%d)"
+        % (len(instream_names), len(instream_iters))
+    )
     instream_descrs = [
         (instream_names[i], instream_iters[i], instream_iters[i] + throttle_cycles)
         for i in range(len(instream_names))

--- a/src/finn/custom_op/fpgadataflow/rtl/finn_loop.py
+++ b/src/finn/custom_op/fpgadataflow/rtl/finn_loop.py
@@ -871,10 +871,22 @@ class FINNLoop(HWCustomOp, RTLBackend):
             "create_bd_intf_pin -mode Slave "
             "-vlnv xilinx.com:interface:axis_rtl:1.0 /%s/s_axis_0" % bd_name
         )
-        for id, inp in enumerate(loop_body.graph.input[1:]):
+        # One tap per parameter graph-input, mirroring generate_hdl_stream_tap():
+        # Requant packs scale (input[1]) and bias (input[2]) into one memstream
+        # driven by the scale tap, so the bias gets no tap of its own.
+        taps = []
+        node_to_taps = {}
+        for gid, inp in enumerate(loop_body.graph.input[1:], start=1):
+            consumer = loop_body.find_consumer(inp.name)
+            if consumer.op_type == "Requant_rtl" and inp.name in consumer.input[2:]:
+                continue
+            taps.append((gid, "IN_%d_stream_tap_wrapper" % gid, consumer.name))
+            node_to_taps.setdefault(consumer.name, []).append(gid)
+        # number the master ports densely, to match the loop body IP's s_axis_1..N
+        for pid, _ in enumerate(taps, start=1):
             cmd.append(
                 "create_bd_intf_pin -mode Master "
-                "-vlnv xilinx.com:interface:axis_rtl:1.0 /%s/m_axis_%d" % (bd_name, id + 1)
+                "-vlnv xilinx.com:interface:axis_rtl:1.0 /%s/m_axis_%d" % (bd_name, pid)
             )
         # get stream tap (+ skid)  components
         skid_file = os.path.join(os.environ["FINN_ROOT"], "finn-rtllib/skid/skid.sv")
@@ -911,18 +923,6 @@ class FINNLoop(HWCustomOp, RTLBackend):
             ),
         )
 
-        # Map each parameter graph-input to its stream tap. A node may consume
-        # several parameter inputs (e.g. Requant: scale=input[1], bias=input[2]),
-        # so keep a per-graph-input tap list plus a node -> [tap ids] index.
-        # taps: list of (gid, tap_name, consumer_name); node_to_taps: name -> [gid]
-        taps = []
-        node_to_taps = {}
-        for id, inp in enumerate(loop_body.graph.input[1:], start=1):
-            consumer = loop_body.find_consumer(inp.name)
-            tap_name = "IN_%d_stream_tap_wrapper" % id
-            taps.append((id, tap_name, consumer.name))
-            node_to_taps.setdefault(consumer.name, []).append(id)
-
         def node_entry(node_name):
             # Entry tap (lowest gid) of a node: where the set index enters the
             # node's param taps. A multi-param node chains its taps internally
@@ -941,9 +941,8 @@ class FINNLoop(HWCustomOp, RTLBackend):
             # across distinct destination nodes (branching dataflow).
             return [node_entry(d) for d in dsts]
 
-        # instantiate all stream taps and connect their clk and rst; wire each
-        # tap's m_axis_1 to the stg output m_axis_<gid> by its true graph-input id
-        for gid, tap_name, _consumer in taps:
+        # instantiate all stream taps and connect their clk and rst
+        for pid, (_gid, tap_name, _consumer) in enumerate(taps, start=1):
             cmd.append(
                 "create_bd_cell -type hier -reference %s /%s/%s" % (tap_name, bd_name, tap_name)
             )
@@ -958,7 +957,7 @@ class FINNLoop(HWCustomOp, RTLBackend):
             )
             cmd.append(
                 "connect_bd_intf_net [get_bd_intf_pins %s/m_axis_%s] "
-                "[get_bd_intf_pins %s/%s/m_axis_1]" % (bd_name, gid, bd_name, tap_name)
+                "[get_bd_intf_pins %s/%s/m_axis_1]" % (bd_name, pid, bd_name, tap_name)
             )
 
         # Chain a multi-param node's taps in series (e.g. Requant scale -> bias):
@@ -1258,6 +1257,7 @@ class FINNLoop(HWCustomOp, RTLBackend):
         # connect components with each other
         # stream tap with finn ip
         connect_signals = loop_body_intf_names["s_axis"]
+        assert len(taps) == len(connect_signals) - 1, "stream tap / loop body param mismatch"
         for id, sig in enumerate(connect_signals[:-1]):
             cmd.append(
                 "connect_bd_intf_net "


### PR DESCRIPTION
The following test failed:
pytest tests/fpgadataflow/test_fpgadataflow_finnloop.py::test_finnloop_end2end_mlo_requant
This PR fixes this issue by aligning the numbering or parameter streams to align with the changes made to the requant memstream, so that the bias sharing the scale memstream no longer shifts the port and descriptor indices.

This setup now passes the following tests with certainty:
tests/fpgadataflow/test_fpgadataflow_finnloop.py 
tests/fpgadataflow/test_fpgadataflow_requant.py
tests/transformation/test_loop_rolling.py 
tests/fpgadataflow/test_fifosizing.py
tests/fpgadataflow/test_fpgadataflow_ipstitch.py
tests/end2end/test_end2end_cybsec_mlp.py
