### PR TITLE
Improve LayerNorm reciprocal-square-root accuracy

### DIFF
--- a/finn-rtllib/layernorm/layernorm.sv
+++ b/finn-rtllib/layernorm/layernorm.sv
@@ -33,6 +33,7 @@
 module layernorm #(
 	int unsigned  N,
 	int unsigned  SIMD,
+	int unsigned  NUM_RSQRT_REFINEMENTS = 1,
 	bit  FORCE_BEHAVIORAL = 0
 )(
 	// Global Control
@@ -54,6 +55,10 @@ module layernorm #(
 	initial begin
 		if(N%SIMD != 0) begin
 			$error("%m: SIMD(%0d) must divide N(%0d).", SIMD, N);
+			$finish;
+		end
+		if((NUM_RSQRT_REFINEMENTS < 1) || (NUM_RSQRT_REFINEMENTS > 2)) begin
+			$error("%m: NUM_RSQRT_REFINEMENTS must be one or two.");
 			$finish;
 		end
 	end
@@ -87,8 +92,8 @@ module layernorm #(
 		localparam int unsigned  STATISTICS_LATENCY =
 			// SIMD adder tree + accumulation + decouple
 			$clog2(SIMD) * 2   +     4        +    3 +
-			// Variance: *1/N + rsqrt
-			step   *    (  3  + 14  );
+			// Variance: *1/N + rsqrt + optional second Newton refinement
+			step   *    (  3  + 14 + 12*(NUM_RSQRT_REFINEMENTS-1)  );
 		localparam int unsigned  VALUE_QUEUE_LEN = NN + STATISTICS_LATENCY;
 		localparam int unsigned  STATS_QUEUE_LEN = 2 + (VALUE_QUEUE_LEN-1)/NN;
 
@@ -198,18 +203,50 @@ module layernorm #(
 			end
 			1: /* Var: inverse square root */ begin
 				uwire  vrdy;
+				uwire edge_t  estimate;
 				rsqrtf #(
 					.SUSTAINABLE_INTERVAL(NN),
 					.FORCE_BEHAVIORAL(FORCE_BEHAVIORAL)
 				) vari_rsqurt (
 					.clk, .rst,
 					.x(total.dat), .xvld(total.vld), .xrdy(vrdy),
-					.r(norm .dat), .rvld(norm .vld)
+					.r(estimate.dat), .rvld(estimate.vld)
 				);
 				always_ff @(posedge clk) begin
 					assert(rst || !total.vld || vrdy) else begin
 						$error("%m Overrunning rsqrt computation.");
 						$stop;
+					end
+				end
+
+				if(NUM_RSQRT_REFINEMENTS == 1) begin : genSingleRefinement
+					assign	norm = estimate;
+				end
+				else begin : genSecondRefinement
+					uwire edge_t  variance;
+					uwire  variance_rdy;
+					queue #(.DATA_WIDTH(32), .ELASTICITY(16)) variance_queue (
+						.clk, .rst,
+						.idat(total.dat), .ivld(total.vld), .irdy(variance_rdy),
+						.odat(variance.dat), .ovld(variance.vld), .ordy(estimate.vld)
+					);
+
+					rsqrtf_refine #(.FORCE_BEHAVIORAL(FORCE_BEHAVIORAL)) refine (
+						.clk, .rst,
+						.x(variance.dat), .y(estimate.dat),
+						.yvld(variance.vld && estimate.vld),
+						.r(norm.dat), .rvld(norm.vld)
+					);
+
+					always_ff @(posedge clk) begin
+						assert(rst || !total.vld || variance_rdy) else begin
+							$error("%m Overrunning variance queue.");
+							$stop;
+						end
+						assert(rst || !estimate.vld || variance.vld) else begin
+							$error("%m Missing variance for rsqrt refinement.");
+							$stop;
+						end
 					end
 				end
 			end

