### PR TITLE
Fix watchdog leak in rtlsim_multi_io

### DIFF
--- a/finn_xsi/finn_xsi/adapter.py
+++ b/finn_xsi/finn_xsi/adapter.py
@@ -209,23 +209,37 @@ def rtlsim_multi_io(
         sim.stream_input(stream_name, hexstring_input)
 
     hex_output_streams = {}
+    watchdogs = []
     for out in io_dict["outputs"]:
         stream_name = out + sname
+        watchdog = sim.create_watchdog(f"{stream_name} timeout", liveness_threshold)
+        watchdogs.append(watchdog)
         hex_output_streams[out] = sim.collect_output(
             stream_name,
             num_out_values[out],
-            watchdog=sim.create_watchdog(f"{stream_name} timeout", liveness_threshold),
+            watchdog=watchdog,
         )
 
     start_ticks = sim.ticks
-    ret = sim.run()
-    if len(ret) > 0:
-        assert False, (
-            get_rtlsim_timeout_error_message(liveness_threshold, liveness_estimate)
-            + f" Triggered watchdogs: {str(ret)}. Check rtlsim_trace if any."
-        )
-    end_ticks = sim.ticks
-    for out in io_dict["outputs"]:
-        io_dict["outputs"][out] = list(map(lambda var: int(var, base=16), hex_output_streams[out]))
+    try:
+        ret = sim.run()
+        if len(ret) > 0:
+            assert False, (
+                get_rtlsim_timeout_error_message(liveness_threshold, liveness_estimate)
+                + f" Triggered watchdogs: {str(ret)}. Check rtlsim_trace if any."
+            )
+        end_ticks = sim.ticks
+        for out in io_dict["outputs"]:
+            io_dict["outputs"][out] = list(
+                map(lambda var: int(var, base=16), hex_output_streams[out])
+            )
+    finally:
+        # Remove the per-output watchdogs so they do not outlive this data pass.
+        # sim.watchdogs is persistent; a leftover (already-exhausted) watchdog
+        # would keep ticking and prematurely abort any later sim.run(), e.g. a
+        # post-hook AXI-Lite weight read-back (see test_fpgadataflow_mvau).
+        for watchdog in watchdogs:
+            if watchdog in sim.watchdogs:
+                sim.remove_watchdog(watchdog)
 
     return end_ticks - start_ticks

--- a/tests/fpgadataflow/test_fpgadataflow_mvau.py
+++ b/tests/fpgadataflow/test_fpgadataflow_mvau.py
@@ -529,16 +529,6 @@ def test_fpgadataflow_mvau_rtlsim(mem_mode, idt, wdt, act, nf, sf, mw, mh, pumpe
 def test_fpgadataflow_mvau_large_depth_decoupled_mode_rtlsim(
     mem_mode, idt, wdt, act, nf, sf, mw, mh, preferred_impl_style, ram_style, part
 ):
-    # TODO: bring back skipped test when solved
-    if (
-        preferred_impl_style == "rtl"
-        and part == "xczu7ev-ffvc1156-2-e"
-        and ram_style == "ultra"
-        and mw == mh == 128
-        and nf == sf == -1
-        and act is None
-    ):
-        pytest.skip("Temporarily xfail this test, because last address can't be read back.")
     if preferred_impl_style == "rtl" and act is not None:
         pytest.skip("RTL-MVAU doesn't support const mem mode or embedded activations")
     if nf == -1:


### PR DESCRIPTION
`rtlsim_multi_io` created a per-output-stream watchdog for each data pass but never removed it. The stale (exhausted) watchdog kept ticking and prematurely aborted the next `sim.run()`, e.g. a post-hook AXI-Lite weight read-back, truncating the transfer and causing a `KeyError` on the uncollected addresses.

- Remove each per-output watchdog in a `try/finally` after the data pass.
- Re-enables the previously skipped MVAU URAM weight read-back (HLS and RTL).

Kudos to @sgerber-amd
