### PR TITLE
Fix RTL thresholding runtime weights address space mismatch

### DIFF
--- a/src/finn/custom_op/fpgadataflow/rtl/thresholding_rtl.py
+++ b/src/finn/custom_op/fpgadataflow/rtl/thresholding_rtl.py
@@ -502,9 +502,12 @@ class Thresholding_rtl(Thresholding, RTLBackend):
             if thresholds.shape[0] == 1:
                 thresholds = np.broadcast_to(thresholds, (pe, expected_thresholds))
                 num_channels = pe
-            width_padded = roundup_to_integer_multiple(thresholds.shape[1], 2**o_bitwidth)
+            # Calculate width_padded to match RTL address space allocation.
+            # RTL uses clog2(n_thres_steps) bits for threshold addressing, so we need
+            # to pad to 2^clog2(n_thres_steps) to align with the RTL memory layout.
+            width_padded = 1 << math.ceil(math.log2(max(n_thres_steps, 2)))
             thresh_padded = np.zeros((thresholds.shape[0], width_padded))
-            thresh_padded[: thresholds.shape[0], :expected_thresholds] = thresholds
+            thresh_padded[: thresholds.shape[0], :n_thres_steps] = thresholds[:, :n_thres_steps]
             thresh_stream = []
             bw_hexdigit = roundup_to_integer_multiple(wdt.bitwidth(), 32)
             padding = np.zeros(width_padded, dtype=np.int32)

--- a/src/finn/custom_op/fpgadataflow/rtl/thresholding_rtl.py
+++ b/src/finn/custom_op/fpgadataflow/rtl/thresholding_rtl.py
@@ -502,10 +502,11 @@ class Thresholding_rtl(Thresholding, RTLBackend):
             if thresholds.shape[0] == 1:
                 thresholds = np.broadcast_to(thresholds, (pe, expected_thresholds))
                 num_channels = pe
-            # Calculate width_padded to match RTL address space allocation.
-            # RTL uses clog2(n_thres_steps) bits for threshold addressing, so we need
-            # to pad to 2^clog2(n_thres_steps) to align with the RTL memory layout.
-            width_padded = 1 << math.ceil(math.log2(max(n_thres_steps, 2)))
+            # Calculate width_padded to match RTL AXI address space allocation.
+            # RTL uses $clog2(N) bits for threshold addressing in the AXI interface,
+            # so the address space per channel is 2^clog2(n_thres_steps).
+            # For N=1, clog2(1)=0, so only 1 slot per channel.
+            width_padded = 1 << max(0, math.ceil(math.log2(n_thres_steps)))
             thresh_padded = np.zeros((thresholds.shape[0], width_padded))
             thresh_padded[: thresholds.shape[0], :n_thres_steps] = thresholds[:, :n_thres_steps]
             thresh_stream = []

