### PR TITLE
Support asymmetric Quant activation conversion

### DIFF
--- a/src/finn/transformation/qonnx/qonnx_activation_handlers.py
+++ b/src/finn/transformation/qonnx/qonnx_activation_handlers.py
@@ -179,7 +179,19 @@ class QuantActBaseHandler(ABC):
             mt_inst.set_nodeattr("out_dtype", out_dtype)
         else:
             # Set datatype
-            mt_inst.set_nodeattr("out_dtype", out_dtype)
+            # Signed Quant identity conversion inserts its negative offset as a
+            # following Add. Until that Add is absorbed, MultiThreshold itself
+            # produces the unsigned level index (for example 0..127 for INT7).
+            # Annotating this intermediate as signed makes QONNX execution
+            # sanitize valid upper-half levels before the offset is applied.
+            mt_out_dtype = out_dtype
+            if (
+                self._q_node.op_type == "Quant"
+                and out_dtype.startswith("INT")
+                and np.any(adder_bias != 0)
+            ):
+                mt_out_dtype = "U" + out_dtype
+            mt_inst.set_nodeattr("out_dtype", mt_out_dtype)
 
             # Insertion parameters
             up_stream_node = mt_node
@@ -483,10 +495,18 @@ class QuantIdentityHandler(QuantActBaseHandler):
     def _check_compatibility(self):
         # Gather parameters to check
         if self._q_node.op_type == "Quant":
-            if not self._model.get_initializer(self._q_node.input[2]) == 0:
+            quant_scale = self._model.get_initializer(self._q_node.input[1])
+            zero_point = self._model.get_initializer(self._q_node.input[2])
+            if zero_point is None:
+                raise ValueError("Quant identity activations require a static zero-point.")
+            if quant_scale is None:
+                raise ValueError("Quant identity activations require a static scale.")
+            num_scale_channels = quant_scale.flatten().shape[0]
+            num_zero_point_channels = zero_point.flatten().shape[0]
+            if num_zero_point_channels not in (1, num_scale_channels):
                 raise ValueError(
-                    "Only Quant nodes with zero-point == 0 "
-                    "are currently supported for identity activations."
+                    "Quant identity activations only support scalar zero-point or "
+                    "one zero-point per scale channel."
                 )
         elif self._q_node.op_type == "BipolarQuant":
             quant_scale = self._model.get_initializer(self._q_node.input[1])
@@ -522,7 +542,8 @@ class QuantIdentityHandler(QuantActBaseHandler):
                     min_non_scaled_val = -(2 ** (bit_width - 1) - 1)
                 else:
                     min_non_scaled_val = -(2 ** (bit_width - 1))
-            bias = np.array([min_non_scaled_val], dtype=np_default_dtype)
+            zero_point = self._model.get_initializer(self._q_node.input[2])
+            bias = np.array([min_non_scaled_val], dtype=np_default_dtype) - zero_point
         return bias
 
     def _calculate_thresholds(self):
@@ -531,10 +552,12 @@ class QuantIdentityHandler(QuantActBaseHandler):
         q_inst = getCustomOp(self._q_node)
         if self._q_node.op_type == "Quant":
             bit_width = self._model.get_initializer(self._q_node.input[3])
+            zero_point = self._model.get_initializer(self._q_node.input[2])
             narrow = q_inst.get_nodeattr("narrow")
             signed = q_inst.get_nodeattr("signed")
         elif self._q_node.op_type == "BipolarQuant":
             bit_width = 1.0
+            zero_point = np.array([0.0], dtype=np_default_dtype)
         else:
             raise RuntimeError("Got an unexpected quantizer node type")
 
@@ -559,6 +582,7 @@ class QuantIdentityHandler(QuantActBaseHandler):
             # boundary below an input that Quant legitimately rounds down, causing
             # a one-step MultiThreshold mismatch. float64 keeps that error ~1e-15.
             flat_scale = quant_scale.flatten().astype(np.float64)
