### PR TITLE
Allow reshape-equivalent inputs during custom-op execution

### DIFF
--- a/src/finn/custom_op/fpgadataflow/hls/outer_shuffle_hls.py
+++ b/src/finn/custom_op/fpgadataflow/hls/outer_shuffle_hls.py
@@ -121,7 +121,30 @@ class OuterShuffle_hls(OuterShuffle, HLSBackend):
         ]
 
     def execute_node(self, context, graph):
-        HLSBackend.execute_node(self, context, graph)
+        node = self.onnx_node
+        input_name = node.input[0]
+        input_value = context[input_name]
+        expected_shape = tuple(self.get_normal_input_shape())
+        if input_value.shape == expected_shape:
+            HLSBackend.execute_node(self, context, graph)
+            return
+
+        expected_elements = int(np.prod(expected_shape))
+        if input_value.size != expected_elements:
+            raise RuntimeError(
+                f"{node.name}: cannot reshape input {input_value.shape} to {expected_shape}"
+            )
+
+        # OuterShuffle explicitly begins with a reshape before applying its
+        # permutation. Some decomposed shuffle chains preserve the tensor's
+        # logical graph shape while using another equal-sized view as the HLS
+        # stream shape. Present that view to the generic HLS executor, then
+        # restore the full execution context for surrounding nodes.
+        context[input_name] = input_value.reshape(expected_shape)
+        try:
+            HLSBackend.execute_node(self, context, graph)
+        finally:
+            context[input_name] = input_value
 
     def timeout_value(self):
         """Set timeout value for HLS functions defined for one clock cycle"""

--- a/src/finn/custom_op/fpgadataflow/rtl/elementwise_binary_rtl.py
+++ b/src/finn/custom_op/fpgadataflow/rtl/elementwise_binary_rtl.py
@@ -390,6 +390,16 @@ class ElementwiseBinary_rtl(ElementwiseBinaryOperation, RTLBackend):
         }
         super().derive_characteristic_fxns(period, override_rtlsim_dict=io_dict, pre_hook=pre_hook)
 
+    def _reshape_dynamic_input(self, value, ind):
+        expected_shape = self.get_normal_input_shape(ind=ind)
+        if list(value.shape) == expected_shape:
+            return value
+        assert value.size == int(np.prod(expected_shape)), (
+            f"Input shape mismatch for {self.onnx_node.input[ind]}: "
+            f"got {list(value.shape)}, expected {expected_shape}"
+        )
+        return value.reshape(expected_shape)
+
     def execute_node(self, context, graph):
         mode = self.get_nodeattr("exec_mode")
         if mode == "rtlsim":
@@ -398,13 +408,14 @@ class ElementwiseBinary_rtl(ElementwiseBinaryOperation, RTLBackend):
             lhs = context[node.input[0]]
             rhs = context[node.input[1]]
 
-            assert list(lhs.shape) == self.get_normal_input_shape(
-                ind=0
-            ), f"Input shape mismatch for {node.input[0]}"
+            if self.lhs_style == "input":
+                lhs = self._reshape_dynamic_input(lhs, 0)
+            else:
+                assert list(lhs.shape) == self.get_normal_input_shape(
+                    ind=0
+                ), f"Input shape mismatch for {node.input[0]}"
             if self.rhs_style != "const":
-                assert list(rhs.shape) == self.get_normal_input_shape(
-                    ind=1
-                ), f"Input shape mismatch for {node.input[1]}"
+                rhs = self._reshape_dynamic_input(rhs, 1)
 
             out_shape = self.get_normal_output_shape(ind=0)
 

--- a/src/finn/custom_op/fpgadataflow/rtl/inner_shuffle_rtl.py
+++ b/src/finn/custom_op/fpgadataflow/rtl/inner_shuffle_rtl.py
@@ -148,6 +148,21 @@ class InnerShuffle_rtl(InnerShuffle, RTLBackend):
     def execute_node(self, context, graph):
         mode = self.get_nodeattr("exec_mode")
         if mode == "rtlsim":
-            RTLBackend.execute_node(self, context, graph)
+            node = self.onnx_node
+            input_name = node.input[0]
+            input_value = context[input_name]
+            expected_shape = tuple(self.get_normal_input_shape())
+            if input_value.shape == expected_shape:
+                RTLBackend.execute_node(self, context, graph)
+                return
+            if input_value.size != math.prod(expected_shape):
+                raise RuntimeError(
+                    f"{node.name}: cannot reshape input {input_value.shape} to {expected_shape}"
+                )
+            context[input_name] = input_value.reshape(expected_shape)
+            try:
+                RTLBackend.execute_node(self, context, graph)
+            finally:
+                context[input_name] = input_value
         else:
             InnerShuffle.execute_node(self, context, graph)

--- a/tests/fpgadataflow/test_fpgadataflow_elementwise_binary_rtl.py
+++ b/tests/fpgadataflow/test_fpgadataflow_elementwise_binary_rtl.py
@@ -17,6 +17,7 @@ from qonnx.transformation.infer_shapes import InferShapes
 from qonnx.util.basic import gen_finn_dt_tensor, qonnx_make_model
 
 from finn.core.onnx_exec import execute_onnx