--- a/tests/fpgadataflow/test_fpgadataflow_thresholding_runtime.py
+++ b/tests/fpgadataflow/test_fpgadataflow_thresholding_runtime.py
@@ -123,6 +123,109 @@ def make_single_thresholding_modelwrapper(impl_style, T, idt, odt, actval, n_inp
     return model
 
 
+# Additional test configurations that exercise edge cases found in TFC model:
+# - Large channel counts with non-power-of-2 PE
+# - numSteps < 2^output_bits (e.g., 2 thresholds with 2-bit output)
+# These configurations test the address space calculation alignment between
+# Python weight generation and RTL.
+@pytest.mark.parametrize("impl_style", ["rtl"])
+@pytest.mark.parametrize(
+    "idt_odt_nsteps",
+    [
+        # TFC-like config: UINT8 input, INT2 output (4 values), but only 2 thresholds
+        # This exposes mismatch when n_steps < 2^output_bits
+        (DataType["UINT8"], DataType["INT2"], 2),
+        # Another edge case: 3 thresholds with 2-bit output
+        (DataType["UINT8"], DataType["UINT2"], 3),
+    ],
+)
+@pytest.mark.parametrize("cfg", [(16, 4), (64, 8), (784, 49)])
+@pytest.mark.fpgadataflow
+@pytest.mark.vivado
+@pytest.mark.slow
+def test_runtime_thresholds_tfc_like(impl_style, idt_odt_nsteps, cfg):
+    """Test runtime threshold read with TFC-like configurations.
+
+    These test cases specifically target the edge case where numSteps is less than
+    2^output_bits, which can cause address space mismatch between Python weight
+    generation and RTL if not handled correctly.
+
+    The TFC w2a2 model has:
+    - NumChannels=784, PE=49
+    - numSteps=2 (only 2 thresholds)
+    - outputDataType=INT2 (2 bits, 4 possible values)
+    """
+    ch = cfg[0]
+    pe = cfg[1]
+    n_inp_vecs = [1, 1, 1]
+    idt = idt_odt_nsteps[0]
+    odt = idt_odt_nsteps[1]
+    n_steps = idt_odt_nsteps[2]
+
+    # Generate random thresholds with explicit n_steps
+    T = np.random.randint(
+        idt.min(),
+        idt.max() + 1,
+        (ch, n_steps),
+    ).astype(np.float32)
+    T = np.sort(T, axis=1)
+
+    actval = odt.min()
+
+    model = make_single_thresholding_modelwrapper(impl_style, T, idt, odt, actval, n_inp_vecs, ch)
+    model = model.transform(SpecializeLayers(test_fpga_part))
+
+    assert model.graph.node[0].op_type == "Thresholding_rtl"
+
+    node = model.get_nodes_by_op_type("Thresholding_rtl")[0]
+    op_inst = getCustomOp(node)
+    op_inst.set_nodeattr("PE", pe)
+    op_inst.set_nodeattr("runtime_writeable_weights", 1)
+
+    old_weight_stream = make_runtime_weight_stream(op_inst, T)
+
+    # Build and run RTL simulation
+    model = model.transform(InsertFIFO(True))
+    model = model.transform(SpecializeLayers(test_fpga_part))
+    model = model.transform(GiveUniqueNodeNames())
+    model = model.transform(PrepareIP(test_fpga_part, target_clk_ns))
+    model = model.transform(HLSSynthIP())
+    model = model.transform(CreateStitchedIP(test_fpga_part, target_clk_ns))
+    model = model.transform(PrepareRTLSim())
+    model.set_metadata_prop("exec_mode", "rtlsim")
+
+    in_tensor = gen_finn_dt_tensor(idt, tuple(n_inp_vecs + [ch]))
+    in_tensor = np.tile(in_tensor, (2, 1, 1, 1))
+
+    exec_ctx = {model.get_first_global_in(): in_tensor}
+    extracted_weight_stream = []
+
+    def read_weights(sim):
+        addr = 0
+        read_handles = []
+        addresses = []
+        for i in range(len(old_weight_stream)):
+            addresses.append(addr)
+            addr += 4
+        read_handles.append(sim.read_axilite("s_axilite_0", iter(addresses)))
+        sim.run()
+        for addr in addresses:
+            extracted_weight_stream.append(int(read_handles[0][addr], 16))
+
+    rtlsim_exec(model, exec_ctx, pre_hook=read_weights)
+
+    # Validate the AXI Read weights match what was written
+    first_mismatch = next(
+        (i for i, (w, r) in enumerate(zip(old_weight_stream, extracted_weight_stream)) if w != r),
+        "N/A",
+    )
+    assert extracted_weight_stream == old_weight_stream, (
+        f"Weight mismatch! Written {len(old_weight_stream)} entries, "
+        f"read back {len(extracted_weight_stream)} entries. "
+        f"First mismatch at index {first_mismatch}"
+    )
+
+
 @pytest.mark.parametrize("impl_style", ["rtl", "hls"])
 @pytest.mark.parametrize(
     "idt_act_cfg", [(DataType["INT16"], DataType["INT4"]), (DataType["UINT8"], DataType["UINT4"])]

--- a/tests/fpgadataflow/test_fpgadataflow_thresholding_runtime.py
+++ b/tests/fpgadataflow/test_fpgadataflow_thresholding_runtime.py
@@ -132,7 +132,10 @@ def make_single_thresholding_modelwrapper(impl_style, T, idt, odt, actval, n_inp
 @pytest.mark.parametrize(
     "idt_odt_nsteps",
     [
-        # TFC-like config: UINT8 input, INT2 output (4 values), but only 2 thresholds
+        # TFC w1a1: UINT8 input, BINARY output (1 bit), only 1 threshold
+        # RTL has $clog2(1)=0 threshold address bits, so only 1 slot per channel
+        (DataType["UINT8"], DataType["BINARY"], 1),
+        # TFC w2a2: UINT8 input, INT2 output (4 values), but only 2 thresholds
         # This exposes mismatch when n_steps < 2^output_bits
         (DataType["UINT8"], DataType["INT2"], 2),
         # Another edge case: 3 thresholds with 2-bit output


### PR DESCRIPTION
Fixes runtime writeable weights for RTL thresholding when numSteps < 2^outputBits.

Problem: make_weight_file() calculated width_padded using roundup(n_steps, 2^output_bits), but RTL allocates address space using $clog2(numSteps) bits. This caused address overflow for:
 - TFC w1a1 (numSteps=1, BINARY output): Python generated 2 entries per channel, RTL only has 1 slot
- TFC w2a2 (numSteps=2, INT2 output): Python generated 4 entries per channel, RTL only has 2 slots

Fix: Changed width_padded calculation to 2^clog2(numSteps) to match RTL AXI address allocation.

Test: Added test_runtime_thresholds_tfc_like covering TFC-like configurations