+            flat_zero_point = zero_point.flatten().astype(np.float64)
             num_scale_channels = flat_scale.shape[0]
             step = np.abs(flat_scale)
             half_step = step / 2.0
@@ -571,10 +595,33 @@ class QuantIdentityHandler(QuantActBaseHandler):
             if not signed:
                 min_threshold = half_step
             for c in range(num_scale_channels):
+                zero_point_index = 0 if flat_zero_point.shape[0] == 1 else c
+                shifted_min_threshold = (
+                    min_threshold[c] - step[c] * flat_zero_point[zero_point_index]
+                )
                 for t in range(num_thresholds):
-                    thresholds[c][t] = min_threshold[c] + step[c] * t
+                    thresholds[c][t] = shifted_min_threshold + step[c] * t
             # narrow back to the storage dtype only after the accumulation
             thresholds = thresholds.astype(np_default_dtype)
+
+            # MultiThreshold uses an inclusive >= comparison, whereas QONNX
+            # ROUND/HALF_EVEN sends an exact tie to the even output level. If
+            # the lower level is even, make that boundary exclusive by moving
+            # it one representable float toward +infinity. Boundaries whose
+            # upper level is even remain inclusive.
+            rounding_mode = q_inst.get_nodeattr("rounding_mode").upper()
+            if self._q_node.op_type == "Quant" and rounding_mode in ("ROUND", "HALF_EVEN"):
+                signed = q_inst.get_nodeattr("signed")
+                bit_width_int = int(np.asarray(bit_width).reshape(-1)[0])
+                if signed:
+                    min_level = -(2 ** (bit_width_int - 1)) + int(narrow)
+                else:
+                    min_level = 0
+                lower_levels = min_level + np.arange(num_thresholds)
+                lower_even = (lower_levels % 2) == 0
+                thresholds[:, lower_even] = np.nextafter(
+                    thresholds[:, lower_even], np.float32(np.inf)
+                )
 
             # First try to consider the tensor layout of the output for
             # determining the number of output channels

--- a/src/finn/transformation/qonnx/quant_act_to_multithreshold.py
+++ b/src/finn/transformation/qonnx/quant_act_to_multithreshold.py
@@ -110,10 +110,6 @@ class ConvertQuantActToMultiThreshold(Transformation):
                     predecessor_op_type = predecessor[0].op_type
                 else:
                     predecessor_op_type = predecessor
-                if n.op_type == "Quant" and not model.get_initializer(n.input[2]) == 0:
-                    raise ValueError(
-                        "Only Quant nodes with zero-point == 0 are currently supported."
-                    )
 
                 # Check that this node passes the user filter
                 if not self._filter_function(model, n):

--- a/src/finn/transformation/streamline/absorb.py
+++ b/src/finn/transformation/streamline/absorb.py
@@ -150,7 +150,10 @@ class AbsorbScalarBiasIntoMultiThreshold(Transformation):
                         continue
                     for candidate in DataType.get_accumulator_dt_cands():
                         odt = DataType[candidate]