--- a/finn-rtllib/layernorm/layernorm_wrapper_template.v
+++ b/finn-rtllib/layernorm/layernorm_wrapper_template.v
@@ -31,7 +31,8 @@ layernorm #(
 	.FORCE_BEHAVIORAL(1),
 `endif
 	.N($N$),
-	.SIMD($SIMD$)
+	.SIMD($SIMD$),
+	.NUM_RSQRT_REFINEMENTS($NUM_RSQRT_REFINEMENTS$)
 )
 impl
 (

--- a/finn-rtllib/layernorm/rsqrtf.sv
+++ b/finn-rtllib/layernorm/rsqrtf.sv
@@ -167,6 +167,65 @@ module rsqrtf_dspfp32 #(
 
 endmodule : rsqrtf_dspfp32
 
+// One additional Newton-Raphson refinement:
+//   r = y * (1.5 - 0.5*x*y*y)
+// The three FP32 FMA stages accept a new (x, y) pair every cycle.
+module rsqrtf_refine #(
+	bit  FORCE_BEHAVIORAL = 0
+)(
+	input  logic         clk,
+	input  logic         rst,
+
+	input  logic [31:0]  x,
+	input  logic [31:0]  y,
+	input  logic         yvld,
+
+	output logic [31:0]  r,
+	output logic         rvld
+);
+
+	localparam int unsigned  LATENCY = 12;
+	logic  Vld[LATENCY] = '{ default: 0 };
+	logic [31:0]  Y[8] = '{ default: 'x };
+	always_ff @(posedge clk) begin
+		if(rst) begin
+			Vld <= '{ default: 0 };
+			Y <= '{ default: 'x };
+		end
+		else begin
+			Vld <= { yvld, Vld[0:LATENCY-2] };
+			Y <= { y, Y[0:6] };
+		end
+	end
+	assign	rvld = Vld[LATENCY-1];
+
+	uwire [31:0]  x2 = { x[31], x[30:23]-1, x[22:0] };
+	uwire [31:0]  c = $shortrealtobits(1.5);
+	uwire [31:0]  p[2];
+
+	rsqrtf_dspfp32 #(.FORCE_BEHAVIORAL(FORCE_BEHAVIORAL)) DSP0 (
+		.clk, .rst,
+		.ena('1), .bsel('1), .csel('0),
+		.a(y), .b(x2), .c('x), .d('x),
+		.rvld('0), .r(p[0])
+	);
+
+	rsqrtf_dspfp32 #(.FORCE_BEHAVIORAL(FORCE_BEHAVIORAL)) DSP1 (
+		.clk, .rst,
+		.ena('1), .bsel('0), .csel('1),
+		.a(Y[3]), .b('x), .c, .d(p[0]),
+		.rvld('0), .r(p[1])
+	);
+
+	rsqrtf_dspfp32 #(.FORCE_BEHAVIORAL(FORCE_BEHAVIORAL)) DSP2 (
+		.clk, .rst,
+		.ena('1), .bsel('0), .csel('0),
+		.a(Y[7]), .b('x), .c('x), .d(p[1]),
+		.rvld, .r
+	);
+
+endmodule : rsqrtf_refine
+
 module rsqrtf #(
 	int unsigned  SUSTAINABLE_INTERVAL,  // Average II sustained over 12 Cycles
 	// Guarantee readiness at II, do not expose delays of arbitrating between iterations:

--- a/src/finn/custom_op/fpgadataflow/layernorm.py
+++ b/src/finn/custom_op/fpgadataflow/layernorm.py
@@ -30,6 +30,7 @@ class LayerNorm(HWCustomOp):
         my_attrs.update(
             {
                 "SIMD": ("i", True, 0),
+                "numRsqrtRefinements": ("i", False, 1),
                 "ifm_dim": ("ints", True, []),
                 "epsilon": ("f", True, 1e-5),
                 # FINN DataTypes for inputs, outputs

--- a/src/finn/custom_op/fpgadataflow/rtl/layernorm_rtl.py
+++ b/src/finn/custom_op/fpgadataflow/rtl/layernorm_rtl.py
@@ -39,6 +39,11 @@ class LayerNorm_rtl(LayerNorm, RTLBackend):
         simd = self.get_nodeattr("SIMD")
         topname = self.get_verilog_top_module_name()
         n = self.get_normal_input_shape()[-1]
+        num_rsqrt_refinements = self.get_nodeattr("numRsqrtRefinements")
+        assert num_rsqrt_refinements in (
+            1,
+            2,
+        ), "LayerNorm supports one or two rsqrt refinements"
         assert (
             n % simd == 0
         ), """Requirement N (last dim) divisable by SIMD is violated.
@@ -46,6 +51,7 @@ class LayerNorm_rtl(LayerNorm, RTLBackend):
         code_gen_dict = {
             "$N$": int(n),
             "$SIMD$": int(simd),
+            "$NUM_RSQRT_REFINEMENTS$": int(num_rsqrt_refinements),
             "$TOP_MODULE_NAME$": topname,
         }
 
@@ -127,12 +133,23 @@ class LayerNorm_rtl(LayerNorm, RTLBackend):
         simd = self.get_nodeattr("SIMD")
         idim = self.get_normal_input_shape()
         n = idim[-1]
+        num_rsqrt_refinements = self.get_nodeattr("numRsqrtRefinements")
         assert (
             n % simd == 0
         ), """Requirement N (last dim) divisable by SIMD is violated.
             Please set SIMD to a different value"""
         val_queue_len_0 = n // simd + math.ceil(math.log2(simd)) * 2 + 7
-        val_queue_len_1 = n // simd + math.ceil(math.log2(simd)) * 2 + 24
+        val_queue_len_1 = (
+            n // simd + math.ceil(math.log2(simd)) * 2 + 24 + 12 * (num_rsqrt_refinements - 1)
+        )
         exp_cycles = val_queue_len_0 + val_queue_len_1 + np.prod(idim) // simd + 5
 
         return int(exp_cycles)
+
+    def dsp_estimation(self, fpgapart=None):
+        # The optional second Newton step uses a three-DSP FP32 FMA pipeline.
+        simd = self.get_nodeattr("SIMD")
+        interval = self.get_normal_input_shape()[-1] // simd
+        rsqrt_dsps = max(1, 4 - interval)
+        num_rsqrt_refinements = self.get_nodeattr("numRsqrtRefinements")
+        return 5 * simd + rsqrt_dsps + 3 * (num_rsqrt_refinements - 1)

--- a/tests/fpgadataflow/test_fpgadataflow_layernorm.py
+++ b/tests/fpgadataflow/test_fpgadataflow_layernorm.py
@@ -169,6 +169,47 @@ def test_fpgadataflow_rtl_layernorm(idt, ishape, simd, sim_style):
 @pytest.mark.fpgadataflow
 @pytest.mark.vivado
 @pytest.mark.slow
+def test_fpgadataflow_rtl_layernorm_second_rsqrt_refinement():
+    """The optional second Newton step should closely match exact LayerNorm."""
+    idt = DataType["FLOAT32"]
+    ishape = [1, 4, 48]
+    model = create_layernorm_model(
+        idt, ishape, has_scale=False, has_bias=False, epsilon=9.999999960041972e-13
+    )
+    input_data = gen_finn_dt_tensor(idt, ishape)
+    input_dict = {model.graph.input[0].name: input_data}
+    expected = oxe.execute_onnx(model, input_dict)[model.graph.output[0].name]
+
+    model = model.transform(InferShapes())
+    model = model.transform(InferDataTypes())
+    model = model.transform(ExtractNormScaleBias())
+    model = model.transform(to_hw.InferLayerNorm())
+    model = model.transform(to_hw.InferElementwiseBinaryOperation())
+    model = model.transform(SpecializeLayers(test_fpga_part))
+    model = model.transform(GiveUniqueNodeNames())
+
+    layernorm_node = model.get_nodes_by_op_type("LayerNorm_rtl")[0]
+    layernorm = getCustomOp(layernorm_node)
+    layernorm.set_nodeattr("SIMD", 2)
+    layernorm.set_nodeattr("numRsqrtRefinements", 2)
+    assert layernorm.dsp_estimation() == 14
+
+    model = model.transform(SetExecMode("rtlsim"))
+    model = model.transform(PrepareIP(test_fpga_part, target_clk_ns))
+    model = model.transform(HLSSynthIP())
+    model = model.transform(PrepareRTLSim())
+    actual = oxe.execute_onnx(model, input_dict)[model.graph.output[0].name]
+
+    assert np.allclose(expected, actual, rtol=1e-4, atol=1e-3)
+    layernorm_node = model.get_nodes_by_op_type("LayerNorm_rtl")[0]
+    cycles_rtlsim = getCustomOp(layernorm_node).get_nodeattr("cycles_rtlsim")
+    exp_cycles = model.analysis(exp_cycles_per_layer)[layernorm_node.name]
+    assert np.isclose(exp_cycles, cycles_rtlsim, atol=10)
+
+
+@pytest.mark.fpgadataflow
+@pytest.mark.vivado
+@pytest.mark.slow
 @pytest.mark.parametrize("idt", [DataType["FLOAT32"]])
 @pytest.mark.parametrize(
     "ishape,simd",


### PR DESCRIPTION
# Improve LayerNorm reciprocal-square-root accuracy

## Why

LayerNorm can operate on low-variance inputs where error in the existing reciprocal-square-root approximation becomes large enough to noticeably affect output accuracy in SigLip.

## How

This adds an optional second Newton–Raphson refinement:
`r = y × (1.5 - 0.5 × x × y²)`

The refinement is implemented as a pipelined three-FMA FP32 datapath. The LayerNorm configuration exposes `numRsqrtRefinements`, defaulting to the existing single-refinement behavior, and updates latency and DSP estimates accordingly. An RTL simulation test verifies the improved result against the ONNX LayerNorm reference.