+from finn.custom_op.fpgadataflow.rtl.elementwise_binary_rtl import ElementwiseAdd_rtl
 from finn.transformation.fpgadataflow.convert_to_hw_layers import (
     InferElementwiseBinaryOperation,
 )
@@ -39,6 +40,29 @@ NUMPY_REFERENCES = {
     "ElementwiseAdd": np.add,
     "ElementwiseMul": np.multiply,
 }
+
+
+def test_elementwise_rtl_accepts_reshape_equivalent_dynamic_input():
+    node = oh.make_node(
+        "ElementwiseAdd_rtl",
+        ["lhs", "rhs"],
+        ["out"],
+        domain="finn.custom_op.fpgadataflow.rtl",
+        lhs_shape=[1, 2, 3],
+        rhs_shape=[1, 2, 3],
+        name="ElementwiseAdd_rtl_test",
+    )
+    instance = ElementwiseAdd_rtl(node)
+    input_value = np.arange(6, dtype=np.float32).reshape(1, 3, 2)
+
+    reshaped = instance._reshape_dynamic_input(input_value, 0)
+
+    assert reshaped.shape == (1, 2, 3)
+    assert np.array_equal(reshaped, input_value.reshape(1, 2, 3))
+    assert input_value.shape == (1, 3, 2)
+
+    with pytest.raises(AssertionError, match="Input shape mismatch for lhs"):
+        instance._reshape_dynamic_input(np.zeros((1, 4), dtype=np.float32), 0)
 
 
 def create_elementwise_model(op_type, lhs_dtype, rhs_dtype, lhs_shape, rhs_shape, out_dtype=None):

--- a/tests/fpgadataflow/test_fpgadataflow_shuffle.py
+++ b/tests/fpgadataflow/test_fpgadataflow_shuffle.py
@@ -15,6 +15,7 @@ import os
 import tempfile
 import torch
 import torch.onnx
+from onnx import helper
 from brevitas.export import export_qonnx
 from qonnx.core.datatype import DataType
 from qonnx.core.modelwrapper import ModelWrapper
@@ -30,6 +31,8 @@ from torch import nn
 import finn.core.onnx_exec as oxe
 from finn import xsi as finnxsi
 from finn.analysis.fpgadataflow.exp_cycles_per_layer import exp_cycles_per_layer
+from finn.custom_op.fpgadataflow.hls.outer_shuffle_hls import OuterShuffle_hls
+from finn.custom_op.fpgadataflow.hlsbackend import HLSBackend
 from finn.transformation.fpgadataflow.compile_cppsim import CompileCppSim
 from finn.transformation.fpgadataflow.convert_to_hw_layers import InferShuffle
 from finn.transformation.fpgadataflow.create_stitched_ip import CreateStitchedIP
@@ -122,6 +125,38 @@ class SetShuffleSIMD(Transformation):
                 if self.enable_waveforms:
                     inst.set_nodeattr("rtlsim_trace", "debug.wdb")
         return model, False