-                        if odt.allowed(new_min) and odt.allowed(new_max):
+                        if all(
+                            odt.allowed(value)
+                            for value in range(int(new_min), int(new_max) + 1)
+                        ):
                             break
                     else:
                         raise AssertionError(

--- a/src/finn/transformation/streamline/absorb.py
+++ b/src/finn/transformation/streamline/absorb.py
@@ -143,28 +143,20 @@ class AbsorbScalarBiasIntoMultiThreshold(Transformation):
                     new_min = out_bias
                     new_max = out_bias + thresholds.shape[-1]
 
-                    # Derive the smallest datatype that represents the full
-                    # shifted output range [new_min, new_max]. Use an unsigned
-                    # type when the range is non-negative, otherwise a signed
-                    # type wide enough to cover both endpoints. Note a signed
-                    # type reaching -(new_max + 1) also represents +new_max, so
-                    # the negative magnitude that must fit is the more negative
-                    # of new_min and -(new_max + 1).
-                    if new_min >= 0:
-                        odt = DataType.get_smallest_possible(new_max)
-                    else:
-                        odt = DataType.get_smallest_possible(min(new_min, -(new_max + 1)))
-
-                    # Check whether the new range can be represented with the
-                    # derived integer datatype
-                    if not (odt.allowed(new_max) and odt.allowed(new_min)):
-                        # Cannot be represented, warn and skip transforming
-                        warnings.warn(
-                            f"{self.__class__.__name__}: Cannot absorb bias"
-                            f" from {consumer.name} into {node.name}: {bias}"
-                        )
-                        # Skip to the next candidate node
+                    # MultiThreshold outputs must remain integer-valued. Find
+                    # the narrowest datatype that represents every value in the
+                    # shifted range, including special types such as TERNARY.
+                    if int(new_min) != new_min or int(new_max) != new_max:
                         continue
+                    for candidate in DataType.get_accumulator_dt_cands():
+                        odt = DataType[candidate]
+                        if odt.allowed(new_min) and odt.allowed(new_max):
+                            break
+                    else:
+                        raise AssertionError(
+                            "Could not compute new MultiThreshold DataType "
+                            f"(min = {new_min} max = {new_max})"
+                        )
 
                     # Absorbing a bias can widen the output datatype (e.g. a
                     # large positive bias). Skip the absorption if the output

--- a/tests/transformation/test_qonnx_to_finn.py
+++ b/tests/transformation/test_qonnx_to_finn.py
@@ -238,6 +238,20 @@ def test_unsigned_quant_conversion_supports_per_channel_zero_point():
 
 
 @pytest.mark.transform
+def test_unsigned_narrow_quant_streamline_preserves_ternary_datatype():
+    x = np.array([[-0.5, -0.25, 0.0, 0.25, 0.5]], dtype=np.float32)
+    model = _make_single_quant_model(x, [0.25], [1.0], [2.0], 0, 1, "ROUND")
+    streamlined = model.transform(ConvertQONNXtoFINN()).transform(Streamline())
+
+    expected = oxe.execute_onnx(model, {"global_in": x})["global_out"]
+    actual = oxe.execute_onnx(streamlined, {"global_in": x})["global_out"]
+    threshold = streamlined.get_nodes_by_op_type("MultiThreshold")[0]
+
+    assert streamlined.get_tensor_datatype(threshold.output[0]).name == "TERNARY"
+    assert np.array_equal(actual, expected)
+
+
+@pytest.mark.transform
 def test_QONNX_to_FINN_threshold_precision():
     """Regression test for a float32 accumulation error in MultiThreshold
     threshold derivation (QuantActBaseHandler._calculate_thresholds).

--- a/tests/transformation/test_qonnx_to_finn.py
+++ b/tests/transformation/test_qonnx_to_finn.py
@@ -45,6 +45,10 @@ from tempfile import TemporaryDirectory
 
 import finn.core.onnx_exec as oxe
 from finn.transformation.qonnx.convert_qonnx_to_finn import ConvertQONNXtoFINN
+from finn.transformation.qonnx.quant_act_to_multithreshold import (
+    ConvertQuantActToMultiThreshold,
+)
+from finn.transformation.streamline import Streamline
 from finn.util.test import get_test_model_trained
 
 
@@ -167,6 +171,70 @@ def _make_single_quant_model(x, scale, zeropt, bitwidth, signed, narrow, roundin
     model.opset_import.append(helper.make_opsetid("qonnx.custom_op.general", 1))
     m = ModelWrapper(model)
     return m.transform(InferShapes()).transform(InferDataTypes())
+
+
+@pytest.mark.transform
+def test_quant_act_filter_leaves_rejected_candidate_untouched():
+    """A Quant candidate rejected by the caller must remain untouched."""
+
+    x = np.zeros((1, 2), dtype=np.float32)
+    model = _make_single_quant_model(x, [0.25], [3.0], [8.0], 0, 0, "ROUND")
+    with pytest.warns(UserWarning, match="filtering function returned False"):
+        converted = model.transform(ConvertQuantActToMultiThreshold(lambda _model, _node: False))
+    assert len(converted.get_nodes_by_op_type("Quant")) == 1
+    assert len(converted.get_nodes_by_op_type("MultiThreshold")) == 0
+
+
+@pytest.mark.transform
+def test_signed_quant_conversion_preserves_saturated_levels():
+    x = np.array([[-100.0, 100.0]], dtype=np.float32)
+    model = _make_single_quant_model(x, [0.25], [0.0], [7.0], 1, 0, "ROUND")
+    converted = model.transform(ConvertQONNXtoFINN())
+
+    expected = oxe.execute_onnx(model, {"global_in": x})["global_out"]
+    actual = oxe.execute_onnx(converted, {"global_in": x})["global_out"]
+    assert np.array_equal(actual, expected)
+
+
+@pytest.mark.transform
+def test_signed_quant_conversion_preserves_round_to_even_ties():
+    x = np.array([[-0.375, -0.125, 0.125, 0.375]], dtype=np.float32)
+    model = _make_single_quant_model(x, [0.25], [0.0], [7.0], 1, 0, "ROUND")
+    converted = model.transform(ConvertQONNXtoFINN())
+
+    expected = oxe.execute_onnx(model, {"global_in": x})["global_out"]
+    actual = oxe.execute_onnx(converted, {"global_in": x})["global_out"]
+    assert np.array_equal(actual, expected)
+
+
+@pytest.mark.transform
+def test_unsigned_quant_conversion_supports_nonzero_zero_point():
+    x = np.array([[-1.0, -0.125, 0.0, 0.5, 1.0]], dtype=np.float32)
+    model = _make_single_quant_model(x, [0.125], [2.25], [7.0], 0, 0, "ROUND")
+    converted = model.transform(ConvertQONNXtoFINN())
+    streamlined = converted.transform(Streamline())
+
+    expected = oxe.execute_onnx(model, {"global_in": x})["global_out"]
+    actual = oxe.execute_onnx(converted, {"global_in": x})["global_out"]
+    streamlined_actual = oxe.execute_onnx(streamlined, {"global_in": x})["global_out"]
+    assert np.array_equal(actual, expected)
+    assert np.array_equal(streamlined_actual, expected)
+
+
+@pytest.mark.transform
+def test_unsigned_quant_conversion_supports_per_channel_zero_point():
+    x = np.array([[-0.25, 0.5]], dtype=np.float32)
+    model = _make_single_quant_model(
+        x, [0.125, 0.25], [1.5, 2.25], [7.0], 0, 0, "ROUND"
+    )
+    converted = model.transform(ConvertQONNXtoFINN())
+    streamlined = converted.transform(Streamline())
+
+    expected = oxe.execute_onnx(model, {"global_in": x})["global_out"]
+    actual = oxe.execute_onnx(converted, {"global_in": x})["global_out"]
+    streamlined_actual = oxe.execute_onnx(streamlined, {"global_in": x})["global_out"]
+    assert np.array_equal(actual, expected)
+    assert np.array_equal(streamlined_actual, expected)
 
 
 @pytest.mark.transform


### PR DESCRIPTION
# Support asymmetric Quant activation conversion

## Why

QONNX-to-FINN activation conversion rejected non-zero zero points and could produce incorrect intermediate datatypes for signed, unsigned and narrow quantizers.

## How

Account for scalar and per-channel zero points when deriving thresholds and biases, preserve the unsigned intermediate level range, handle round-to-even boundaries and select a datatype that represents every output level.