### PR TITLE
[MLO] Fail fast when loop rolling resolves to iteration=1

### DIFF
--- a/src/finn/transformation/fpgadataflow/loop_rolling.py
+++ b/src/finn/transformation/fpgadataflow/loop_rolling.py
@@ -487,36 +487,40 @@ class LoopRolling(Transformation):
         # TODO: write a check to ensure that there is only one
         #       set of consecutive nodes.
         nodes = osh.find_nodes_of_optype(graph, LoopBody.function.name)
+        # MLO requires at least two repetitions of the loop body to roll into a
+        # FINNLoop. A single instance (iteration=1) cannot be handled by the
+        # downstream MLO machinery.
+        if len(nodes) < 2:
+            raise Exception(
+                f"LoopRolling: MLO requires at least 2 repetitions of the loop "
+                f"body, but found {len(nodes)}. A single-instance model cannot be "
+                f"rolled into a FINNLoop. Disable 'mlo' (or fix 'loop_body_hierarchy'/"
+                f"'loop_body_range') for this model."
+            )
         # Loop through all the nodes (execept the last one) and
         # identify the input to output pairs
 
         # my loop rolling code assumes that the activation inputs are listed first and
         # that corresponding output activations have the same index as the input
         input_swaps = []
-        if len(nodes) == 1:
-            # find and label the activation inputs
-            for i, input in enumerate(nodes[0].inputs):
-                if not input.is_initializer():
-                    if input.is_graph_input() or input.producer().op_type != "Constant":
-                        input_swaps.append((len(input_swaps), i))
-        else:
-            for i in range(len(nodes) - 1):
-                a_node = nodes[i]
-                b_node = nodes[i + 1]
+        # nodes is guaranteed to have >= 2 entries (checked above).
+        for i in range(len(nodes) - 1):
+            a_node = nodes[i]
+            b_node = nodes[i + 1]
 
-                for a_out in a_node.outputs:
-                    # Require that outputs of a have a single use of b_node
-                    assert len(a_out.uses()) == 1
-                    assert a_out.uses()[0][0] is b_node
+            for a_out in a_node.outputs:
+                # Require that outputs of a have a single use of b_node
+                assert len(a_out.uses()) == 1
+                assert a_out.uses()[0][0] is b_node
 
-                    a_use_index = a_out.uses()[0][1]
-                    input_swap = (a_out.index(), a_use_index)
-                    if i == 0:
-                        # add swaps from the first node
-                        input_swaps.append(input_swap)
-                    else:
-                        # check that they are the same in the rest
-                        assert input_swap in input_swaps
+                a_use_index = a_out.uses()[0][1]
+                input_swap = (a_out.index(), a_use_index)
+                if i == 0:
+                    # add swaps from the first node
+                    input_swaps.append(input_swap)
+                else:
+                    # check that they are the same in the rest
+                    assert input_swap in input_swaps
 
         # apply the input swaps to each nodes
         for node in nodes:

--- a/tests/transformation/test_loop_rolling.py
+++ b/tests/transformation/test_loop_rolling.py
@@ -330,3 +330,38 @@ def test_inconsistent_initializer_shape():
 
     # on success (the expected raise fired) drop the scratch dir, kept otherwise
     robust_rmtree(out_dir)
+
+
+@pytest.mark.transform
+def test_single_instance_loop_rolling_raises():
+    # A model with a single loop-body instance (num_layers=1) resolves to
+    # iteration=1, which the MLO infrastructure does not support.
+    out_dir = Path(make_build_dir(prefix="test_single_instance_loop_"))
+    input_size = 20
+    hidden_size = 20
+    num_layers = 1
+
+    onnx_path, model = export_model_to_qonnx(out_dir, input_size, hidden_size, num_layers)
+
+    qonnx_cleanup(onnx_path, out_file=onnx_path)
+    model_wrapper = ModelWrapper(onnx_path)
+
+    template_path = out_dir / "loop-body-template.onnx"
+    loop_extraction = LoopExtraction(
+        hierarchy_list=[["", "layers.0"]], loop_body_template_path=template_path
+    )
+    model_wrapper = model_wrapper.transform(loop_extraction)
+
+    # exactly one loop-body instance -> rolling would yield iteration=1
+    assert (
+        len(model_wrapper.get_nodes_by_op_type("fn_loop-body")) == 1
+    ), "Expected a single loop-body instance for num_layers=1"
+
+    with pytest.raises(
+        Exception,
+        match="LoopRolling: MLO requires at least 2 repetitions of the loop body",
+    ):
+        model_wrapper = model_wrapper.transform(LoopRolling(loop_extraction.loop_body_template))
+
+    # on success (the expected raise fired) drop the scratch dir, kept otherwise
+    robust_rmtree(out_dir)


### PR DESCRIPTION
`LoopRolling` now raises a clear error when the loop body has fewer than 2 instances, instead of producing a degenerate iteration=1 `FINNLoop`.
