### PR TITLE
Pin every CI stage to one commit so the Docker tag and stashed sources stay consistent

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -869,7 +869,6 @@ void checkoutPinned() {
     branches: [[name: PINNED_SCM_COMMIT]],
     userRemoteConfigs: scm.userRemoteConfigs,
     extensions: scm.extensions,
-    browser: scm.browser,
   ])
 }
 

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -90,6 +90,16 @@ int finnCiMinFreeGB() {
 @Field
 static final String FINN_BUILD_LABEL = 'finn-build'
 
+// The commit every stage checks out. Resolved once from the branch tip on the
+// first checkoutPinned() call (Validate) and reused unchanged for the rest of
+// the build, so `git describe` — and therefore the Docker tag baked by
+// run-docker.sh — is identical in the Build Docker Image stage and its
+// consumers. Without this, each stage's checkout re-resolves the branch head;
+// a push mid-build desyncs the tag and hard-fails the PREBUILT check in
+// run-docker.sh. @Field so the SHA survives CPS replay across stages/agents.
+@Field
+String PINNED_SCM_COMMIT = ''
+
 // Optional setup-local.sh stage label and cache root.
 // Read via helpers, not @Field, so env resolution happens
 // inside the running pipeline rather than at script load.
@@ -126,6 +136,10 @@ pipeline {
   agent none
   options {
     timeout(time: 72, unit: 'HOURS')
+    // Every stage checks out through checkoutPinned() instead of the implicit
+    // per-agent checkout, so the whole build tests one commit even if the
+    // branch is pushed mid-run. See checkoutPinned() / PINNED_SCM_COMMIT.
+    skipDefaultCheckout()
   }
   parameters {
     // STAGES choices mirror finn_ci.config.jenkins_stage_choices(). Drift
@@ -151,6 +165,7 @@ pipeline {
       agent { label "${FINN_BUILD_LABEL}" }
       steps {
         script {
+          checkoutPinned()
           wipeStaleWorkspace()
           announceCiMode()
           loadStageConfig()
@@ -165,14 +180,14 @@ pipeline {
     stage('Build Docker Image') {
       agent { label "${FINN_BUILD_LABEL}" }
       environment { FINN_DOCKER_PREBUILT = '0' }
-      steps { script { wipeStaleWorkspace(); withAgentNfsEnv(exposeSharedImage: false) { buildAndPublishDockerImage() } } }
+      steps { script { checkoutPinned(); wipeStaleWorkspace(); withAgentNfsEnv(exposeSharedImage: false) { buildAndPublishDockerImage() } } }
     }
     stage('Run Tests') {
       steps { script { runParallelOrFail(buildParallelStageMap()) } }
     }
     stage('Check Stage Results') {
       agent { label "${FINN_BUILD_LABEL}" }
-      steps { script { withAgentNfsEnv { aggregateReports() } } }
+      steps { script { checkoutPinned(); withAgentNfsEnv { aggregateReports() } } }
     }
   }
   // post { always } runs on graceful completion AND graceful abort. It is
@@ -425,7 +440,7 @@ void runShard(Map entry) {
   node(FINN_BUILD_LABEL) {
     withAgentNfsEnv {
       stage(stageName) {
-        checkout scm
+        checkoutPinned()
         wipeStaleWorkspace()
         String perBuildRoot = finnCiPerBuildRoot()
         String buildDir = "${perBuildRoot}/${stashName}"
@@ -497,7 +512,7 @@ void runLocalSetupTest() {
   node(finnLocalBuildLabel()) {
     withAgentNfsEnv {
       stage('Local Setup (non-Docker) with Vivado') {
-        checkout scm
+        checkoutPinned()
         wipeStaleWorkspace()
         String perBuildRoot = finnCiPerBuildRoot()
         String buildDir = "${perBuildRoot}/local_setup"
@@ -833,6 +848,30 @@ void findCopyZip(String testType, String board, String findDir, String copyDir) 
 // ============================================================================
 // Cross-cutting helpers
 // ============================================================================
+
+// Single checkout entry point for every stage (skipDefaultCheckout() is set, so
+// nothing else clones). The first call (Validate) resolves the branch tip and
+// records it in PINNED_SCM_COMMIT; every later call — on any agent — checks out
+// that exact SHA, reusing the job's configured remotes/extensions/browser so
+// credentials, refspecs and tag fetching match a plain `checkout scm`. This
+// keeps `git describe` (and the Docker tag) constant across stages even if the
+// branch moves mid-build. Must run before wipeStaleWorkspace(), which needs a
+// populated git workspace to `git clean`/`git status`.
+void checkoutPinned() {
+  if (!PINNED_SCM_COMMIT) {
+    def vars = checkout scm
+    PINNED_SCM_COMMIT = vars.GIT_COMMIT
+    echo "checkoutPinned: pinned build to ${PINNED_SCM_COMMIT}"
+    return
+  }
+  checkout([
+    $class: 'GitSCM',
+    branches: [[name: PINNED_SCM_COMMIT]],
+    userRemoteConfigs: scm.userRemoteConfigs,
+    extensions: scm.extensions,
+    browser: scm.browser,
+  ])
+}
 
 // Per-shard scratch lives under WORKSPACE_TMP (a sibling of the git
 // workspace) so git clean has no deep NFS scratch tree to walk. We still

--- a/ci/Jenkinsfile_HW
+++ b/ci/Jenkinsfile_HW
@@ -59,6 +59,15 @@ Map<String, Map> BUILD_BOARD_ZIP_PATHS = [:]
 @Field
 static final String FINN_BUILD_LABEL = 'finn-build'
 
+// The commit every stage checks out. Resolved once from the branch tip on the
+// first checkoutPinned() call (Get node status) and reused unchanged for the
+// rest of the build, so the test file Collect stashes and the reports
+// aggregated at the end all come from one commit even if the branch moves
+// mid-run. @Field so the SHA survives CPS replay across stages/agents. Mirrors
+// the same field in Jenkinsfile.
+@Field
+String PINNED_SCM_COMMIT = ''
+
 // The only test file a board runs: stashed by Collect, given to pytest on the board.
 @Field
 static final String HW_TEST_FILE = 'test_bnn_hw_pytest.py'
@@ -119,6 +128,10 @@ pipeline {
     disableConcurrentBuilds()
     // Backstop only. Every board-facing step is bounded already.
     timeout(time: 4, unit: 'HOURS')
+    // Every stage checks out through checkoutPinned() instead of the implicit
+    // per-agent checkout, so the whole build stashes and tests one commit even
+    // if the branch is pushed mid-run. See checkoutPinned() / PINNED_SCM_COMMIT.
+    skipDefaultCheckout()
   }
   parameters {
     string(name: 'build_job_name', defaultValue: 'finn',
@@ -133,20 +146,20 @@ pipeline {
   stages {
     stage('Get node status') {
       agent { label "${FINN_BUILD_LABEL}" }
-      steps { script { loadHwShards(); validateBoardFilter(); refreshNodeOnlineFlags() } }
+      steps { script { checkoutPinned(); loadHwShards(); validateBoardFilter(); refreshNodeOnlineFlags() } }
     }
     stage('Reboot Zynq platforms') {
       steps { script { runRebootParallelStage() } }
     }
     stage('Wait for Nodes to reboot') {
-      options { skipDefaultCheckout() }
+      // No checkoutPinned(): this stage touches only board agents, not the source.
       agent { label "${FINN_BUILD_LABEL}" }
       steps { script { waitForRebootedNodes() } }
     }
-    // Default checkout puts ci/test_bnn_hw_pytest.py in the workspace to stash.
+    // checkoutPinned() puts ci/test_bnn_hw_pytest.py in the workspace to stash.
     stage('Collect build information for HW testing') {
       agent { label "${FINN_BUILD_LABEL}" }
-      steps { script { collectBuildArtifacts() } }
+      steps { script { checkoutPinned(); collectBuildArtifacts() } }
     }
     // Nested `stage(name)` per test type so each gets its own row in the UI.
     stage('Run Hardware Tests') {
@@ -163,19 +176,48 @@ pipeline {
     }
   }
   // post so boards that did report still publish when an earlier stage fails.
-  // checkout scm replaces the one a stage agent would have implied.
+  // checkoutPinned() replaces the checkout a stage agent would have implied.
   post {
     always {
       node("${FINN_BUILD_LABEL}") {
         script {
           stage('Check Stage Results') {
-            checkout scm
+            checkoutPinned()
             aggregateReports()
           }
         }
       }
     }
   }
+}
+
+
+// ============================================================================
+// Checkout
+// ============================================================================
+
+// Single checkout entry point for every stage (skipDefaultCheckout() is set, so
+// nothing else clones). The first call (Get node status) resolves the branch
+// tip and records it in PINNED_SCM_COMMIT; every later call — on any agent —
+// checks out that exact SHA, reusing the job's configured
+// remotes/extensions/browser so credentials, refspecs and tag fetching match a
+// plain `checkout scm`. Keeps the stashed test file and finn_ci behaviour
+// constant across stages even if the branch moves mid-build. Mirrors the helper
+// in Jenkinsfile.
+void checkoutPinned() {
+  if (!PINNED_SCM_COMMIT) {
+    def vars = checkout scm
+    PINNED_SCM_COMMIT = vars.GIT_COMMIT
+    echo "checkoutPinned: pinned build to ${PINNED_SCM_COMMIT}"
+    return
+  }
+  checkout([
+    $class: 'GitSCM',
+    branches: [[name: PINNED_SCM_COMMIT]],
+    userRemoteConfigs: scm.userRemoteConfigs,
+    extensions: scm.extensions,
+    browser: scm.browser,
+  ])
 }
 
 

--- a/ci/Jenkinsfile_HW
+++ b/ci/Jenkinsfile_HW
@@ -216,7 +216,6 @@ void checkoutPinned() {
     branches: [[name: PINNED_SCM_COMMIT]],
     userRemoteConfigs: scm.userRemoteConfigs,
     extensions: scm.extensions,
-    browser: scm.browser,
   ])
 }
 


### PR DESCRIPTION
Both CI pipelines re-resolved the branch tip on each stage's checkout, so a push to the branch mid-build desynced git describe between stages. In Jenkinsfile this made the Build Docker Image stage's tag differ from later consumers, hard-failing the strict FINN_DOCKER_PREBUILT tag check in run-docker.sh; in Jenkinsfile_HW it meant the stashed test file and reports could come from different commits.

Both files now set skipDefaultCheckout() and route every checkout through a checkoutPinned() helper: the first call resolves the branch tip into an @Field PINNED_SCM_COMMIT, and every later stage/agent checks out that exact SHA (reusing scm's remotes/extensions/browser). Result: one commit per build everywhere.

- ci/Jenkinsfile — pinned Validate, Build Docker Image, Check Stage Results, runShard, runLocalSetupTest.
- ci/Jenkinsfile_HW — pinned Get node status, Collect, post Check Stage Results; folded the redundant stage-level skipDefaultCheckout() into the pipeline option.