+
+
+def test_outer_shuffle_hls_accepts_reshape_equivalent_context(monkeypatch):
+    node = helper.make_node(
+        "OuterShuffle_hls",
+        ["inp"],
+        ["out"],
+        domain="finn.custom_op.fpgadataflow.hls",
+        in_shape=[1, 3, 2, 2],
+        transpose_in_shape=[1, 3, 2, 2],
+        transpose_out_shape=[1, 2, 3, 2],
+        out_shape=[1, 2, 3, 2],
+        perm=[0, 2, 1, 3],
+        data_type="INT8",
+        SIMD=2,
+        NumChannels=2,
+        name="OuterShuffle_hls_test",
+    )
+    instance = OuterShuffle_hls(node)
+    input_value = np.arange(12, dtype=np.float32).reshape(1, 2, 2, 3)
+    context = {"inp": input_value}
+
+    def fake_hls_execute(_instance, execution_context, _graph):
+        assert execution_context["inp"].shape == (1, 3, 2, 2)
+        execution_context["out"] = np.zeros((1, 2, 3, 2), dtype=np.float32)
+
+    monkeypatch.setattr(HLSBackend, "execute_node", fake_hls_execute)
+
+    instance.execute_node(context, None)
+
+    assert context["inp"] is input_value
+    assert context["inp"].shape == (1, 2, 2, 3)
 
 
 @pytest.mark.parametrize(

--- a/tests/fpgadataflow/test_fpgadataflow_shuffle.py
+++ b/tests/fpgadataflow/test_fpgadataflow_shuffle.py
@@ -15,7 +15,7 @@ import os
 import tempfile
 import torch
 import torch.onnx
-from onnx import helper
+from onnx import TensorProto, helper
 from brevitas.export import export_qonnx
 from qonnx.core.datatype import DataType
 from qonnx.core.modelwrapper import ModelWrapper
@@ -24,7 +24,7 @@ from qonnx.transformation.base import Transformation
 from qonnx.transformation.general import GiveReadableTensorNames, GiveUniqueNodeNames
 from qonnx.transformation.infer_datatypes import InferDataTypes
 from qonnx.transformation.infer_shapes import InferShapes
-from qonnx.util.basic import gen_finn_dt_tensor
+from qonnx.util.basic import gen_finn_dt_tensor, qonnx_make_model
 from qonnx.util.cleanup import cleanup as qonnx_cleanup
 from torch import nn
 
@@ -33,6 +33,8 @@ from finn import xsi as finnxsi
 from finn.analysis.fpgadataflow.exp_cycles_per_layer import exp_cycles_per_layer
 from finn.custom_op.fpgadataflow.hls.outer_shuffle_hls import OuterShuffle_hls
 from finn.custom_op.fpgadataflow.hlsbackend import HLSBackend
+from finn.custom_op.fpgadataflow.rtl.inner_shuffle_rtl import InnerShuffle_rtl
+from finn.custom_op.fpgadataflow.rtlbackend import RTLBackend
 from finn.transformation.fpgadataflow.compile_cppsim import CompileCppSim
 from finn.transformation.fpgadataflow.convert_to_hw_layers import InferShuffle
 from finn.transformation.fpgadataflow.create_stitched_ip import CreateStitchedIP
@@ -156,6 +158,72 @@ def test_outer_shuffle_hls_accepts_reshape_equivalent_context(monkeypatch):
     instance.execute_node(context, None)
 
     assert context["inp"] is input_value
+    assert context["inp"].shape == (1, 2, 2, 3)
+
+
+def test_inner_shuffle_uses_transpose_input_shape(monkeypatch):
+    node = helper.make_node(
+        "Shuffle",
+        ["inp"],
+        ["out"],
+        domain="finn.custom_op.fpgadataflow",
+        backend="fpgadataflow",
+        in_shape=[1, 3, 2, 2],
+        transpose_in_shape=[1, 3, 4],
+        transpose_out_shape=[1, 4, 3],
+        out_shape=[1, 4, 3],
+        perm=[0, 2, 1],
+        data_type="INT8",
+        SIMD=1,
+        name="Shuffle_test",
+    )
+    inp = helper.make_tensor_value_info("inp", TensorProto.FLOAT, [1, 3, 2, 2])
+    out = helper.make_tensor_value_info("out", TensorProto.FLOAT, [1, 4, 3])
+    graph = helper.make_graph([node], "inner-shuffle-reshape", [inp], [out])
+    model = ModelWrapper(qonnx_make_model(graph, producer_name="inner-shuffle-reshape"))
+    model.set_tensor_datatype("inp", DataType["INT8"])
+    model.set_tensor_datatype("out", DataType["INT8"])
+
+    model = model.transform(InferInnerOuterShuffles())
+
+    transformed_node = model.graph.node[0]
+    transformed_inst = getCustomOp(transformed_node)
+    assert transformed_node.op_type == "InnerShuffle"
+    assert transformed_inst.get_normal_input_shape() == [1, 3, 2, 2]
+    assert transformed_inst.get_nodeattr("transpose_in_shape") == [1, 3, 4]
+    assert transformed_inst.get_normal_output_shape() == (1, 4, 3)
+
+    input_value = np.arange(12, dtype=np.float32).reshape(1, 3, 2, 2)
+    software_context = {"inp": input_value}
+    transformed_inst.execute_node(software_context, None)
+    expected = input_value.reshape(1, 3, 4).transpose(0, 2, 1)
+    assert np.array_equal(software_context["out"], expected)
+
+    rtl_node = helper.make_node(
+        "InnerShuffle_rtl",
+        ["inp"],
+        ["out"],
+        domain="finn.custom_op.fpgadataflow.rtl",
+        backend="fpgadataflow",
+        in_shape=[1, 3, 2, 2],
+        transpose_in_shape=[1, 3, 4],
+        data_type="INT8",
+        SIMD=1,
+        name="InnerShuffle_rtl_test",
+    )
+    rtl_inst = InnerShuffle_rtl(rtl_node)
+    rtl_inst.set_nodeattr("exec_mode", "rtlsim")
+    rtl_input_value = input_value.reshape(1, 2, 2, 3)
+    context = {"inp": rtl_input_value}
+
+    def fake_rtl_execute(_instance, execution_context, _graph):
+        assert execution_context["inp"].shape == (1, 3, 2, 2)
+        execution_context["out"] = np.zeros((1, 4, 3), dtype=np.float32)
+
+    monkeypatch.setattr(RTLBackend, "execute_node", fake_rtl_execute)
+    rtl_inst.execute_node(context, None)
+
+    assert context["inp"] is rtl_input_value
     assert context["inp"].shape == (1, 2, 2, 3)
 
 


### PR DESCRIPTION
# Allow reshape-equivalent inputs during custom-op execution

## Why

Fused reshapes can leave execution-context tensors with a different logical shape from the hardware operator's stream shape, despite having the same number of elements. Strict shape checks caused otherwise valid simulations to fail.

## How

Temporarily reshape compatible inputs for HLS OuterShuffle, RTL InnerShuffle and RTL elementwise execution, then restore the original execution context.